### PR TITLE
fix: load WordPress file API before GeoLite2 download

### DIFF
--- a/includes/class-geolocation.php
+++ b/includes/class-geolocation.php
@@ -269,7 +269,11 @@ class Geolocation {
 			'https://download.maxmind.com/app/geoip_download'
 		);
 
-		$tmp_file = download_url( $url, 120 );
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php'; // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude.FileIncludeFound
+		}
+
+		$tmp_file = \download_url( $url, 120 );
 		if ( is_wp_error( $tmp_file ) ) {
 			return new \WP_Error(
 				'faz_geo_download_failed',


### PR DESCRIPTION
## Summary
- fix fatal error when updating GeoLite2 via REST by ensuring `download_url()` is loaded
- include `wp-admin/includes/file.php` only when needed
- call `\download_url()` explicitly from namespaced context

## Problem
The endpoint `update_geolite2()` can call `Geolocation::download_database()` in contexts where `download_url()` is not loaded, causing:

`Uncaught Error: Call to undefined function FazCookie\Includes\download_url()`

## Validation
- syntax check: `php -l includes/class-geolocation.php`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata significativamente la gestione degli errori durante il download del database di geolocalizzazione. Quando il download fallisce, gli utenti riceveranno messaggi d'errore precisi e dettagliati che illustrano il motivo esatto del problema, anziché messaggi generici, rendendo la risoluzione dei problemi molto più semplice ed efficace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->