### PR TITLE
Fix to ensure ClassicPress compatibility

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -457,20 +457,18 @@ return [].concat.apply([],results);
 });
 };
 
-/* Default Content-Type middleware */
-apiFetch.use(function(options,next){
+/* Register built-in middlewares directly — apiFetch.use does not exist yet */
+registerMiddleware(function(options,next){
 var opts=Object.assign({},options);
 if(opts.data&&!(opts.data instanceof window.FormData)){
 opts.headers=Object.assign({"Content-Type":"application/json"},opts.headers||{});
 }
 return next(opts);
 });
+registerMiddleware(createNonceMiddleware(nonce));
+registerMiddleware(createRootURLMiddleware(root));
 
-/* Register default root + nonce middlewares */
-apiFetch.use(createNonceMiddleware(nonce));
-apiFetch.use(createRootURLMiddleware(root));
-
-/* Assign public API — must come after the .use() calls above */
+/* Assign public API — must come after the registerMiddleware calls above */
 apiFetch.use=registerMiddleware;
 apiFetch.setFetchHandler=function(h){fetchHandler=h;};
 apiFetch.createRootURLMiddleware=createRootURLMiddleware;


### PR DESCRIPTION
used a polyfill for wp-api-fetch to correct JS errors in ClassicPress, included logic to load correct scripts for WP and CP conditionally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Risolti problemi di compatibilità nell'area amministrativa con ClassicPress: evitato conflitto con il caricamento di apiFetch e ripristinata coerenza delle icone.

* **New Features**
  * Rilevamento automatico di ClassicPress e comportamento adattivo degli asset.
  * Inserimento di un polyfill inline per le chiamate API su ClassicPress.
  * Localizzazione della configurazione admin con flag isClassicPress.
  * Caricamento mirato di script e stili per pagina, con supporto specifico per l'upload del banner.

* **Refactor**
  * Flusso di enqueue degli asset riorganizzato per gestire dipendenze e iniezione condizionale del polyfill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->