### PR TITLE
hotfix(1.13.1): auto-exclude FAZ scripts from cache-plugin Delay JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to FAZ Cookie Manager are documented in this file.
 
+## [1.13.1] — 2026-04-24
+
+### Fixed
+- **Auto-exclude the plugin's own scripts from cache/optimization plugins.** LiteSpeed Cache's "Delay JS" (and the equivalent feature in WP Rocket / Autoptimize / SG Optimizer / Hummingbird / W3 Total Cache) defaults to holding every JS file back until the first user interaction. For a consent banner this is a critical regression: the banner — and the `document.createElement` interceptor that blocks third-party trackers pre-consent — stays dormant on page load, and when the user finally scrolls/taps, the optimizer releases every deferred script at once, so ad and analytics scripts execute alongside the banner instead of being gated by it. On `fabiodalez.it` this presented as "banner appears only after clicking"; on `gooloo.de` it presented as "ads flow in only on the second tap". Both were the same LiteSpeed delay behaviour, not a plugin bug, but the plugin now opts itself out by default so admins don't have to configure anything.
+  - `script_loader_tag` now adds `data-no-defer="1" data-no-optimize="1" data-no-minify="1" data-cfasync="false" data-ao-skip="1"` to every `<script>` emitted for a FAZ handle (main, gcm, tcf-cmp, a11y, wca, microsoft-consent, faz-fw). These are the opt-out attributes recognised by LiteSpeed Cache, WP Rocket, Autoptimize, SG Optimizer, Hummingbird, Cloudflare Rocket Loader and W3 Total Cache.
+  - Belt-and-suspenders hooks on `litespeed_optm_js_defer_exc`, `litespeed_optm_js_delay_inc`, `litespeed_optimize_js_excludes`, `rocket_exclude_defer_js`, `rocket_delay_js_exclusions`, `rocket_minify_excluded_external_js`, `autoptimize_filter_js_exclude` add the `plugins/faz-cookie-manager/` path pattern to each plugin's exclude list and scrub our path from LiteSpeed's include-based Delay JS list, covering the case where a future cache-plugin release changes attribute support.
+
 ## [1.13.0] — 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ Value format: `consentid:{base64},consent:yes,action:yes,necessary:yes,functiona
 
 ## Changelog
 
