### PR TITLE
fix display flex in Cookie Banner > Preference Center

### DIFF
--- a/admin/assets/css/faz-admin.css
+++ b/admin/assets/css/faz-admin.css
@@ -184,6 +184,7 @@
 }
 #faz-banner .faz-card-body {
 	display: flex;
+	flex-direction: column;
 	gap: 12px 24px;
 }
 #faz-banner .faz-card-body > .faz-form-group {


### PR DESCRIPTION
<img width="1284" height="1071" alt="2026-03-04 10_13_37" src="https://github.com/user-attachments/assets/6c0f18af-31eb-46e4-8349-89bd96970a6e" />

Add flex-direction: column; to #faz-banner .faz-card-body to show flex in column mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Modificato il layout della sezione banner per visualizzare gli elementi in disposizione verticale anziché orizzontale su desktop, mantenendo la compatibilità con i viewport mobili.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->