### PR TITLE
fix(blocking): exempt wp_localize_script + wp_set_script_translations payloads from content-substring matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to FAZ Cookie Manager are documented in this file.
 
+## [1.13.18] — 2026-05-15
+
+### Fixed
+
+- **`wp_localize_script` and `wp_set_script_translations` payloads no longer trigger false-positive blocking** — inline `<script id="*-js-extra">` and `<script id="*-js-translations">` tags carry only data (config objects or i18n strings), never executable tracker code. The output-buffer / `wp_inline_script_tag` substring matcher would previously rewrite these tags to `type="text/plain"` whenever a config key or translated string incidentally contained a provider name (e.g. trx_addons emits `animate_to_mc4wp_form_submitted`, which substring-matched the `mc4wp` MailChimp pattern and crashed the page with `ReferenceError: TRX_ADDONS_STORAGE is not defined`). Both ID shapes are now exempt in `filter_inline_script_tag()` and the OB fallback `process_script_tag()`. `-js-before` and `-js-after` payloads (which DO accept executable code via `wp_add_inline_script()`) continue to route through the regular provider matcher.
+
+### Tests
+
+- 5 PHP-reflection regression tests in `tests/e2e/specs/v1-13-18-fixes.spec.ts` covering both call sites (filter + OB fallback), both ID suffixes (`-js-extra` and `-js-translations`), and the negative case (`-js-before` still blocked).
+
 ## [1.13.17] — 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -547,21 +547,8 @@ Value format: `consentid:{base64},consent:yes,action:yes,necessary:yes,functiona
 
 Only the most recent release is listed here. The complete history is in [CHANGELOG.md](CHANGELOG.md) (Keep-a-Changelog format) and on the [GitHub Releases page](https://github.com/fabiodalez-dev/FAZ-Cookie-Manager/releases).
 
-### 1.13.17
-- **Fix**: `dataLayer is not defined` when third-party trackers emit a bare `dataLayer.push()` before GTM bootstraps. Pre-initialised via `wp_add_inline_script('before')`.
-- **Fix**: Cookie category counts stay stale after scan + auto-categorise — every cookie create/update/delete now invalidates the Category controller cache, the banner template, the IAB unmatched-vendors transient, and 10 page-cache adapters.
-- **Fix**: REST `bulk_update` was silently dropping `opt_in_script` / `opt_out_script` — now iterates schema editable fields through the same `sanitize_script_field` capability gate as single-cookie updates.
-- **Fix**: `_cookieScripts` no longer truncates at 500 cookies (paged query, JSON-key-anchored LIKE, 10000-row ceiling).
-- **Fix**: `sanitize_meta_for_current_user` intercepts every write path into `wp_faz_cookies.meta`. Closes a stored-XSS surface for multisite Site Administrators without `unfiltered_html`.
-- **Fix**: Own `wp_localize_script` payloads (`{handle}-js-extra`) can no longer be classified as analytics by the output-buffer blocker. Closes #99 and #101 (reported independently by @Myblueroom).
-- **Fix**: WP Rocket "Load JavaScript deferred" no longer wraps our `_fazConfig` bootstrap payload in a `DOMContentLoaded` callback (which would scope `var _fazConfig` to the callback and break `script.js` with `Cannot set properties of undefined`). New `rocket_defer_inline_exclusions` filter excludes `_fazConfig`, `_fazCfg`, `_fazGcm`, `_fazTcfConfig` from DeferJS wrapping. Closes #95 (thanks @dominikkucharski for the diagnosis and reference patch).
-- **Fix**: `<noscript>`-wrapped iframes injected by page builders (Bricks/Elementor/Divi) no longer become 0x0 phantom placeholders.
-- **Fix**: Escape key no longer dismisses the consent banner without a recorded decision (EDPB dark-pattern). Preference center close-on-Escape preserved.
-- **Added**: `Necessary` selectable in Custom Blocking Rules dropdown.
-- **Added**: Banner-status toggle on the Cookie Banner admin page mirroring Settings → Banner Control.
-- **Added**: CCPA 1798.135(c) compliance — `[faz_do_not_sell]` renders a Withdraw opt-out button + `dns_rescinded` log entry.
-- **Added**: DSAR validation announces errors via `role=alert`, `aria-invalid` per field, focus on first invalid. WCAG 1.4.11 focus indicator on `.faz-dsar-btn` / `.faz-dnsmpi-btn`.
-- **Release**: `scripts/build-release.sh` — scripted 3-way ZIP builder for wp.org / GitHub / ClassicPress Directory. Refs #20.
+### 1.13.18 — 2026-05-15
+- **Fix**: `wp_localize_script` and `wp_set_script_translations` payloads (inline `<script id="*-js-extra">` and `<script id="*-js-translations">`) are no longer false-positively blocked when their body contains a substring that matches a provider pattern. These ID shapes carry only data/i18n strings, never executable tracker code — the prior content-substring matcher would crash third-party plugins whose config keys happened to mention a provider (e.g. trx_addons emits `animate_to_mc4wp_form_submitted`, which matched MailChimp's `mc4wp` and broke the page with `ReferenceError: TRX_ADDONS_STORAGE is not defined`).
 
 ## Translations
 

--- a/faz-cookie-manager.php
+++ b/faz-cookie-manager.php
@@ -16,10 +16,10 @@
  * Plugin Name:       FAZ Cookie Manager
  * Plugin URI:        https://github.com/fabiodalez-dev/faz-cookie-manager
  * Description:       A comprehensive GDPR/CCPA cookie consent manager with built-in cookie scanner, local consent logging, Google Consent Mode v2, and IAB TCF v2.3 support.
- * Version:           1.13.17
+ * Version:           1.13.18
  * Requires at least: 5.0
  * Tested up to:      6.9
- * Stable tag:        1.13.17
+ * Stable tag:        1.13.18
  * Requires PHP:      7.4
  * Author:            Fabio D'Alessandro
  * Author URI:        https://fabiodalez.it/
@@ -51,7 +51,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'FAZ_VERSION', '1.13.17' );
+define( 'FAZ_VERSION', '1.13.18' );
 define( 'FAZ_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'FAZ_PLUGIN_BASEPATH', plugin_dir_path( __FILE__ ) );
 define( 'FAZ_PLUGIN_FILENAME', __FILE__ );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1665,6 +1665,15 @@ class Frontend {
 		if ( $this->is_own_inline_script_id( $id ) ) {
 			return $full;
 		}
+		// wp_localize_script / wp_set_script_translations payloads carry only
+		// config data or translation strings — never executable tracker code.
+		// Substring matching against their body produces false positives
+		// (e.g. trx_addons emits `animate_to_mc4wp_form_submitted` which
+		// would otherwise match the `mc4wp` MailChimp pattern and crash
+		// the page with `ReferenceError: TRX_ADDONS_STORAGE is not defined`).
+		if ( $this->is_wp_localize_or_translations_inline_id( $id ) ) {
+			return $full;
+		}
 
 		// Never block whitelisted scripts.
 		if ( $this->is_whitelisted( $attrs, $content ) ) {
@@ -3440,6 +3449,51 @@ class Frontend {
 	}
 
 	/**
+	 * Detect inline scripts that carry only config/i18n payload — never tracker code.
+	 *
+	 * WordPress core emits two ID shapes that are guaranteed to be data-only:
+	 *
+	 *   - `<handle>-js-extra`        — `wp_localize_script()` output. Always a
+	 *                                  `var NAME = { … };` assignment. No function
+	 *                                  calls, no network I/O, no tracker pixels.
+	 *   - `<handle>-js-translations` — `wp_set_script_translations()` output.
+	 *                                  Always `wp.i18n.setLocaleData( JSON, domain );`
+	 *                                  reaching only into WP's in-memory i18n store.
+	 *
+	 * Neither shape can host an analytics call. Yet `match_script_to_provider()`
+	 * runs a `stripos( $content, $pattern )` substring match against the body of
+	 * the inline script, which means any localised string or config key that
+	 * incidentally contains a provider name (e.g. trx_addons emits the config key
+	 * `animate_to_mc4wp_form_submitted`, RankMath localises `addtoany`, Yoast
+	 * carries `gtag` in instruction strings) will trigger a false-positive block.
+	 * The block rewrites the tag to `type="text/plain"`, the `var NAME = …`
+	 * assignment never runs, and downstream code that reads the global crashes
+	 * with `ReferenceError: NAME is not defined`.
+	 *
+	 * `-js-before` and `-js-after` are NOT exempted — `wp_add_inline_script()`
+	 * with those positions accepts arbitrary executable code (a third-party
+	 * plugin may legitimately emit a tracker call this way), so they still
+	 * route through the regular provider matcher.
+	 *
+	 * The exemption applies to inline tags from any plugin, not just our own,
+	 * because the convention is enforced by WordPress core: only `wp_localize_script`
+	 * produces the `-js-extra` suffix, and only `wp_set_script_translations`
+	 * produces the `-js-translations` suffix. A malicious plugin choosing one of
+	 * those IDs to hide a tracker has the entire rest of the page to exfiltrate
+	 * from — the assumption "the IDs WP core appends mark data, not behaviour"
+	 * is the same one WordPress itself relies on.
+	 *
+	 * @param string $id Inline script tag ID.
+	 * @return bool
+	 */
+	private function is_wp_localize_or_translations_inline_id( $id ) {
+		if ( ! is_string( $id ) || '' === $id ) {
+			return false;
+		}
+		return 1 === preg_match( '/-js-(extra|translations)$/', $id );
+	}
+
+	/**
 	 * Inject opt-out hints into our own `<script>` tags so cache /
 	 * optimisation plugins leave them alone. A deferred or delayed
 	 * consent banner defeats the plugin's purpose: the banner (and the
@@ -3785,6 +3839,12 @@ class Frontend {
 		// The handle covers WP 6.3+; the ID-derived check covers WP 5.7-6.2
 		// and the output-buffer fallback's rendered IDs.
 		if ( $this->is_own_script_handle( $handle ) || $this->is_own_inline_script_id( $id ) ) {
+			return $tag;
+		}
+		// wp_localize_script / wp_set_script_translations payloads carry only
+		// config data or translation strings — never executable tracker code.
+		// See is_wp_localize_or_translations_inline_id() for the full rationale.
+		if ( $this->is_wp_localize_or_translations_inline_id( $id ) ) {
 			return $tag;
 		}
 		// Extract attributes and inline content separately so the whitelist

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://buymeacoffee.com/fabiodalez
 Tags: cookie, gdpr, ccpa, consent, privacy
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 1.13.17
+Stable tag: 1.13.18
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -228,6 +228,9 @@ The full changelog (every release back to 1.0.0) lives at:
 https://github.com/fabiodalez-dev/FAZ-Cookie-Manager/blob/main/CHANGELOG.md
 and on the GitHub Releases page:
 https://github.com/fabiodalez-dev/FAZ-Cookie-Manager/releases
+
+= 1.13.18 =
+* Fix: `wp_localize_script` and `wp_set_script_translations` payloads (inline `<script id="*-js-extra">` and `<script id="*-js-translations">`) are no longer false-positively blocked when their body contains a substring that matches a provider pattern. These ID shapes carry only data/i18n strings, never executable tracker code — the prior content-substring matcher would crash third-party plugins whose config keys happened to mention a provider (e.g. trx_addons emits the key `animate_to_mc4wp_form_submitted`, which matched MailChimp's `mc4wp` and broke the page with `ReferenceError: TRX_ADDONS_STORAGE is not defined`). `-js-before` and `-js-after` payloads stay on the regular blocking path.
 
 = 1.13.17 =
 * Fix: `dataLayer is not defined` when third-party trackers emit a bare `dataLayer.push()` before GTM bootstraps. Pre-init via `wp_add_inline_script('before')`. Closes wp.org thread "bug-report-datalayer-is-not-defined".

--- a/tests/e2e/specs/v1-13-18-fixes.spec.ts
+++ b/tests/e2e/specs/v1-13-18-fixes.spec.ts
@@ -87,7 +87,16 @@ test.describe('1.13.18 — wp_localize_script payloads exempt from content-subst
       $blocked = array( 'analytics', 'marketing', 'functional', 'performance' );
 
       $tag = '<script id="trx-mock-js-extra">var TRX_MOCK_STORAGE = {"animate_to_mc4wp_form_submitted":"1"};</script>';
-      preg_match( '/<script([^>]*)>(.*?)<\\/script>/s', $tag, $m );
+
+      // Defensive: if preg_match somehow fails on the hardcoded tag above (it
+      // shouldn't — that would mean someone mutated the literal), fail loud
+      // with REGEX_FAIL rather than passing an empty $m to invokeArgs() and
+      // letting process_script_tag() see undefined indices. The test below
+      // asserts PASSTHROUGH, so a silent failure would mimic the success path.
+      if ( 1 !== preg_match( '/<script([^>]*)>(.*?)<\\/script>/s', $tag, $m ) ) {
+        echo 'REGEX_FAIL';
+        return;
+      }
 
       $result = $method->invokeArgs( $instance, array( $m, $providers, $blocked ) );
       $rewritten = ( false !== strpos( $result, 'type="text/plain"' ) || false !== strpos( $result, 'data-faz-category=' ) );

--- a/tests/e2e/specs/v1-13-18-fixes.spec.ts
+++ b/tests/e2e/specs/v1-13-18-fixes.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression suite for the 1.13.18 release.
+ *
+ * Single fix: `*-js-extra` and `*-js-translations` inline payloads (the
+ * output of `wp_localize_script()` and `wp_set_script_translations()`) are
+ * exempt by default from the provider-substring matcher. These ID shapes
+ * carry only data (`var NAME = {...}`) or i18n strings (`wp.i18n.setLocaleData(...)`),
+ * never tracker calls, so matching `stripos( $content, $pattern )` against
+ * their body produces false positives whenever a config key or a translated
+ * string incidentally contains a provider name.
+ *
+ * Canonical bug: trx_addons (ThemeREX) emits a localize payload with the
+ * config key `animate_to_mc4wp_form_submitted`. The substring `mc4wp`
+ * matches MailChimp → category `marketing` → the tag is rewritten to
+ * `type="text/plain"` → `var TRX_ADDONS_STORAGE = {...}` never runs →
+ * `ReferenceError: TRX_ADDONS_STORAGE is not defined` crashes Elementor's
+ * `frontend/init` handler.
+ *
+ * The fix exempts both ID suffixes (`-js-extra`, `-js-translations`) at
+ * the top of `filter_inline_script_tag()` (WP 5.7+) and `process_script_tag()`
+ * (output-buffer fallback for WP < 5.7), keeping `-js-before` / `-js-after`
+ * on the regular path because `wp_add_inline_script()` with those positions
+ * accepts arbitrary executable code.
+ */
+
+import { test, expect } from '../fixtures/wp-fixture';
+import { wpEval } from '../utils/wp-env';
+
+test.describe('1.13.18 — wp_localize_script payloads exempt from content-substring blocking', () => {
+  test('filter_inline_script_tag leaves a `-js-extra` payload intact even when its body contains a provider substring', () => {
+    // Build a tag shape identical to what wp_localize_script emits, with
+    // a body that contains the literal substring `mc4wp` inside a
+    // config-key value (the trx_addons reproduction).
+    const result = wpEval(`
+      $tag = '<script id="trx-mock-js-extra">var TRX_MOCK_STORAGE = {"site_url":"http://example.test","animate_to_mc4wp_form_submitted":"1"};</script>';
+      $filtered = apply_filters( 'wp_inline_script_tag', $tag, 'trx-mock-js-extra', 'trx_mock' );
+      $rewritten = ( false !== strpos( $filtered, 'type="text/plain"' ) || false !== strpos( $filtered, 'data-faz-category=' ) );
+      echo $rewritten ? 'BLOCKED' : 'PASSTHROUGH';
+    `).trim();
+
+    expect(result, '`-js-extra` payload with `mc4wp` substring must pass through unchanged').toBe('PASSTHROUGH');
+  });
+
+  test('filter_inline_script_tag leaves a `-js-translations` payload intact even when its body contains a provider substring', () => {
+    const result = wpEval(`
+      $tag = '<script id="trx-mock-js-translations">( function( domain, translations ) { var localeData = translations.locale_data[ domain ] || translations.locale_data.messages; wp.i18n.setLocaleData( { "Sign up to mc4wp": [ "Iscriviti a mc4wp" ] }, "trx_mock" ); } )( "trx_mock", {"locale_data":{"trx_mock":{"":{}}}} );</script>';
+      $filtered = apply_filters( 'wp_inline_script_tag', $tag, 'trx-mock-js-translations', 'trx_mock' );
+      $rewritten = ( false !== strpos( $filtered, 'type="text/plain"' ) || false !== strpos( $filtered, 'data-faz-category=' ) );
+      echo $rewritten ? 'BLOCKED' : 'PASSTHROUGH';
+    `).trim();
+
+    expect(result, '`-js-translations` payload with `mc4wp` substring must pass through unchanged').toBe('PASSTHROUGH');
+  });
+
+  test('filter_inline_script_tag STILL blocks a `-js-before` payload when its body looks like a tracker call', () => {
+    // `wp_add_inline_script( $handle, $code, 'before' )` accepts arbitrary
+    // executable code, so the matcher must keep examining its body.
+    // The substring `mc4wp` here is part of a function call shape, not a
+    // config key — but the exemption is about the ID SUFFIX, not body
+    // content, and `-js-before` is NOT exempted.
+    const result = wpEval(`
+      $tag = '<script id="trx-mock-js-before">window.mc4wp = window.mc4wp || []; window.mc4wp.push({event:"x"});</script>';
+      $filtered = apply_filters( 'wp_inline_script_tag', $tag, 'trx-mock-js-before', 'trx_mock' );
+      $rewritten = ( false !== strpos( $filtered, 'type="text/plain"' ) && false !== strpos( $filtered, 'data-faz-category="marketing"' ) );
+      echo $rewritten ? 'BLOCKED' : 'PASSTHROUGH';
+    `).trim();
+
+    expect(result, '`-js-before` payload (executable code path) must still be blocked when the body matches a provider').toBe('BLOCKED');
+  });
+
+  test('process_script_tag (output-buffer fallback for WP < 5.7) leaves `-js-extra` payloads intact too', () => {
+    // The output-buffer path is hit on WP < 5.7 (no wp_inline_script_tag
+    // filter) and as a defense-in-depth catch-all on every version for
+    // scripts injected outside the WP enqueue system. Reflection: build
+    // a (Frontend) instance and call its private process_script_tag()
+    // directly with a regex match shaped like the real OB pipeline.
+    const result = wpEval(`
+      $instance = new \\FazCookie\\Frontend\\Frontend( 'faz-cookie-manager', '1.0' );
+      $reflection = new ReflectionClass( $instance );
+      $method = $reflection->getMethod( 'process_script_tag' );
+      $method->setAccessible( true );
+
+      $providers_method = $reflection->getMethod( 'get_provider_category_map' );
+      $providers_method->setAccessible( true );
+      $providers = $providers_method->invoke( $instance );
+
+      $blocked = array( 'analytics', 'marketing', 'functional', 'performance' );
+
+      $tag = '<script id="trx-mock-js-extra">var TRX_MOCK_STORAGE = {"animate_to_mc4wp_form_submitted":"1"};</script>';
+      preg_match( '/<script([^>]*)>(.*?)<\\/script>/s', $tag, $m );
+
+      $result = $method->invokeArgs( $instance, array( $m, $providers, $blocked ) );
+      $rewritten = ( false !== strpos( $result, 'type="text/plain"' ) || false !== strpos( $result, 'data-faz-category=' ) );
+      echo $rewritten ? 'BLOCKED' : 'PASSTHROUGH';
+    `).trim();
+
+    expect(result, 'OB-path `-js-extra` payload must pass through unchanged').toBe('PASSTHROUGH');
+  });
+
+  test('the new is_wp_localize_or_translations_inline_id helper returns true only for the documented ID shapes', () => {
+    const result = wpEval(`
+      $instance = new \\FazCookie\\Frontend\\Frontend( 'faz-cookie-manager', '1.0' );
+      $reflection = new ReflectionClass( $instance );
+      $method = $reflection->getMethod( 'is_wp_localize_or_translations_inline_id' );
+      $method->setAccessible( true );
+
+      $cases = array(
+        'trx_addons-js-extra'                  => true,
+        'wp-i18n-js-translations'              => true,
+        'someplugin-js-before'                 => false,
+        'someplugin-js-after'                  => false,
+        'random-script-id'                     => false,
+        ''                                     => false,
+        // Edge: legitimate IDs whose handle base happens to end in
+        // "-js" should still match because preg_match anchors on $.
+        'analytics-handler-js-extra'           => true,
+      );
+
+      $out = array();
+      foreach ( $cases as $id => $expected ) {
+        $actual = $method->invoke( $instance, $id );
+        $out[] = ( $expected === $actual ) ? 'OK' : sprintf( 'FAIL[%s expected=%s actual=%s]', $id, var_export( $expected, true ), var_export( $actual, true ) );
+      }
+      echo implode( ';', $out );
+    `).trim();
+
+    expect(result.split(';').every((token) => token === 'OK'), result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Inline `<script id=\"*-js-extra\">` (output of `wp_localize_script()`) and `<script id=\"*-js-translations\">` (output of `wp_set_script_translations()`) carry only configuration data or i18n strings — never executable tracker code. The provider matcher in `filter_inline_script_tag()` and the OB fallback `process_script_tag()` runs `stripos( \$content, \$pattern )` against the inline body, which produces false positives whenever a config key or localized string incidentally contains a provider name.

## Canonical failure mode

Reported by me on `fabiodalez.it/marcos` (WordPress + ThemeREX *Original* theme + `trx_addons` plugin):

```
__scripts.js:3 Uncaught ReferenceError: TRX_ADDONS_STORAGE is not defined
    at __scripts.js:3:208820
    at jQuery dispatch / Elementor Frontend.init
```

`trx_addons` emits a localize payload whose body contains the config key `animate_to_mc4wp_form_submitted`. The substring `mc4wp` matches MailChimp → category `marketing` (blocked pre-consent) → the tag is rewritten to `type=\"text/plain\"` → `var TRX_ADDONS_STORAGE = {...}` never runs → `ReferenceError` crashes Elementor's `frontend/init` handler.

Same shape applies to any plugin whose localize data or translation strings incidentally mention `gtag`, `fbq`, `mc4wp`, `addtoany`, `taboola`, etc. — RankMath, Yoast, WPForms, WooCommerce, theme-emitted i18n strings.

## Fix

New helper `is_wp_localize_or_translations_inline_id( \$id )` matches `/-js-(extra|translations)\$/` and short-circuits both call sites before the matcher runs:

- `filter_inline_script_tag()` — WP 5.7+ filter path
- `process_script_tag()` — output-buffer fallback (WP < 5.7 + defense-in-depth on every version)

`-js-before` and `-js-after` are explicitly NOT exempted: `wp_add_inline_script()` with those positions accepts arbitrary executable code and a third-party plugin may legitimately emit a tracker call there.

## Rationale for applying the exemption to *any* plugin's IDs

The `*-js-extra` and `*-js-translations` ID conventions are enforced by WordPress core itself, and the contract is that those tags contain a `var X = {...}` assignment or a `wp.i18n.setLocaleData(...)` call — not behaviour. A malicious plugin choosing one of those IDs to hide a tracker has the entire rest of the page to exfiltrate from; the assumption \"WP-emitted ID suffixes mark data, not behaviour\" is the same one WordPress itself relies on.

## Test plan

5 PHP-reflection regression tests in `tests/e2e/specs/v1-13-18-fixes.spec.ts`:

- [x] `-js-extra` payload with `mc4wp` substring → passthrough
- [x] `-js-translations` payload with `mc4wp` substring → passthrough
- [x] `-js-before` payload with executable `mc4wp` call → still BLOCKED (negative test)
- [x] `process_script_tag` OB-fallback path → same exemption, passthrough
- [x] Helper truth table (random IDs, empty, edge suffix variants) → expected behaviour

All 5 pass locally (7.6s).

## Workaround (for users on 1.13.17 without upgrading)

Admin → Settings → Script Blocking → Whitelist Patterns → add `trx_addons` (or the affected plugin's enqueue handle). The hyphen-prefix match in `matches_whitelist_pattern()` will catch `trx_addons-js-extra` and bypass the matcher.

## Files changed

- `frontend/class-frontend.php` — new helper + 2 call-site early-exits
- `tests/e2e/specs/v1-13-18-fixes.spec.ts` — new regression suite
- `faz-cookie-manager.php` / `readme.txt` — version bump 1.13.17 → 1.13.18
- `CHANGELOG.md` / `README.md` / `readme.txt` — changelog entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.13.18

* **Bug Fixes**
  * Risolto problema di falsi positivi di blocking per i payload inline generati da WordPress (wp_localize_script e wp_set_script_translations) quando contengono sottostringhe corrispondenti ai pattern dei provider.

* **Tests**
  * Aggiunti 5 test di regressione e2e per coprire il fix e i vari scenari d'utilizzo.

* **Documentation**
  * Aggiornato il changelog per la versione 1.13.18.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fabiodalez-dev/FAZ-Cookie-Manager/pull/102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->