+### 1.13.1
+- **Auto-exclude FAZ scripts from cache plugins' Delay JS** — LiteSpeed Cache, WP Rocket, Autoptimize, SG Optimizer, Hummingbird, Cloudflare Rocket Loader and W3 Total Cache all default to deferring every JS file until first user interaction, which kept the consent banner dormant on page load and let trackers fire the moment the user scrolled. The plugin now adds `data-no-defer data-no-optimize data-no-minify data-cfasync="false" data-ao-skip` to every FAZ `<script>` and hooks the matching pattern-based exclude filters so admins no longer need to configure a thing.
+
 ### 1.13.0
 - **Fix (#80)**: per-service consent cookie stays under the browser's 4 KB limit — `_fazSetInStore` omits `svc.<id>` entries whose value matches the category (the frontend loader already falls back to the category when absent). Previously a ~160-service install made every "Save My Preferences" click a no-op because the oversized write was silently dropped.
 - **Fix (#78)**: scanner `discover_urls` places recently-modified pages in `priority_urls` so they're exempt from the client-side early-stop threshold — freshly-edited posts could previously be skipped on large sites.

--- a/faz-cookie-manager.php
+++ b/faz-cookie-manager.php
@@ -16,10 +16,10 @@
  * Plugin Name:       FAZ Cookie Manager
  * Plugin URI:        https://github.com/fabiodalez-dev/faz-cookie-manager
  * Description:       A comprehensive GDPR/CCPA cookie consent manager with built-in cookie scanner, local consent logging, Google Consent Mode v2, and IAB TCF v2.3 support.
- * Version:           1.13.0
+ * Version:           1.13.1
  * Requires at least: 5.0
  * Tested up to:      6.9
- * Stable tag:        1.13.0
+ * Stable tag:        1.13.1
  * Requires PHP:      7.4
  * Author:            Fabio D'Alessandro
  * Author URI:        https://fabiodalez.it/
@@ -51,7 +51,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'FAZ_VERSION', '1.13.0' );
+define( 'FAZ_VERSION', '1.13.1' );
 define( 'FAZ_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'FAZ_PLUGIN_BASEPATH', plugin_dir_path( __FILE__ ) );
 define( 'FAZ_PLUGIN_FILENAME', __FILE__ );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -129,6 +129,29 @@ class Frontend {
 		add_filter( 'script_loader_tag', array( $this, 'filter_script_loader_tag' ), 10, 3 );
 		add_filter( 'style_loader_tag', array( $this, 'filter_style_loader_tag' ), 10, 4 );
 
+		// Run *after* `filter_script_loader_tag` (priority 20 > 10) to tag
+		// our own scripts with opt-out hints for cache/optimization plugins.
+		// Consent banners MUST run before third-party trackers, so defer /
+		// delay / combine optimisations on FAZ assets would defeat the whole
+		// plugin (a LiteSpeed-delayed banner appears only after the first
+		// user interaction, by which point ad/analytics scripts released by
+		// the same interaction have already fired).
+		add_filter( 'script_loader_tag', array( $this, 'tag_own_scripts_nooptimize' ), 20, 2 );
+
+		// LiteSpeed Cache pattern-based exclude lists (belt-and-suspenders
+		// in case the tag attribute ever gets stripped by a future LS release).
+		add_filter( 'litespeed_optm_js_defer_exc', array( $this, 'litespeed_exclude_own_scripts' ) );
+		add_filter( 'litespeed_optm_js_delay_inc', array( $this, 'litespeed_exclude_own_scripts_from_include' ) );
+		add_filter( 'litespeed_optimize_js_excludes', array( $this, 'litespeed_exclude_own_scripts' ) );
+
+		// WP Rocket exclude helpers — same intent.
+		add_filter( 'rocket_exclude_defer_js', array( $this, 'rocket_exclude_own_scripts' ) );
+		add_filter( 'rocket_delay_js_exclusions', array( $this, 'rocket_exclude_own_scripts' ) );
+		add_filter( 'rocket_minify_excluded_external_js', array( $this, 'rocket_exclude_own_scripts' ) );
+
+		// Autoptimize exclude helper.
+		add_filter( 'autoptimize_filter_js_exclude', array( $this, 'autoptimize_exclude_own_scripts' ) );
+
 		// WP 5.7+ exposes wp_inline_script_tag for inline scripts added via
 		// wp_add_inline_script(). Using this filter catches them BEFORE the
 		// output buffer, giving a cleaner block (the browser never sees the
@@ -2944,6 +2967,174 @@ class Frontend {
 	 * @param string $src    Script source URL.
 	 * @return string Modified tag.
 	 */
+	/**
+	 * Return the list of script handles owned by this plugin.
+	 *
+	 * The handles are derived from `$this->plugin_name` so alternative
+	 * asset paths (`faz-fw`) are handled too. Kept as an instance method
+	 * to stay in sync with whatever base name the bootstrap passes in.
+	 *
+	 * @return string[]
+	 */
+	private function get_own_script_handles() {
+		$base = (string) $this->plugin_name;
+		if ( '' === $base ) {
+			$base = 'faz-cookie-manager';
+		}
+		return array(
+			$base,
+			$base . '-gcm',
+			$base . '-tcf-cmp',
+			$base . '-a11y',
+			$base . '-wca',
+			$base . '-microsoft-consent',
+			'faz-fw',
+		);
+	}
+
+	/**
+	 * Inject opt-out hints into our own `<script>` tags so cache /
+	 * optimisation plugins leave them alone. A deferred or delayed
+	 * consent banner defeats the plugin's purpose: the banner (and the
+	 * `_fazCreateElementBackup` interceptor that blocks third-party
+	 * trackers pre-consent) must run at page load, not at first user
+	 * interaction — otherwise ads and analytics scripts released by the
+	 * same interaction get to execute alongside the banner.
+	 *
+	 * The attributes below are recognised by the major plugins:
+	 *   - `data-no-defer`        — LiteSpeed Cache, Hummingbird, SG Optimizer
+	 *   - `data-no-optimize`     — LiteSpeed Cache, WP Rocket, W3 Total Cache
+	 *   - `data-no-minify`       — WP Rocket
+	 *   - `data-cfasync="false"` — Autoptimize, Cloudflare Rocket Loader
+	 *   - `data-ao-skip`         — Autoptimize
+	 *
+	 * Priority 20 ensures this runs after our own `filter_script_loader_tag`
+	 * (priority 10) so we don't tag a script we may have re-typed to
+	 * `text/plain`.
+	 *
+	 * @param string $tag    Full `<script>` tag.
+	 * @param string $handle Registered script handle.
+	 * @return string
+	 */
+	public function tag_own_scripts_nooptimize( $tag, $handle ) {
+		if ( is_admin() || ! is_string( $handle ) || '' === $handle ) {
+			return $tag;
+		}
+		if ( ! in_array( $handle, $this->get_own_script_handles(), true ) ) {
+			return $tag;
+		}
+		$hints = ' data-no-defer="1" data-no-optimize="1" data-no-minify="1" data-cfasync="false" data-ao-skip="1"';
+		// `script_loader_tag` receives the *composite* markup for this
+		// handle — the external `<script src>` PLUS any inline before/after
+		// snippets registered via `wp_add_inline_script()` concatenated in
+		// a single string. Tag every opening `<script>` in the blob
+		// (excluding ones we have already neutralised to `text/plain` or
+		// that already carry the hints from a prior filter pass).
+		$new_tag = preg_replace_callback(
+			'#<script\b([^>]*?)(/?)>#i',
+			function ( $m ) use ( $hints ) {
+				$attrs = $m[1];
+				// Skip blocked scripts and idempotent re-runs.
+				if ( false !== strpos( $attrs, 'type="text/plain"' ) || false !== strpos( $attrs, "type='text/plain'" ) ) {
+					return $m[0];
+				}
+				if ( false !== strpos( $attrs, 'data-no-defer' ) ) {
+					return $m[0];
+				}
+				return '<script' . $attrs . $hints . $m[2] . '>';
+			},
+			$tag
+		);
+		return is_string( $new_tag ) ? $new_tag : $tag;
+	}
+
+	/**
+	 * LiteSpeed Cache filter callback — add our plugin's path fragment
+	 * to whatever exclude list LiteSpeed is assembling (defer / delay /
+	 * generic JS optimize). Pattern-matched against script `src`, so
+	 * `plugins/faz-cookie-manager/` matches every asset the plugin
+	 * enqueues regardless of the registered handle. Used as a fallback
+	 * in case the `data-no-defer` tag attribute ever stops being honoured
+	 * by a future LiteSpeed release.
+	 *
+	 * @param mixed $excludes Pattern list (array or newline-joined string).
+	 * @return mixed
+	 */
+	public function litespeed_exclude_own_scripts( $excludes ) {
+		$pattern = 'plugins/faz-cookie-manager/';
+		if ( is_string( $excludes ) ) {
+			if ( false !== strpos( $excludes, $pattern ) ) {
+				return $excludes;
+			}
+			return trim( $excludes . "\n" . $pattern );
+		}
+		if ( ! is_array( $excludes ) ) {
+			$excludes = array();
+		}
+		if ( ! in_array( $pattern, $excludes, true ) ) {
+			$excludes[] = $pattern;
+		}
+		return $excludes;
+	}
+
+	/**
+	 * LiteSpeed `Delay JS` *include* list: it's the opposite semantic —
+	 * when configured, ONLY listed patterns are delayed. If an admin set
+	 * it, we must make sure our scripts are NOT in it, otherwise we
+	 * would be delayed again. Remove any entry that matches our plugin
+	 * path.
+	 *
+	 * @param mixed $includes Pattern list.
+	 * @return mixed
+	 */
+	public function litespeed_exclude_own_scripts_from_include( $includes ) {
+		if ( is_array( $includes ) ) {
+			return array_values( array_filter( $includes, static function ( $v ) {
+				return is_string( $v ) && false === strpos( $v, 'faz-cookie-manager' );
+			} ) );
+		}
+		if ( is_string( $includes ) ) {
+			$lines = preg_split( '/[\r\n]+/', $includes );
+			$lines = array_values( array_filter( (array) $lines, static function ( $v ) {
+				return is_string( $v ) && false === strpos( $v, 'faz-cookie-manager' );
+			} ) );
+			return implode( "\n", $lines );
+		}
+		return $includes;
+	}
+
+	/**
+	 * WP Rocket exclude callback — same pattern-based approach.
+	 *
+	 * @param array $excludes Existing exclude patterns.
+	 * @return array
+	 */
+	public function rocket_exclude_own_scripts( $excludes ) {
+		if ( ! is_array( $excludes ) ) {
+			$excludes = array();
+		}
+		$pattern = '/wp-content/plugins/faz-cookie-manager/(.*)';
+		if ( ! in_array( $pattern, $excludes, true ) ) {
+			$excludes[] = $pattern;
+		}
+		return $excludes;
+	}
+
+	/**
+	 * Autoptimize exclude callback — accepts a comma-separated string.
+	 *
+	 * @param string $excludes Comma-joined exclusion list.
+	 * @return string
+	 */
+	public function autoptimize_exclude_own_scripts( $excludes ) {
+		$pattern = 'faz-cookie-manager';
+		$excludes = is_string( $excludes ) ? $excludes : '';
+		if ( false !== strpos( $excludes, $pattern ) ) {
+			return $excludes;
+		}
+		return '' === $excludes ? $pattern : rtrim( $excludes, ', ' ) . ', ' . $pattern;
+	}
+
 	public function filter_script_loader_tag( $tag, $handle, $src ) {
 		if ( is_admin() ) {
 			return $tag;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: fabiodalez
 Tags: cookie, gdpr, ccpa, consent, privacy
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 1.13.0
+Stable tag: 1.13.1
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
## Context

Reported by admin of `fabiodalez.it` after 1.13.0 deploy, and independently by Max (gooloo.de) the same day:

> *"When I visit my site for the first time in a new Tab on my Phone (usually Homepage at gooloo.de), I dont see the adverts 'flow in'. Usually that only happens on the second Tap..."*

## Root cause

LiteSpeed Cache's *Delay JS* feature (and the equivalent in WP Rocket, Autoptimize, SG Optimizer, Hummingbird, Cloudflare Rocket Loader and W3 Total Cache) wraps every enqueued `<script>` with `type="litespeed/javascript"` until the first user interaction. For a consent banner this is a critical regression:

1. Page loads → FAZ scripts deferred, `document.createElement` interceptor NOT yet armed, banner NOT yet rendered.
2. User scrolls/taps → cache plugin releases every deferred script *at once*.
3. Ad and analytics scripts execute alongside the consent banner instead of being gated by it.

Verified on `fabiodalez.it`: `window._fazConfig` was `undefined` until first mouse click, then every deferred script (FAZ + ads) fired simultaneously. Same symptom on 1.12.x — this isn't a 1.13.0 regression, just an integration issue admins usually paper over by adding `faz-cookie-manager` to the plugin's *JS Delay Excludes* textarea by hand.

## Fix

Make the plugin opt itself out **by default** from every mainstream cache/optimization plugin's Delay/Defer/Combine paths, so admins no longer need to configure anything.

### 1. Tag our `<script>` elements with the standard opt-out hints

`script_loader_tag` filter at priority 20 (after the content-blocking filter at 10), keyed on the plugin's own handles (derived from `$this->plugin_name` so `faz-fw` alt assets are covered too). Every `<script>` inside the composite tag returned by `WP_Scripts` — external src, inline *before*, inline *after*, in one shot — gets:

```
data-no-defer="1"       → LiteSpeed Cache, Hummingbird, SG Optimizer
data-no-optimize="1"    → LiteSpeed Cache, WP Rocket, W3 Total Cache
data-no-minify="1"      → WP Rocket
data-cfasync="false"    → Autoptimize, Cloudflare Rocket Loader
data-ao-skip="1"        → Autoptimize
```

The callback skips tags already rewritten to `text/plain` (never re-tag a neutralised script) and is idempotent across re-filter runs (`data-no-defer` presence guard).

### 2. Belt-and-suspenders pattern-based exclude hooks

For future cache-plugin releases that might change attribute support:

- `litespeed_optm_js_defer_exc` → add `plugins/faz-cookie-manager/`
- `litespeed_optm_js_delay_inc` → **scrub** our path (LiteSpeed's Delay JS include list is semantically inverted — configured entries are delayed, so our plugin must be kept *out* of it)
- `litespeed_optimize_js_excludes` → add path
- `rocket_exclude_defer_js`, `rocket_delay_js_exclusions`, `rocket_minify_excluded_external_js` → add full-path regex
- `autoptimize_filter_js_exclude` → append to comma-joined string

## Verification

- **Local curl**: every FAZ `<script>` now emits with the 5 data attributes (main src, before-inline, after-inline, gcm, tcf-cmp) — including the *composite* tag that WP returns for the main handle. First iteration of the filter used `preg_replace ... 1` and tagged only the first `<script>` in that blob; switched to `preg_replace_callback` to tag every opening `<script>` while preserving the already-rewritten `text/plain` ones.
- **Regression suite** (`coderabbit-fixes-omnibus` + `pr-regression` + `blocking-compliance` + `scan-catalog-deep`): **59 passed, 1 skipped**, 0 failures, 8.2 min.

## Release

Bumped to 1.13.1 across `faz-cookie-manager.php`, `readme.txt`, `README.md` and `CHANGELOG.md`. Release ZIP will be created via `release.md` procedure once this merges to main.

## Follow-ups (out of scope for this PR)

- Message to gooloo.de admin explaining the same root cause applies to AdSense deferred by LiteSpeed on his install.