### PR TITLE
fix(i18n): switch locale during initial server-side banner render

### DIFF
--- a/admin/modules/banners/includes/class-template.php
+++ b/admin/modules/banners/includes/class-template.php
@@ -177,6 +177,20 @@ class Template {
 	 * @return void
 	 */
 	public function generate() {
+		// Switch WP locale to the banner's target language *before* any
+		// `__( '...', 'faz-cookie-manager' )` runs inside prepare_html() or
+		// the shortcode registration below. Without this, a site with WP
+		// locale en_US and faz_settings.languages.default=de would cache a
+		// banner template under the `[de]` key that still contains English
+		// strings like "We value your privacy" — because gettext resolves
+		// against the runtime locale, not the plugin's language setting.
+		// See GitHub issue tracking banner German-only regression.
+		$locale_switched = false;
+		$target_locale   = function_exists( 'faz_wp_locale' ) ? faz_wp_locale( $this->language ) : '';
+		if ( $target_locale && function_exists( 'switch_to_locale' ) && $target_locale !== get_locale() ) {
+			$locale_switched = switch_to_locale( $target_locale );
+		}
+
 		$settings    = isset( $this->properties['settings'] ) ? $this->properties['settings'] : array();
 		$this->id    = isset( $settings['versionID'] ) ? $settings['versionID'] : 'default';
 		$this->type  = isset( $settings['type'] ) ? $settings['type'] : 'box';
@@ -222,6 +236,14 @@ class Template {
 
 		if ( false === $this->is_preview() ) {
 			$this->update();
+		}
+
+		// Pair the earlier switch_to_locale(). Restoring inside generate()
+		// (not in __construct) keeps the scope minimal: only the template
+		// generation path sees the alternate locale, so admin menu strings,
+		// REST responses, etc. are not affected.
+		if ( $locale_switched && function_exists( 'restore_previous_locale' ) ) {
+			restore_previous_locale();
 		}
 	}
 

--- a/frontend/modules/banner-rest/class-banner-rest.php
+++ b/frontend/modules/banner-rest/class-banner-rest.php
@@ -343,47 +343,14 @@ class Banner_Rest {
 
 	/**
 	 * Convert a plugin language code (e.g. "it", "pt-br") to a WordPress locale
-	 * (e.g. "it_IT", "pt_BR"). Falls back to the input when no mapping exists.
-	 *
-	 * Users can override or extend the mapping via the
-	 * `faz_wp_locale_from_language` filter.
+	 * (e.g. "it_IT", "pt_BR"). Thin wrapper over the shared `faz_wp_locale()`
+	 * helper so both the REST endpoint and the initial server-side banner
+	 * render resolve locales from a single source of truth.
 	 *
 	 * @param string $lang Plugin language code.
 	 * @return string
 	 */
 	protected function language_to_wp_locale( $lang ) {
-		$map = array(
-			'en'    => 'en_US',
-			'it'    => 'it_IT',
-			'de'    => 'de_DE',
-			'fr'    => 'fr_FR',
-			'es'    => 'es_ES',
-			'pt'    => 'pt_PT',
-			'pt-br' => 'pt_BR',
-			'nl'    => 'nl_NL',
-			'pl'    => 'pl_PL',
-			'ru'    => 'ru_RU',
-			'cs'    => 'cs_CZ',
-			'sk'    => 'sk_SK',
-			'hu'    => 'hu_HU',
-			'ro'    => 'ro_RO',
-			'bg'    => 'bg_BG',
-			'hr'    => 'hr',
-			'el'    => 'el',
-			'tr'    => 'tr_TR',
-			'sv'    => 'sv_SE',
-			'no'    => 'nb_NO',
-			'da'    => 'da_DK',
-			'fi'    => 'fi',
-			'zh'    => 'zh_CN',
-			'ja'    => 'ja',
-			'ko'    => 'ko_KR',
-			'ar'    => 'ar',
-			'he'    => 'he_IL',
-			'uk'    => 'uk',
-			'sr'    => 'sr_RS',
-		);
-		$locale = isset( $map[ $lang ] ) ? $map[ $lang ] : $lang;
-		return apply_filters( 'faz_wp_locale_from_language', $locale, $lang );
+		return faz_wp_locale( $lang );
 	}
 }

--- a/includes/class-i18n-helpers.php
+++ b/includes/class-i18n-helpers.php
@@ -425,6 +425,60 @@ if ( ! function_exists( 'faz_i18n_term_language' ) ) {
 	}
 }
 
+if ( ! function_exists( 'faz_wp_locale' ) ) {
+	/**
+	 * Map a plugin language code (e.g. "de", "pt-br") to a WordPress locale
+	 * (e.g. "de_DE", "pt_BR"). Falls back to the input when no mapping exists.
+	 *
+	 * Single source of truth used both by the REST banner endpoint and the
+	 * initial server-side banner render. Without it the initial render would
+	 * call `__( '...', 'faz-cookie-manager' )` against the WP-installed
+	 * locale (e.g. en_US) even when the plugin's configured default is a
+	 * different language — producing a cached banner template with English
+	 * strings under a `[de]` cache key.
+	 *
+	 * Override via the `faz_wp_locale_from_language` filter.
+	 *
+	 * @param string $lang Plugin language code.
+	 * @return string WordPress locale code.
+	 */
+	function faz_wp_locale( $lang ) {
+		$map = array(
+			'en'    => 'en_US',
+			'it'    => 'it_IT',
+			'de'    => 'de_DE',
+			'fr'    => 'fr_FR',
+			'es'    => 'es_ES',
+			'pt'    => 'pt_PT',
+			'pt-br' => 'pt_BR',
+			'nl'    => 'nl_NL',
+			'pl'    => 'pl_PL',
+			'ru'    => 'ru_RU',
+			'cs'    => 'cs_CZ',
+			'sk'    => 'sk_SK',
+			'hu'    => 'hu_HU',
+			'ro'    => 'ro_RO',
+			'bg'    => 'bg_BG',
+			'hr'    => 'hr',
+			'el'    => 'el',
+			'tr'    => 'tr_TR',
+			'sv'    => 'sv_SE',
+			'no'    => 'nb_NO',
+			'da'    => 'da_DK',
+			'fi'    => 'fi',
+			'zh'    => 'zh_CN',
+			'ja'    => 'ja',
+			'ko'    => 'ko_KR',
+			'ar'    => 'ar',
+			'he'    => 'he_IL',
+			'uk'    => 'uk',
+			'sr'    => 'sr_RS',
+		);
+		$locale = isset( $map[ $lang ] ) ? $map[ $lang ] : $lang;
+		return apply_filters( 'faz_wp_locale_from_language', $locale, $lang );
+	}
+}
+
 if ( ! function_exists( 'faz_clear_banner_template_cache' ) ) {
 	/**
 	 * Clear all banner template cache variants.


### PR DESCRIPTION
## Problem

The banner template generated in `wp_footer` and cached in the `faz_banner_template[lang]` option calls `__( '...', 'faz-cookie-manager' )` without any locale switch. Result: on a site with WP locale `en_US` and `faz_settings.languages.default = de`, the `[de]` cache slot still contained English shortcode output and leaked English strings onto the frontend.

**Repro**:

```bash
wp option update faz_settings '{"languages":{"default":"de","selected":["de"]}}' --format=json
wp option delete faz_banner_template
curl -H 'Accept-Language: de-DE,de;q=0.9' http://127.0.0.1:9998/ \
    | grep 'data-faz-tag="title"'
# → data-faz-tag="title">We value your privacy   ❌ should be German
```

The REST endpoint `/faz/v1/banner/{lang}` already did the right thing via `switch_to_locale()` before delegating to `Banner_Template`. The server-rendered initial banner did not.

## Fix

Three surgical edits:

1. **New helper `faz_wp_locale($lang)`** in `includes/class-i18n-helpers.php` — single source of truth for plugin-code → WP-locale mapping (`de` → `de_DE`, `pt-br` → `pt_BR`, etc.). Overridable via the existing `faz_wp_locale_from_language` filter.

2. **`Banner_Rest::language_to_wp_locale()` delegates** to `faz_wp_locale()` — removes a 30-row duplicated map.

3. **`Banner_Template::generate()` wraps** `prepare_html()` + `update()` with `switch_to_locale(faz_wp_locale($this->language))` / `restore_previous_locale()`. Scope is limited to `generate()` so admin menus, REST responses outside the banner, and other request surfaces never see the alternate locale.

## Test impact

Ran `multilingual-cache.spec.ts` + language-related `pr-regression.spec.ts`:

```
10 passed · 2 failed · 1 skipped (1.5m)
```

Previously those specs had a higher fail rate under nginx.

## Known limitation (NOT fixed here)

The one remaining multilingual fail — `pr-regression.spec.ts:811 German-only site shows German banner text` — is caused by a **separate, data-level bug**: the `wp_faz_banners.contents[lang]` DB record seeded for a newly-added language can contain mixed strings (e.g. `title: "We value your privacy"` while `description` is already translated):

```json
"de": {
  "notice": {
    "elements": {
      "title": "We value your privacy",     ← English (seed gap)
      "description": "Wir verwenden Cookies...", ← German
      "buttons": { "elements": {
        "accept": "Accept All",              ← English (seed gap)
        "reject": "Reject All",              ← English (seed gap)
        "readMore": "Cookie-Richtlinie"      ← German
      }}
    }
  }
}
```

That is a seed-data problem in the admin "add language" flow and needs a follow-up fix; it bypasses gettext entirely and cannot be reached by `switch_to_locale`.

## Test plan

- [x] `php -l` clean on all 3 modified files
- [x] `faz_wp_locale('de')` returns `'de_DE'`
- [x] Manual repro (curl with Accept-Language de-DE) — gettext-resolved strings now German (e.g. revisit tooltip "Einstellungen zus..."), only DB-sourced strings remain English
- [x] REST endpoint `/faz/v1/banner/de` still passes (backward-compatible — Banner_Rest only got a trivial delegation change)

## Branch context

Based on `main`. Independent of PR #69 (graph audit) and PR #70 (shared fixture). All three PRs can merge in any order; `faz_wp_locale()` exists only in this PR's diff so no conflicts.