### PR TITLE
fix(wp-rocket): banner crashes with "Load JavaScript deferred" enabled

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -173,6 +173,7 @@ class Frontend {
 			add_filter( 'rocket_exclude_defer_js', array( $this, 'rocket_exclude_own_scripts' ) );
 			add_filter( 'rocket_delay_js_exclusions', array( $this, 'rocket_exclude_own_scripts' ) );
 			add_filter( 'rocket_minify_excluded_external_js', array( $this, 'rocket_exclude_own_scripts' ) );
+			add_filter( 'rocket_defer_inline_exclusions', array( $this, 'rocket_exclude_own_inline' ) );
 
 			// Autoptimize exclude helper.
 			add_filter( 'autoptimize_filter_js_exclude', array( $this, 'autoptimize_exclude_own_scripts' ) );
@@ -3376,6 +3377,24 @@ class Frontend {
 			$excludes[] = $pattern;
 		}
 		return $excludes;
+	}
+
+	/**
+	 * WP Rocket inline-content exclude callback — same pattern-based approach.
+	 *
+	 * @param array $excluded Existing inline-content exclusion patterns.
+	 * @return array
+	 */
+	public function rocket_exclude_own_inline( $excluded ) {
+		if ( ! is_array( $excluded ) ) {
+			$excluded = array();
+		}
+		foreach ( array( '_fazConfig', '_fazCfg', '_fazGcm' ) as $needle ) {
+			if ( ! in_array( $needle, $excluded, true ) ) {
+				$excluded[] = $needle;
+			}
+		}
+		return $excluded;
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -3389,7 +3389,7 @@ class Frontend {
 		if ( ! is_array( $excluded ) ) {
 			$excluded = array();
 		}
-		foreach ( array( '_fazConfig', '_fazCfg', '_fazGcm' ) as $needle ) {
+		foreach ( array( '_fazConfig', '_fazCfg', '_fazGcm', '_fazTcfConfig' ) as $needle ) {
 			if ( ! in_array( $needle, $excluded, true ) ) {
 				$excluded[] = $needle;
 			}


### PR DESCRIPTION
## Problem

With **WP Rocket "Load JavaScript deferred"** enabled, the `_fazConfig` localize block gets wrapped in `window.addEventListener('DOMContentLoaded', function() {...})` by WP Rocket DeferJS, breaking the banner with:

```
Uncaught TypeError: Cannot set properties of undefined (setting '_backupNodes')
    at script.min.js:1
```

Reproduces on a stock WordPress install with FAZ Cookie Manager + WP Rocket — not specific to any theme or plugin combination.

## Root cause

WP Rocket's `DeferJS::defer_inline_js()` wraps any inline `<script>` whose content matches the regex `jQuery|\$\.\(|\$\(` (case-insensitive). Our localize block contains the provider regex `addtoany-jquery` from `known-providers.json`, so the substring match triggers the wrapper.

After wrapping, the localize becomes:

```js
window.addEventListener('DOMContentLoaded', function() {
    var _fazConfig = {...};   // ← function-local, never reaches window
});
```

`var _fazConfig` inside the callback is a function-local variable — `window._fazConfig` is never set. When `script.min.js` runs `const _fazStore = window._fazConfig; _fazStore._backupNodes = []`, `_fazStore` is `undefined` → TypeError.

## Fix

Hook `rocket_defer_inline_exclusions` (companion to the existing 3 Rocket filters at `class-frontend.php:173-175`) to add `_fazConfig`, `_fazCfg`, `_fazGcm` patterns.

WP Rocket short-circuits the wrapping in `DeferJS.php:142` (`continue` if content matches an exclusion) before reaching the jQuery detection on line 146:

```php
// DeferJS.php:142 — checked FIRST, before jQuery detection
if ( empty( $inline_exclusions ) || preg_match( "/({$inline_exclusions})/msi", $inline_js['content'] ) ) {
    continue;  // skip wrapping
}

// DeferJS.php:146 — only reached if above didn't match
if ( ! empty( $jquery_patterns ) && ! preg_match( "/({$jquery_patterns})/msi", $inline_js['content'] ) ) {
    continue;
}
```

Belt-and-suspenders: this also future-proofs against other `*-jquery` providers being added to the catalog (jquery-easing, lity-jquery, etc.).

## Reproduction steps

1. Fresh WordPress install
2. Activate FAZ Cookie Manager (default settings, default known-providers.json)
3. Activate WP Rocket
4. WP Rocket → File Optimization → JavaScript → enable "Load JavaScript deferred"
5. Visit any frontend page → console shows TypeError

## Video


https://github.com/user-attachments/assets/d86552c6-50a0-4c23-97ad-87db3d2ef3ba

## Verification

Before fix:
```
$ curl -s https://example.com/ | grep -c "window.addEventListener('DOMContentLoaded'"
1   # ← localize is wrapped
```

After fix:
```
$ curl -s https://example.com/ | grep -c "window.addEventListener('DOMContentLoaded'"
0   # ← localize stays at top level, var _fazConfig leaks to window correctly
```

Banner loads, no console errors.

## Notes

The underlying bug is in WP Rocket — wrapping `wp_localize_script` payloads (which always emit `var X = ...` at script top level) in a callback fundamentally breaks them, and the jQuery detection regex is too permissive (substring match without word boundaries). I'll report this separately to WP Rocket support, but the fix here makes the plugin resilient to it for all users on current and past WP Rocket versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove Funzionalità**
  * Migliorato il supporto per WP Rocket: il plugin ora esclude automaticamente i payload inline relativi al bootstrap dei cookie e alle configurazioni (es. _fazConfig, _fazCfg, _fazGcm, _fazTcfConfig) dall'ottimizzazione inline, evitando che vengano iniettati e garantendo il corretto funzionamento delle funzionalità legate ai cookie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->