### PR TITLE
test(e2e): unstick 3 pre-existing failures (dev env contamination + design widening)

### DIFF
--- a/tests/e2e/specs/cache-plugin-autoexclude.spec.ts
+++ b/tests/e2e/specs/cache-plugin-autoexclude.spec.ts
@@ -136,6 +136,26 @@ test.describe('Cache-plugin auto-exclude (#83 + 1.13.2 post-review)', () => {
   });
 
   test('output-buffer fallback never blocks own wp_localize_script payloads (#100)', async () => {
+    // Two-layer contract enforced by is_wp_localize_or_translations_inline_id():
+    //
+    // 1. ANY inline script whose id ends in `-js-extra` or `-js-translations`
+    //    is exempt from substring provider matching, because WordPress core
+    //    only emits those suffixes for `wp_localize_script()` (data payload)
+    //    and `wp_set_script_translations()` (i18n payload) — neither shape
+    //    hosts executable tracker code. This exemption is plugin-agnostic
+    //    by design: trx_addons localises `animate_to_mc4wp_form_submitted`,
+    //    RankMath includes `addtoany`, Yoast carries `gtag` in instruction
+    //    strings — blocking those breaks the host page with a
+    //    `ReferenceError: NAME is not defined`. See the docstring on
+    //    is_wp_localize_or_translations_inline_id() (frontend/class-frontend.php)
+    //    for the full rationale. A malicious plugin abusing this suffix
+    //    to hide a tracker has the entire rest of the page to exfiltrate
+    //    from — the assumption "core appends `-js-extra` to data only" is
+    //    the same one WordPress itself relies on.
+    //
+    // 2. A foreign inline script WITHOUT the `-js-extra` / `-js-translations`
+    //    suffix and carrying a provider hit IS still blocked. This is the
+    //    cross-plugin guard the consent gate must keep enforcing.
     const raw = wpEval(`
       $fe = new \\FazCookie\\Frontend\\Frontend( 'faz-cookie-manager', '1.0' );
       $r  = new ReflectionClass( $fe );
@@ -154,6 +174,7 @@ test.describe('Cache-plugin auto-exclude (#83 + 1.13.2 post-review)', () => {
       $providers = array( 'gtag(' => 'analytics' );
       $blocked = array( 'analytics' );
 
+      // (1a) own wp_localize_script payload — must pass through unchanged.
       $own_full = '<script id="faz-fw-js-extra">' . $content . '</script>';
       $own = $m->invoke(
         $fe,
@@ -162,27 +183,63 @@ test.describe('Cache-plugin auto-exclude (#83 + 1.13.2 post-review)', () => {
         $blocked
       );
 
-      $foreign_full = '<script id="third-party-js-extra">' . $content . '</script>';
-      $foreign = $m->invoke(
+      // (1b) foreign wp_localize_script payload — also exempt, by design
+      // (see docstring): the substring-match provider detector would
+      // otherwise false-positive on data keys that happen to contain a
+      // provider token (the trx_addons / RankMath / Yoast cases the
+      // exemption was widened for).
+      $foreign_localize_full = '<script id="third-party-js-extra">' . $content . '</script>';
+      $foreign_localize = $m->invoke(
         $fe,
-        array( $foreign_full, ' id="third-party-js-extra"', $content ),
+        array( $foreign_localize_full, ' id="third-party-js-extra"', $content ),
+        $providers,
+        $blocked
+      );
+
+      // (2) foreign inline script WITHOUT the core data-payload suffix,
+      // carrying the same provider hit — this one MUST be blocked.
+      // Proves the consent gate still enforces cross-plugin blocking on
+      // genuine inline tracker tags.
+      $foreign_exec_full = '<script id="third-party-tracker">' . $content . '</script>';
+      $foreign_exec = $m->invoke(
+        $fe,
+        array( $foreign_exec_full, ' id="third-party-tracker"', $content ),
         $providers,
         $blocked
       );
 
       echo wp_json_encode( array(
-        'own_unchanged' => $own === $own_full,
-        'own_blocked' => false !== strpos( $own, 'type="text/plain"' ),
-        'foreign_blocked' => false !== strpos( $foreign, 'type="text/plain"' ),
-        'foreign_category' => false !== strpos( $foreign, 'data-faz-category="analytics"' ),
+        'own_unchanged'             => $own === $own_full,
+        'own_blocked'               => false !== strpos( $own, 'type="text/plain"' ),
+        'foreign_localize_unchanged'=> $foreign_localize === $foreign_localize_full,
+        'foreign_localize_blocked'  => false !== strpos( $foreign_localize, 'type="text/plain"' ),
+        'foreign_exec_blocked'      => false !== strpos( $foreign_exec, 'type="text/plain"' ),
+        'foreign_exec_category'     => false !== strpos( $foreign_exec, 'data-faz-category="analytics"' ),
       ) );
     `).trim();
     const result = JSON.parse(raw) as Record<string, boolean>;
 
+    // Layer 1: -js-extra suffix → exempt regardless of origin.
     expect(result.own_unchanged, 'own {handle}-js-extra payload must remain executable').toBe(true);
     expect(result.own_blocked, 'own localized payload must not be rewritten to text/plain').toBe(false);
-    expect(result.foreign_blocked, 'foreign matching inline script still needs blocking').toBe(true);
-    expect(result.foreign_category, 'foreign blocked script keeps its category marker').toBe(true);
+    expect(
+      result.foreign_localize_unchanged,
+      'foreign {handle}-js-extra payload must also remain executable (wp_localize_script convention is plugin-agnostic; substring-match would false-positive on data keys carrying provider names)',
+    ).toBe(true);
+    expect(
+      result.foreign_localize_blocked,
+      'foreign {handle}-js-extra payload must not be rewritten to text/plain',
+    ).toBe(false);
+
+    // Layer 2: foreign inline script WITHOUT the core suffix → still blocked.
+    expect(
+      result.foreign_exec_blocked,
+      'foreign inline script without the -js-extra suffix carrying a provider hit must still be blocked',
+    ).toBe(true);
+    expect(
+      result.foreign_exec_category,
+      'foreign blocked script keeps its category marker',
+    ).toBe(true);
   });
 
   test('litespeed_exclude_own_scripts_from_include is path-anchored (no false-positive scrub)', async () => {

--- a/tests/e2e/specs/multi-banner-geo-routing.spec.ts
+++ b/tests/e2e/specs/multi-banner-geo-routing.spec.ts
@@ -712,12 +712,21 @@ test.describe.serial('Multi-banner geo-routing (Controller selector + Banner mod
     // faz_trust_cf_ipcountry_header filter — protects from spoofed headers
     // on installs that do not actually sit behind Cloudflare.
     const result = wpEval(`
+      // The dev-only mu-plugin faz-geo-dev-fake-cf registers
+      // __return_true on faz_trust_cf_ipcountry_header so geo-routing
+      // can be exercised on a localhost install without a real GeoLite2
+      // database. That contaminates the "default OFF" contract this
+      // test verifies — clear callbacks so the assertion observes the
+      // production default (false). Each wp eval invocation is a fresh
+      // PHP process; mutating $wp_filter here does not leak across tests.
+      remove_all_filters( 'faz_trust_cf_ipcountry_header' );
+
       // Establish a baseline WITHOUT the CF header so we know what
       // get_visitor_country() would naturally resolve to via the fallback
-      // chain (MaxMind / ip-api.com). The "trust OFF → not DE" assertion
-      // was flaky when the fallback genuinely resolved to DE (German
-      // dev box / VPN). Comparing OFF against the baseline is robust:
-      // the contract is "header has no effect", not "result is not DE".
+      // chain (MaxMind / ip-api.com). Comparing OFF against the baseline
+      // is robust: the contract is "header has no effect", not
+      // "result is not DE" (the fallback could genuinely resolve to DE
+      // on a German dev box / VPN).
       unset( $_SERVER['HTTP_CF_IPCOUNTRY'] );
       $baseline = \\FazCookie\\Includes\\Geolocation::get_visitor_country();
 

--- a/tests/e2e/specs/pr104-review-fixes.spec.ts
+++ b/tests/e2e/specs/pr104-review-fixes.spec.ts
@@ -292,6 +292,17 @@ test.describe('PR104 — F-SEC-02 GEOIP_COUNTRY_CODE opt-in filter', () => {
     // is never reached. Force a non-localhost REMOTE_ADDR for the
     // duration of the assertion AND bypass the per-IP transient cache.
     const result = wpEval(`
+      // Defensive cleanup: the dev-only mu-plugin faz-geo-dev-fake-cf
+      // registers __return_true on faz_trust_cf_ipcountry_header AND
+      // injects $_SERVER['HTTP_CF_IPCOUNTRY']='IT' on every request,
+      // which would short-circuit the detection chain before the
+      // GEOIP branch this test verifies. Strip both. We also strip the
+      // GEOIP filter for symmetry (no current dev fixture sets it, but
+      // the assertion needs to observe production default 'false').
+      remove_all_filters( 'faz_trust_cf_ipcountry_header' );
+      remove_all_filters( 'faz_trust_geoip_country_code' );
+      unset( $_SERVER['HTTP_CF_IPCOUNTRY'], $_SERVER['HTTP_CF_REGION_CODE'] );
+
       $_SERVER['REMOTE_ADDR'] = '8.8.8.8';
       // Clear any cached lookup for that IP from previous tests.
       delete_transient( 'faz_geo_' . md5( '8.8.8.8' ) );


### PR DESCRIPTION
## Summary

Three E2E tests on `main` were red. Investigation showed **none of them was a production bug** — they were assertions that no longer matched the world they ran in.

| Test | Issue | Root cause |
|---|---|---|
| `multi-banner-geo-routing.spec.ts:710` (GEO-21) | #118 | Dev-only mu-plugin `faz-geo-dev-fake-cf` registers `__return_true` on `faz_trust_cf_ipcountry_header` |
| `pr104-review-fixes.spec.ts:288` (GEOIP_COUNTRY_CODE) | #119 | Same mu-plugin contamination (CF chain short-circuits before GEOIP runs) |
| `cache-plugin-autoexclude.spec.ts:138` (#100) | #117 | Code at `frontend/class-frontend.php:3694` was deliberately widened to exempt any plugin's `-js-extra` from substring provider matching; test still asserted the old narrow behavior |

## Why each is not a production bug

**#118 / #119 — Geo trust filters.** `includes/class-geolocation.php` correctly gates both CF-IPCountry and GEOIP_COUNTRY_CODE on their respective `faz_trust_*` filters as the **first** member of the `&&` clause. Short-circuit evaluation means the headers are never read when the filter returns its default `false`. The tests failed because the dev WP install ships a mu-plugin (`wp-content/mu-plugins/faz-geo-dev-fake-cf.php`) that registers `__return_true` on `faz_trust_cf_ipcountry_header` unconditionally on localhost — so the test process inherits a filter that production never has.

Fix: each `wp eval` block now starts with `remove_all_filters('faz_trust_*')` to strip the mu-plugin's contribution. Each `wp eval` is its own PHP process, so this does not leak across tests.

**#117 — `wp_localize_script` exemption.** `is_wp_localize_or_translations_inline_id()` was widened from "own handles only" to "any plugin's `-js-extra` / `-js-translations`" because the substring-match provider detector false-positives on legitimate localized data: trx_addons' `animate_to_mc4wp_form_submitted` matches the `mc4wp` MailChimp pattern, RankMath localizes `addtoany`, Yoast carries `gtag` in instruction strings. Blocking those rewrites the tag to `type="text/plain"`, the `var NAME = …` assignment never runs, and the host page crashes with `ReferenceError: NAME is not defined`. The exemption is plugin-agnostic by core convention (only `wp_localize_script()` produces `-js-extra`; only `wp_set_script_translations()` produces `-js-translations`). The 30-line docstring on the function documents this trade-off in detail.

Fix: the test now asserts the **two-layer contract** instead of the old narrow one:
1. ANY `-js-extra` suffix is exempt (own + foreign both), proving false-positive prevention.
2. A foreign inline script **without** the suffix carrying a provider hit IS still blocked — the cross-plugin consent gate that genuinely matters.

## Test plan

- [x] All 3 previously-red tests pass: `npx playwright test -g 'GEO-21|GEOIP_COUNTRY_CODE is ignored by default|output-buffer fallback never blocks own wp_localize_script payloads'` → `3 passed (9.6s)`
- [x] No regressions in the full spec files: `cache-plugin-autoexclude.spec.ts` + `pr104-review-fixes.spec.ts` → `30 passed (46.3s)`
- [ ] CI green
- [ ] Issues #117, #118, #119 closed via `Closes` lines in the commit body

## Files changed

- `tests/e2e/specs/multi-banner-geo-routing.spec.ts` — GEO-21 strips mu-plugin filter contamination
- `tests/e2e/specs/pr104-review-fixes.spec.ts` — GEOIP test strips CF filter + injected header
- `tests/e2e/specs/cache-plugin-autoexclude.spec.ts` — #100 test asserts the widened two-layer contract