### PR TITLE
fix: send no-cache headers on all faz/v1 REST responses

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
         language: [ javascript-typescript, php ]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: github/codeql-action/init@3b054500189c7b3ca9be7cd4f035ca58c00776cd # v3
+      - uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/analyze@3b054500189c7b3ca9be7cd4f035ca58c00776cd # v3
+      - uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        language: [ javascript-typescript ]
+        language: [ javascript-typescript, php ]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: github/codeql-action/init@3b054500189c7b3ca9be7cd4f035ca58c00776cd # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
     strategy:
       matrix:
-        language: [ javascript-typescript, php ]
+        language: [ javascript-typescript ]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -89,6 +89,7 @@ class Admin {
 		add_action( 'wp_ajax_faz_dismiss_unmatched', array( $this, 'ajax_dismiss_unmatched_vendors' ) );
 		add_filter( 'plugin_action_links_' . FAZ_PLUGIN_BASENAME, array( $this, 'plugin_action_links' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+		add_action( 'rest_api_init', array( $this, 'add_rest_nocache_headers' ) );
 	}
 
 	/**
@@ -1289,6 +1290,28 @@ class Admin {
 			do_action( 'faz_after_first_time_install' );
 			delete_option( 'faz_first_time_activated_plugin' );
 		}
+	}
+
+	/**
+	 * Send no-cache headers for all faz/v1 REST responses so HTTP caches
+	 * (LiteSpeed, Nginx proxy, CDNs) never serve stale cookie/category data.
+	 *
+	 * @return void
+	 */
+	public function add_rest_nocache_headers() {
+		add_filter(
+			'rest_pre_serve_request',
+			function ( $served, $result, $request ) {
+				if ( 0 === strpos( $request->get_route(), '/faz/v1' ) ) {
+					header( 'Cache-Control: no-store, no-cache, must-revalidate, max-age=0' );
+					header( 'Pragma: no-cache' );
+					header( 'X-LiteSpeed-Cache-Control: no-cache' );
+				}
+				return $served;
+			},
+			10,
+			3
+		);
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -239,15 +239,14 @@ class Frontend {
 			// inert. Use Customizer → Additional CSS (built-in WordPress)
 			// and target `.faz-consent-container`, `.faz-modal`, etc.
 
-			// Ad-blocker compatibility: use generic handle/var names to avoid filter lists.
-			$faz_settings = $this->get_faz_settings();
-			$alt_asset = ! empty( $faz_settings['banner_control']['alternative_asset_path'] );
+			// Ad-blocker compatibility: serve script inline to avoid URL pattern matching.
+			// The plugin directory name contains "cookie" which triggers filter lists.
+			// The config variable always stays _fazConfig — ad blockers match URLs, not variable names.
+			$faz_settings  = $this->get_faz_settings();
+			$alt_asset     = ! empty( $faz_settings['banner_control']['alternative_asset_path'] );
 			$script_handle = $alt_asset ? 'faz-fw' : $this->plugin_name;
-			$config_var    = $alt_asset ? '_fazCfg' : '_fazConfig';
 
 			if ( $alt_asset ) {
-				// Serve script inline to avoid ad blocker URL pattern matching.
-				// The plugin directory name contains "cookie" which triggers filter lists.
 				$script_path = plugin_dir_path( __FILE__ ) . 'js/script' . $suffix . '.js';
 				wp_register_script( $script_handle, false, array(), $this->version, false );
 				wp_enqueue_script( $script_handle );
@@ -260,11 +259,7 @@ class Frontend {
 				wp_enqueue_script( $script_handle, plugin_dir_url( __FILE__ ) . 'js/script' . $suffix . '.js', array(), $this->version, false );
 			}
 
-			wp_localize_script( $script_handle, $config_var, $this->get_store_data() );
-			if ( $alt_asset ) {
-				// Bridge the alternative config variable to the expected name.
-				wp_add_inline_script( $script_handle, 'window._fazConfig = window._fazCfg;', 'before' );
-			}
+			wp_localize_script( $script_handle, '_fazConfig', $this->get_store_data() );
 			// Inject template CSS as a proper inline style (nonce-compatible; no unsafe-inline needed).
 			// Utility rules appended AFTER boost_css_specificity() so they are NOT
 			// scoped inside #faz-consent — these classes are used on elements outside
@@ -1763,6 +1758,7 @@ class Frontend {
 		// ── Core infrastructure: WordPress, jQuery, and our own scripts ──
 		$whitelist = array(
 			'faz-cookie-manager',
+			'faz-fw',    // alt-asset mode handle (ad-blocker compatibility)
 			'fazcookie',
 			'fazBannerTemplate',
 			'wp-includes/',

--- a/release.md
+++ b/release.md
@@ -25,8 +25,8 @@ scripts/svn-release.sh --version=${VERSION} --no-tag
 
 Update version in **four places**:
 
-- `faz-cookie-manager.php` — lines `Version:`, `Stable tag:`, and `define( 'FAZ_VERSION', '...' )`
-- `readme.txt` — line `Stable tag:`
+- `faz-cookie-manager.php` — lines `Version:`, `Stable tag:`, `Tested up to:`, and `define( 'FAZ_VERSION', '...' )`
+- `readme.txt` — lines `Stable tag:` **and `Tested up to:`** (must match the value in `faz-cookie-manager.php` — Plugin Check fails if they differ or if value < current WP release)
 - `README.md` — **MANDATORY**: add new version entry to the Changelog section (this is NOT optional — every release MUST have a corresponding entry in README.md)
 - `CHANGELOG.md` — add new version section with full details
 


### PR DESCRIPTION
## Summary

- Adds `Cache-Control: no-store`, `Pragma: no-cache`, and `X-LiteSpeed-Cache-Control: no-cache` headers to every `faz/v1` REST API response via the `rest_pre_serve_request` filter
- Prevents HTTP-level caches (LiteSpeed, Nginx proxy, CDNs) from serving stale cookie/category data after autocategorization or any cookie update

## Problem

On sites with LiteSpeed Cache (or similar HTTP caches), `GET /faz/v1/cookies?category=<id>` and `GET /faz/v1/cookies/categories` responses were being cached at the HTTP layer. After autocategorization updated cookies, the plugin's internal WP object cache was correctly invalidated (via `faz_after_update_cookie` action), but LiteSpeed continued to serve the old cached HTTP response — causing the cookie table to show outdated counts until the cache was manually purged.

## Solution

Hook into `rest_pre_serve_request` (the earliest point in the WP REST cycle before headers are sent) and emit no-cache headers for all `/faz/v1` routes.

## Test plan

- [ ] Verify headers are present: `curl -si https://<site>/wp-json/faz/v1/cookies/categories | grep -i cache`
- [ ] On a site with LiteSpeed Cache: run autocategorization, confirm the cookie table updates immediately without needing a manual cache flush
- [ ] Confirm no regression on normal admin cookie/category CRUD operations

@coderabbitai full review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Note di Rilascio

* **Bug Fixes**
  * Implementati header di cache-busting per le risposte dell'API REST, migliorando le prestazioni e la compatibilità con i server.
  * Migliorate la compatibilità con gli ad-blocker e l'handling degli asset per una migliore esperienza utente.

* **Chores**
  * Aggiornato il flusso di lavoro GitHub Actions per estendere l'analisi del codice.
  * Aggiornata la documentazione delle procedure di rilascio con nuovi requisiti di versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->