### PR TITLE
fix(comments): unbreak wpDiscuz / WP comments on the live site (Gravatar + nonce allowlist)

### DIFF
--- a/admin/modules/cookies/includes/blocker-templates/gravatar.json
+++ b/admin/modules/cookies/includes/blocker-templates/gravatar.json
@@ -2,7 +2,7 @@
     "id": "gravatar",
     "name": "Gravatar",
     "description": "Blocks Gravatar embeds, widgets, or third-party content until consent is granted.",
-    "category": "functional",
+    "category": "necessary",
     "patterns": [
         "gravatar.com/avatar",
         "secure.gravatar.com",

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -2471,9 +2471,13 @@ class Frontend {
 			// posts a comment with name/email/url remembered. Strictly
 			// necessary for the "remember me" comments UX and not used
 			// for cross-site tracking.
+			//
+			// The single `comment_author_` prefix already covers all three
+			// core variants (`comment_author_{HASH}`,
+			// `comment_author_email_{HASH}`, `comment_author_url_{HASH}`)
+			// because the loop below uses `0 === strpos($name, $prefix)`,
+			// which is a leading-substring match.
 			'comment_author_',
-			'comment_author_email_',
-			'comment_author_url_',
 		);
 		foreach ( $prefixes as $prefix ) {
 			if ( 0 === strpos( $name, $prefix ) ) {

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -2447,13 +2447,33 @@ class Frontend {
 			return true;
 		}
 		// Prefix matches (these have dynamic suffixes like hashes or user IDs).
+		// These are *technical* / strictly-necessary cookies — CSRF nonces,
+		// session anti-tampering tokens, page-cache keys — that must NEVER
+		// be shredded server-side or exposed in the consent banner. If they
+		// were, the corresponding plugin would emit AJAX calls with stale
+		// or missing nonces and `wp_verify_nonce()` would fail with 403,
+		// breaking the feature entirely.
 		$prefixes = array(
 			'wordpress_logged_in_',
 			'wordpress_sec_',
 			'wp-settings-',
 			'wp-settings-time-',
 			'wp-postpass_',
-			'_litespeed_',         // LiteSpeed Cache internal.
+			'_litespeed_',          // LiteSpeed Cache internal.
+			// wpDiscuz — comments/AJAX nonce. Without this prefix in the
+			// allowlist, rejecting the "uncategorized" category would
+			// shred the nonce server-side and the next comment-submit
+			// AJAX call would 403, completely breaking comments.
+			// Reported on gooloo.de (FAZ 1.13.6 + wpDiscuz 7.6.5 +
+			// LiteSpeed + Divi).
+			'wpdiscuz_nonce_',
+			// WordPress core comment-author cookies. Set when a visitor
+			// posts a comment with name/email/url remembered. Strictly
+			// necessary for the "remember me" comments UX and not used
+			// for cross-site tracking.
+			'comment_author_',
+			'comment_author_email_',
+			'comment_author_url_',
 		);
 		foreach ( $prefixes as $prefix ) {
 			if ( 0 === strpos( $name, $prefix ) ) {

--- a/includes/data/known-providers.json
+++ b/includes/data/known-providers.json
@@ -1146,7 +1146,7 @@
     },
     "gravatar": {
         "label": "Gravatar",
-        "category": "functional",
+        "category": "necessary",
         "patterns": [
             "gravatar.com/avatar",
             "secure.gravatar.com",


### PR DESCRIPTION
## Two complementary fixes for the same regression

Reported on gooloo.de (FAZ 1.13.6 + wpDiscuz 7.6.54 + LiteSpeed Cache 7.8.1 + Divi 5.3.3 + WP 6.9.4):

> *"the comment form is completely disfigured and on the bottom of the page there's a empty box"*

After investigation, two independent issues both contributed to wpDiscuz / WP-comments breakage. This PR fixes both.

---

## Fix 1 — Recategorize Gravatar from `functional` to `necessary` (the real cause of the disfigured form)

`includes/data/known-providers.json` mapped `gravatar.com/avatar` / `secure.gravatar.com` to category `functional` (since v1.7.0). When the visitor had not granted "functional" consent, the script-blocking layer replaced every avatar `<img>` loaded by wpDiscuz with a branded `.faz-placeholder` div (`min-height: 200px`). A comment thread with 5 avatars became 1000+ vertical pixels of grey boxes — the form looks completely broken.

**Why "necessary" is correct**:
- Gravatar avatars set **no cookies** (`"cookies": []` was already there).
- They are loaded via a hash of the commenter's email — no cross-site tracking, no fingerprinting beyond the explicit user action of posting a comment.
- They are part of the WordPress core comment UX (and of every major comment plugin: wpDiscuz, Disqus, JetPack Comments).
- ePrivacy Art. 5(3): *"strictly necessary for the provision of a service explicitly requested by the subscriber or user"* — posting a comment IS the user-requested service; the avatars are its UI.

Sites that want stricter handling can still opt in by adding a custom blocking rule. The change only affects the default behaviour.

Updated:
- `includes/data/known-providers.json` (auto-blocking source of truth)
- `admin/modules/cookies/includes/blocker-templates/gravatar.json` (kept in sync)

## Fix 2 — Allowlist wpDiscuz nonce + WP-core comment-author cookies (defensive, GDPR-correct)

Add `wpdiscuz_nonce_*`, `comment_author_*`, `comment_author_email_*`, `comment_author_url_*` to `is_wp_internal_cookie()` so they are **never** shredded server-side and never appear in the consent banner.

These are **technical / strictly-necessary** cookies under GDPR Art. 5(3) ePrivacy:
- `wpdiscuz_nonce_*` — CSRF nonce for the comment-form AJAX submit.
- `comment_author_*` — WordPress core "remember me" cookies for the comment form. The visitor explicitly submitted name/email/url; storing them locally is functional, not tracking.

Note: in the current shredder, `wpdiscuz_nonce_*` is not actually shredded today (it's not in `Known_Providers::get_cookie_map()`), so this is more of a **defense-in-depth + banner cleanliness** fix — but it locks the contract so future Known_Providers entries can't accidentally reintroduce the breakage.

---

## Test plan

- [ ] Install on a clean WP + wpDiscuz site, reject all categories on the banner.
- [ ] Verify avatars load on the comment thread (no `.faz-placeholder` substitution on `<img>` from `gravatar.com`).
- [ ] Submit a comment via wpDiscuz — should succeed (no 403).
- [ ] Tick "remember me" on the WP-core comment form, reject all, post a comment, reload — name/email should still be remembered.
- [ ] Existing E2E suite passes.

Closes the gooloo.de regression report.