### PR TITLE
fix(pr127): cookie-policy auto-detect respects in-session manual unticks (F009)

### DIFF
--- a/admin/assets/js/pages/cookie-policy.js
+++ b/admin/assets/js/pages/cookie-policy.js
@@ -36,6 +36,16 @@
 	// one. Mirrors the GVL admin page's autoDetectRequestId (PR #127).
 	var autoDetectRequestId = 0;
 
+	// Service IDs the admin manually UNTICKED during this session (since the
+	// last hydration / save). Auto-detect consults this so a re-run does not
+	// silently re-tick a detected service the admin deliberately removed
+	// before saving (F009). A null-prototype map is used as a Set so a
+	// service id that collides with an Object.prototype member name (e.g.
+	// "constructor") can never read as a spurious truthy hit. Reset on
+	// hydration (writeForm) and after a successful save — the saved state
+	// becomes the new baseline.
+	var userUntickedServices = Object.create(null);
+
 	// Set of service IDs the scanner has observed on this site. Populated
 	// in init() by GET /detected-services. Used by renderServicesList()
 	// to draw a small "Detected" badge next to the matching checkboxes so
@@ -175,6 +185,11 @@
 		document.querySelectorAll('#cp-services-list input[type=checkbox]').forEach(function (cb) {
 			cb.checked = services.indexOf(cb.dataset.serviceId) !== -1;
 		});
+		// The hydrated state is the new baseline — clear any in-session
+		// manual-untick tracking so Auto-detect re-suggests freely (F009).
+		// Programmatic .checked above does not fire 'change', so the map is
+		// not about to be repopulated by this write.
+		userUntickedServices = Object.create(null);
 	}
 
 	// ---------- services list (renders the checkboxes) ----------
@@ -462,15 +477,37 @@
 				}
 				// Pre-tick the newly_suggested checkboxes. Already-selected
 				// boxes stay checked (they already are). Save commits.
+				// EXCEPT services the admin manually unticked this session: a
+				// detected service the admin deliberately removed (before
+				// saving) must not be silently re-ticked by a later Auto-detect
+				// run (F009). Auto-detect stays additive without reversing the
+				// admin's unsaved intent.
 				var list = document.getElementById('cp-services-list');
+				var skipped = 0;
 				if (list) {
 					var boxes = list.querySelectorAll('input[type=checkbox][data-service-id]');
 					for (var i = 0; i < boxes.length; i++) {
 						var sid = boxes[i].dataset.serviceId;
-						if (newly.indexOf(sid) !== -1) {
-							boxes[i].checked = true;
-						}
+						if (newly.indexOf(sid) === -1) { continue; }
+						if (userUntickedServices[sid]) { skipped += 1; continue; }
+						boxes[i].checked = true;
 					}
+				}
+				// Report what was ACTUALLY pre-ticked, not the raw suggestion
+				// count: services the admin unticked this session were skipped
+				// above, so the count must subtract them or the status would
+				// claim more boxes than it ticked (the desync CodeRabbit flagged
+				// on F009).
+				var addedCount = newly.length - skipped;
+				if (addedCount === 0) {
+					// Every newly-detected service was one the admin unticked
+					// this session — nothing was pre-ticked, so omit the "Click
+					// Save" prompt. Confirm without lying about a pending change.
+					var noneMsg = (already.length > 0)
+						? t( 'svcAutoDetectAllAlready', 'All %d detected service(s) are already selected.' ).replace('%d', String(already.length))
+						: t( 'svcAutoDetectNoneAdded', 'Detected services left unticked, as you set them.' );
+					setAutoDetectStatus(noneMsg, 'ok');
+					return;
 				}
 				// Accept both positional (%1$d / %2$d — WP i18n best practice
 				// for translators that need to reorder) AND plain %d / %d
@@ -479,9 +516,9 @@
 				// flagged on the GVL admin page (F006, below_gate).
 				var template = t( 'svcAutoDetectDone', 'Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to commit.' );
 				var formatted = template
-					.replace(/%1\$d/g, String(newly.length))
+					.replace(/%1\$d/g, String(addedCount))
 					.replace(/%2\$d/g, String(already.length))
-					.replace('%d', String(newly.length))
+					.replace('%d', String(addedCount))
 					.replace('%d', String(already.length));
 				setAutoDetectStatus(formatted, 'ok');
 			})
@@ -516,6 +553,25 @@
 		if (autoDetectBtn) {
 			autoDetectBtn.disabled = true;
 			autoDetectBtn.addEventListener('click', autoDetectServices);
+		}
+
+		// Track the admin's manual tick/untick of service checkboxes so
+		// Auto-detect can skip a detected service the admin deliberately
+		// unticked this session (F009). Delegated on the container because
+		// the checkboxes are (re)rendered dynamically by renderServicesList().
+		// Programmatic `cb.checked = …` in writeForm() does NOT fire 'change',
+		// so hydration never pollutes this map.
+		var servicesListEl = document.getElementById('cp-services-list');
+		if (servicesListEl) {
+			servicesListEl.addEventListener('change', function (e) {
+				var cb = e.target;
+				if (!cb || cb.type !== 'checkbox' || !cb.dataset || !cb.dataset.serviceId) { return; }
+				if (cb.checked) {
+					delete userUntickedServices[cb.dataset.serviceId];
+				} else {
+					userUntickedServices[cb.dataset.serviceId] = true;
+				}
+			});
 		}
 
 		// Tracks whether the saved settings actually loaded. If the GET failed
@@ -583,7 +639,14 @@
 			var payload = readForm();
 			setStatus(t( 'saving', 'Saving…' ), '');
 			api('POST', 'settings', payload)
-				.then(function () { setStatus(t( 'saved', 'Saved.' ), 'ok'); })
+				.then(function () {
+					setStatus(t( 'saved', 'Saved.' ), 'ok');
+					// Saved state is the new baseline — a service the admin
+					// unticked is now persisted as unselected, so clear the
+					// in-session tracking and let a later Auto-detect re-suggest
+					// it freely (F009).
+					userUntickedServices = Object.create(null);
+				})
 				.catch(function (err) { setStatus(t( 'saveFailed', 'Save failed' ) + ': ' + err.message, 'error'); });
 		});
 

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -765,6 +765,7 @@ class Admin {
 						'svcAutoDetectNoMatch'     => __( 'No matching services found among scanned cookies.', 'faz-cookie-manager' ),
 						/* translators: %d: number of detected services already selected */
 						'svcAutoDetectAllAlready'  => __( 'All %d detected service(s) are already selected.', 'faz-cookie-manager' ),
+						'svcAutoDetectNoneAdded'   => __( 'Detected services left unticked, as you set them.', 'faz-cookie-manager' ),
 						/* translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected */
 						'svcAutoDetectDone'        => __( 'Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to commit.', 'faz-cookie-manager' ),
 						'svcAutoDetectFailed'      => __( 'Auto-detect failed', 'faz-cookie-manager' ),

--- a/languages/faz-cookie-manager-cs_CZ.po
+++ b/languages/faz-cookie-manager-cs_CZ.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: FAZ Cookie Manager 1.7.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/faz-cookie-"
 "manager\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: 2026-04-18 11:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: Czech\n"
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Cookie Policy"
 msgstr "Zásady cookies"
 
-#: admin/class-admin.php:259 admin/class-admin.php:1743 admin/views/base.php:25
+#: admin/class-admin.php:259 admin/class-admin.php:1744 admin/views/base.php:25
 #: admin/views/dashboard.php:157 includes/blocks/editor.js:27
 #: includes/blocks/editor.js:60 includes/blocks/editor.js:93
 msgid "Settings"
@@ -100,12 +100,12 @@ msgstr "Import / Export"
 msgid "System Status"
 msgstr "Stav systému"
 
-#: admin/class-admin.php:487 admin/class-admin.php:1716
+#: admin/class-admin.php:487 admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27 admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr "Přijato"
 
-#: admin/class-admin.php:488 admin/class-admin.php:1720
+#: admin/class-admin.php:488 admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34 admin/views/consent-logs.php:53
 msgid "Rejected"
 msgstr "Odmítnuto"
@@ -932,444 +932,448 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid ""
 "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to "
 "commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr ""
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799 admin/views/system-status.php:90
+#: admin/class-admin.php:800 admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr "Microsoft Clarity"
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811 admin/views/system-status.php:89
+#: admin/class-admin.php:812 admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr "Microsoft UET"
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147 admin/class-admin.php:1148
-#: admin/class-admin.php:1177 admin/class-admin.php:1178
+#: admin/class-admin.php:1148 admin/class-admin.php:1149
+#: admin/class-admin.php:1178 admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr "FAZ Cookie"
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr "FAZ Cookie Manager — Síť"
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr "Konfigurace multisite"
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid ""
 "FAZ Cookie Manager is network-activated. Each subsite has its own "
 "independent configuration."
@@ -1377,7 +1381,7 @@ msgstr ""
 "FAZ Cookie Manager je aktivován na úrovni sítě. Každý podweb má svou vlastní "
 "nezávislou konfiguraci."
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid ""
 "Navigate to each subsite's admin panel to configure the cookie banner, "
 "categories, and settings."
@@ -1385,40 +1389,40 @@ msgstr ""
 "Přejděte do administračního panelu každého podwebu pro konfiguraci cookie "
 "banneru, kategorií a nastavení."
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr "Aktivní weby"
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr "Web"
 
-#: admin/class-admin.php:1210 admin/views/banner.php:110
+#: admin/class-admin.php:1211 admin/views/banner.php:110
 msgid "Banner Status"
 msgstr "Stav banneru"
 
-#: admin/class-admin.php:1211 admin/views/cookies.php:92
+#: admin/class-admin.php:1212 admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr "Akce"
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr "Aktivní"
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr "Neaktivní"
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr "Konfigurovat"
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr "WooCommerce detekován"
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid ""
 "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and "
 "payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart "
@@ -1429,36 +1433,36 @@ msgstr ""
 "stránkách pokladny a košíku, aby váš obchod fungoval. Toto lze přizpůsobit "
 "pomocí"
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr "a"
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr "filtrů."
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid ""
 "Cookie definitions are using the built-in snapshot. Download the latest "
 "version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr "Naplánované skenování našlo %d nových cookies."
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr "Zkontrolovat nyní"
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid ""
 "FAZ Cookie Manager detected services on your site that are not covered by "
@@ -1467,32 +1471,32 @@ msgstr ""
 "FAZ Cookie Manager detekoval služby na vašem webu, které nejsou pokryty "
 "žádným vybraným dodavatelem IAB: %s."
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid ""
 "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 "Přidejte odpovídající dodavatele pro zajištění správného TCF souhlasu pro "
 "tyto služby."
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr "Přejít na seznam dodavatelů"
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr "Zavřít"
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr "Přehled souhlasu s cookies"
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr "%d interakcí se souhlasem za posledních 30 dní."
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr "Zobrazit podrobnosti"
 

--- a/languages/faz-cookie-manager-de_DE.po
+++ b/languages/faz-cookie-manager-de_DE.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: FAZ Cookie Manager 1.9.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/faz-cookie-"
 "manager\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: 2026-04-10\n"
 "Last-Translator: Fabio D'Alessandro\n"
 "Language-Team: German\n"
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Cookie Policy"
 msgstr ""
 
-#: admin/class-admin.php:259 admin/class-admin.php:1743 admin/views/base.php:25
+#: admin/class-admin.php:259 admin/class-admin.php:1744 admin/views/base.php:25
 #: admin/views/dashboard.php:157 includes/blocks/editor.js:27
 #: includes/blocks/editor.js:60 includes/blocks/editor.js:93
 msgid "Settings"
@@ -100,12 +100,12 @@ msgstr ""
 msgid "System Status"
 msgstr ""
 
-#: admin/class-admin.php:487 admin/class-admin.php:1716
+#: admin/class-admin.php:487 admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27 admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr ""
 
-#: admin/class-admin.php:488 admin/class-admin.php:1720
+#: admin/class-admin.php:488 admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34 admin/views/consent-logs.php:53
 msgid "Rejected"
 msgstr ""
@@ -932,555 +932,559 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid ""
 "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to "
 "commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr "Analyse"
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799 admin/views/system-status.php:90
+#: admin/class-admin.php:800 admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr ""
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811 admin/views/system-status.php:89
+#: admin/class-admin.php:812 admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr ""
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147 admin/class-admin.php:1148
-#: admin/class-admin.php:1177 admin/class-admin.php:1178
+#: admin/class-admin.php:1148 admin/class-admin.php:1149
+#: admin/class-admin.php:1178 admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr ""
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr ""
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr ""
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid ""
 "FAZ Cookie Manager is network-activated. Each subsite has its own "
 "independent configuration."
 msgstr ""
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid ""
 "Navigate to each subsite's admin panel to configure the cookie banner, "
 "categories, and settings."
 msgstr ""
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr ""
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr ""
 
-#: admin/class-admin.php:1210 admin/views/banner.php:110
+#: admin/class-admin.php:1211 admin/views/banner.php:110
 msgid "Banner Status"
 msgstr ""
 
-#: admin/class-admin.php:1211 admin/views/cookies.php:92
+#: admin/class-admin.php:1212 admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr ""
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr ""
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr ""
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr ""
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr ""
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid ""
 "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and "
 "payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart "
 "pages so your store keeps working. This can be customised via the"
 msgstr ""
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr ""
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr ""
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid ""
 "Cookie definitions are using the built-in snapshot. Download the latest "
 "version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr ""
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr ""
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid ""
 "FAZ Cookie Manager detected services on your site that are not covered by "
 "any selected IAB vendor: %s."
 msgstr ""
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid ""
 "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr ""
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr ""
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr ""
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr ""
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr ""
 

--- a/languages/faz-cookie-manager-fr_FR.po
+++ b/languages/faz-cookie-manager-fr_FR.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: faz-cookie-manager\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/faz-cookie-"
 "manager\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: 2026-03-23\n"
 "Last-Translator: Pascal (contributed by user pascalminator)\n"
 "Language-Team: French\n"
@@ -89,7 +89,7 @@ msgstr ""
 msgid "Cookie Policy"
 msgstr "Politique de cookies"
 
-#: admin/class-admin.php:259 admin/class-admin.php:1743 admin/views/base.php:25
+#: admin/class-admin.php:259 admin/class-admin.php:1744 admin/views/base.php:25
 #: admin/views/dashboard.php:157 includes/blocks/editor.js:27
 #: includes/blocks/editor.js:60 includes/blocks/editor.js:93
 msgid "Settings"
@@ -103,12 +103,12 @@ msgstr "Importer / Exporter"
 msgid "System Status"
 msgstr "État du système"
 
-#: admin/class-admin.php:487 admin/class-admin.php:1716
+#: admin/class-admin.php:487 admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27 admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr "Accepté"
 
-#: admin/class-admin.php:488 admin/class-admin.php:1720
+#: admin/class-admin.php:488 admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34 admin/views/consent-logs.php:53
 msgid "Rejected"
 msgstr "Refusé"
@@ -935,444 +935,448 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid ""
 "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to "
 "commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr "Analytique"
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799 admin/views/system-status.php:90
+#: admin/class-admin.php:800 admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr "Microsoft Clarity"
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811 admin/views/system-status.php:89
+#: admin/class-admin.php:812 admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr "Microsoft UET"
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147 admin/class-admin.php:1148
-#: admin/class-admin.php:1177 admin/class-admin.php:1178
+#: admin/class-admin.php:1148 admin/class-admin.php:1149
+#: admin/class-admin.php:1178 admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr "FAZ Cookie"
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr "FAZ Cookie Manager — Réseau"
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr "Configuration multisite"
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid ""
 "FAZ Cookie Manager is network-activated. Each subsite has its own "
 "independent configuration."
@@ -1380,7 +1384,7 @@ msgstr ""
 "FAZ Cookie Manager est activé sur le réseau. Chaque sous-site dispose de sa "
 "propre configuration indépendante."
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid ""
 "Navigate to each subsite's admin panel to configure the cookie banner, "
 "categories, and settings."
@@ -1388,40 +1392,40 @@ msgstr ""
 "Accédez au panneau d'administration de chaque sous-site pour configurer la "
 "bannière cookie, les catégories et les paramètres."
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr "Sites actifs"
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr "Site"
 
-#: admin/class-admin.php:1210 admin/views/banner.php:110
+#: admin/class-admin.php:1211 admin/views/banner.php:110
 msgid "Banner Status"
 msgstr "État de la bannière"
 
-#: admin/class-admin.php:1211 admin/views/cookies.php:92
+#: admin/class-admin.php:1212 admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr "Actions"
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr "Actif"
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr "Inactif"
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr "Configurer"
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr "WooCommerce détecté"
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid ""
 "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and "
 "payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart "
@@ -1432,36 +1436,36 @@ msgstr ""
 "Stripe, Mollie, etc.) sur les pages de commande et de panier afin que votre "
 "boutique continue de fonctionner. Cela peut être personnalisé via les"
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr "et"
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr "filtres."
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid ""
 "Cookie definitions are using the built-in snapshot. Download the latest "
 "version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr "L'analyse programmée a trouvé %d nouveau(x) cookie(s)."
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr "Examiner maintenant"
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid ""
 "FAZ Cookie Manager detected services on your site that are not covered by "
@@ -1470,32 +1474,32 @@ msgstr ""
 "FAZ Cookie Manager a détecté des services sur votre site qui ne sont "
 "couverts par aucun fournisseur IAB sélectionné : %s."
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid ""
 "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 "Ajoutez les fournisseurs correspondants pour garantir un consentement TCF "
 "correct pour ces services."
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr "Aller à la liste des fournisseurs"
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr "Ignorer"
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr "Aperçu du consentement aux cookies"
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr "%d interactions de consentement au cours des 30 derniers jours."
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr "Voir les détails"
 

--- a/languages/faz-cookie-manager-hr_HR.po
+++ b/languages/faz-cookie-manager-hr_HR.po
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: FAZ Cookie Manager 1.12.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/faz-cookie-"
 "manager\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: 2026-04-20 00:00+0200\n"
 "Last-Translator: \n"
 "Language-Team: Croatian\n"
@@ -90,7 +90,7 @@ msgstr ""
 msgid "Cookie Policy"
 msgstr "Pravila o kolačićima"
 
-#: admin/class-admin.php:259 admin/class-admin.php:1743 admin/views/base.php:25
+#: admin/class-admin.php:259 admin/class-admin.php:1744 admin/views/base.php:25
 #: admin/views/dashboard.php:157 includes/blocks/editor.js:27
 #: includes/blocks/editor.js:60 includes/blocks/editor.js:93
 msgid "Settings"
@@ -104,12 +104,12 @@ msgstr "Uvoz / izvoz"
 msgid "System Status"
 msgstr "Status sustava"
 
-#: admin/class-admin.php:487 admin/class-admin.php:1716
+#: admin/class-admin.php:487 admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27 admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr "Prihvaćeno"
 
-#: admin/class-admin.php:488 admin/class-admin.php:1720
+#: admin/class-admin.php:488 admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34 admin/views/consent-logs.php:53
 msgid "Rejected"
 msgstr "Odbijeno"
@@ -936,444 +936,448 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid ""
 "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to "
 "commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr ""
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799 admin/views/system-status.php:90
+#: admin/class-admin.php:800 admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr "Microsoft Clarity"
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811 admin/views/system-status.php:89
+#: admin/class-admin.php:812 admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr "Microsoft UET"
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147 admin/class-admin.php:1148
-#: admin/class-admin.php:1177 admin/class-admin.php:1178
+#: admin/class-admin.php:1148 admin/class-admin.php:1149
+#: admin/class-admin.php:1178 admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr "FAZ Cookie"
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr "FAZ Cookie Manager — mreža"
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr "Multisite konfiguracija"
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid ""
 "FAZ Cookie Manager is network-activated. Each subsite has its own "
 "independent configuration."
@@ -1381,7 +1385,7 @@ msgstr ""
 "FAZ Cookie Manager aktiviran je na razini mreže. Svaka podstranica ima "
 "vlastitu neovisnu konfiguraciju."
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid ""
 "Navigate to each subsite's admin panel to configure the cookie banner, "
 "categories, and settings."
@@ -1389,40 +1393,40 @@ msgstr ""
 "Otvorite administracijsko sučelje svake podstranice za konfiguraciju bannera "
 "za kolačiće, kategorija i postavki."
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr "Aktivne stranice"
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr "Stranica"
 
-#: admin/class-admin.php:1210 admin/views/banner.php:110
+#: admin/class-admin.php:1211 admin/views/banner.php:110
 msgid "Banner Status"
 msgstr "Status bannera"
 
-#: admin/class-admin.php:1211 admin/views/cookies.php:92
+#: admin/class-admin.php:1212 admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr "Radnje"
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr "Aktivno"
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr "Neaktivno"
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr "Konfiguriraj"
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr "WooCommerce je detektiran"
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid ""
 "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and "
 "payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart "
@@ -1433,36 +1437,36 @@ msgstr ""
 "stranicama naplate i košarice kako bi trgovina nastavila raditi. Ovo se može "
 "prilagoditi putem"
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr "i"
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr "filtera."
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid ""
 "Cookie definitions are using the built-in snapshot. Download the latest "
 "version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr "Zakazano skeniranje pronašlo je %d novih kolačića."
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr "Pregledaj sada"
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid ""
 "FAZ Cookie Manager detected services on your site that are not covered by "
@@ -1471,32 +1475,32 @@ msgstr ""
 "FAZ Cookie Manager detektirao je usluge na vašoj stranici koje nisu "
 "pokrivene nijednim odabranim IAB dobavljačem: %s."
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid ""
 "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 "Dodajte odgovarajuće dobavljače kako biste osigurali ispravnu TCF privolu za "
 "ove usluge."
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr "Idi na popis dobavljača"
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr "Odbaci"
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr "Pregled privola za kolačiće"
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr "%d interakcija s privolom u zadnjih 30 dana."
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr "Prikaži detalje"
 

--- a/languages/faz-cookie-manager-it_IT.po
+++ b/languages/faz-cookie-manager-it_IT.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: FAZ Cookie Manager 1.5.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/faz-cookie-"
 "manager\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: 2026-03-14\n"
 "Last-Translator: Fabio D'Alessandro\n"
 "Language-Team: Italian\n"
@@ -90,7 +90,7 @@ msgstr ""
 msgid "Cookie Policy"
 msgstr "Informativa cookie"
 
-#: admin/class-admin.php:259 admin/class-admin.php:1743 admin/views/base.php:25
+#: admin/class-admin.php:259 admin/class-admin.php:1744 admin/views/base.php:25
 #: admin/views/dashboard.php:157 includes/blocks/editor.js:27
 #: includes/blocks/editor.js:60 includes/blocks/editor.js:93
 msgid "Settings"
@@ -104,12 +104,12 @@ msgstr "Importa / Esporta"
 msgid "System Status"
 msgstr "Stato del sistema"
 
-#: admin/class-admin.php:487 admin/class-admin.php:1716
+#: admin/class-admin.php:487 admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27 admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr "Accettato"
 
-#: admin/class-admin.php:488 admin/class-admin.php:1720
+#: admin/class-admin.php:488 admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34 admin/views/consent-logs.php:53
 msgid "Rejected"
 msgstr "Rifiutato"
@@ -943,489 +943,493 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid ""
 "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to "
 "commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr "Analitici"
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799 admin/views/system-status.php:90
+#: admin/class-admin.php:800 admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr ""
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811 admin/views/system-status.php:89
+#: admin/class-admin.php:812 admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr ""
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147 admin/class-admin.php:1148
-#: admin/class-admin.php:1177 admin/class-admin.php:1178
+#: admin/class-admin.php:1148 admin/class-admin.php:1149
+#: admin/class-admin.php:1178 admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr "FAZ Cookie"
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr ""
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr ""
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid ""
 "FAZ Cookie Manager is network-activated. Each subsite has its own "
 "independent configuration."
 msgstr ""
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid ""
 "Navigate to each subsite's admin panel to configure the cookie banner, "
 "categories, and settings."
 msgstr ""
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr ""
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr ""
 
-#: admin/class-admin.php:1210 admin/views/banner.php:110
+#: admin/class-admin.php:1211 admin/views/banner.php:110
 msgid "Banner Status"
 msgstr ""
 
-#: admin/class-admin.php:1211 admin/views/cookies.php:92
+#: admin/class-admin.php:1212 admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr "Azioni"
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr ""
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr ""
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr ""
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr "WooCommerce rilevato"
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid ""
 "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and "
 "payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart "
@@ -1437,66 +1441,66 @@ msgstr ""
 "negozio continui a funzionare. Questa impostazione può essere personalizzata "
 "tramite i"
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr "e"
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr "filtri."
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid ""
 "Cookie definitions are using the built-in snapshot. Download the latest "
 "version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr ""
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr ""
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid ""
 "FAZ Cookie Manager detected services on your site that are not covered by "
 "any selected IAB vendor: %s."
 msgstr ""
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid ""
 "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr ""
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr ""
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr ""
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr ""
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr ""
 

--- a/languages/faz-cookie-manager-nl_NL.po
+++ b/languages/faz-cookie-manager-nl_NL.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: FAZ Cookie Manager 1.7.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/faz-cookie-"
 "manager\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: 2026-04-02 13:06+0200\n"
 "Last-Translator: Yannic van Veen (Yard Digital Agency)\n"
 "Language-Team: Dutch\n"
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Cookie Policy"
 msgstr "Cookiebeleid"
 
-#: admin/class-admin.php:259 admin/class-admin.php:1743 admin/views/base.php:25
+#: admin/class-admin.php:259 admin/class-admin.php:1744 admin/views/base.php:25
 #: admin/views/dashboard.php:157 includes/blocks/editor.js:27
 #: includes/blocks/editor.js:60 includes/blocks/editor.js:93
 msgid "Settings"
@@ -100,12 +100,12 @@ msgstr "Import / Export"
 msgid "System Status"
 msgstr "Systeemstatus"
 
-#: admin/class-admin.php:487 admin/class-admin.php:1716
+#: admin/class-admin.php:487 admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27 admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr "Geaccepteerd"
 
-#: admin/class-admin.php:488 admin/class-admin.php:1720
+#: admin/class-admin.php:488 admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34 admin/views/consent-logs.php:53
 msgid "Rejected"
 msgstr "Geweigerd"
@@ -932,444 +932,448 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid ""
 "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to "
 "commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr ""
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799 admin/views/system-status.php:90
+#: admin/class-admin.php:800 admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr "Microsoft Clarity"
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811 admin/views/system-status.php:89
+#: admin/class-admin.php:812 admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr "Microsoft UET"
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147 admin/class-admin.php:1148
-#: admin/class-admin.php:1177 admin/class-admin.php:1178
+#: admin/class-admin.php:1148 admin/class-admin.php:1149
+#: admin/class-admin.php:1178 admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr "FAZ Cookie"
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr "FAZ Cookie Manager — Netwerk"
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr "Configuratie voor meerdere sites"
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid ""
 "FAZ Cookie Manager is network-activated. Each subsite has its own "
 "independent configuration."
@@ -1377,7 +1381,7 @@ msgstr ""
 "FAZ Cookie Manager is netwerk-geactiveerd. Elke subsite heeft zijn eigen "
 "onafhankelijke configuratie."
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid ""
 "Navigate to each subsite's admin panel to configure the cookie banner, "
 "categories, and settings."
@@ -1385,40 +1389,40 @@ msgstr ""
 "Ga naar het beheerpaneel van elke subsite om de cookiewall, categorieën en "
 "instellingen te configureren."
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr "Actieve sites"
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr "Site"
 
-#: admin/class-admin.php:1210 admin/views/banner.php:110
+#: admin/class-admin.php:1211 admin/views/banner.php:110
 msgid "Banner Status"
 msgstr "Banner status"
 
-#: admin/class-admin.php:1211 admin/views/cookies.php:92
+#: admin/class-admin.php:1212 admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr "Acties"
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr "Actief"
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr "Inactief"
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr "Configureer"
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr "WooCommerce gedetecteerd"
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid ""
 "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and "
 "payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart "
@@ -1429,36 +1433,36 @@ msgstr ""
 "de betaalpagina's zodat je winkel blijft werken. Dit kan worden aangepast "
 "via de"
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr "en"
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr "filters."
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid ""
 "Cookie definitions are using the built-in snapshot. Download the latest "
 "version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr "Geplande scan vond %d nieuwe cookie(s)."
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr "Nu beoordelen"
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid ""
 "FAZ Cookie Manager detected services on your site that are not covered by "
@@ -1467,32 +1471,32 @@ msgstr ""
 "FAZ Cookie Manager heeft services op je site gedetecteerd die niet door een "
 "geselecteerde IAB leverancier worden gedekt: %s."
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid ""
 "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 "Voeg de overeenkomende leveranciers toe om een juiste TCF toestemming voor "
 "deze services te garanderen."
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr "Ga naar Leverancierslijst"
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr "Sluiten"
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr "Cookie Consent Overzicht"
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr "%d toestemmingsinteracties in de afgelopen 30 dagen."
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr "Details bekijken"
 

--- a/languages/faz-cookie-manager.pot
+++ b/languages/faz-cookie-manager.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-31T11:26:06+00:00\n"
+"POT-Creation-Date: 2026-05-31T12:09:08+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: faz-cookie-manager\n"
@@ -94,7 +94,7 @@ msgid "Cookie Policy"
 msgstr ""
 
 #: admin/class-admin.php:259
-#: admin/class-admin.php:1743
+#: admin/class-admin.php:1744
 #: admin/views/base.php:25
 #: admin/views/dashboard.php:157
 #: includes/blocks/editor.js:27
@@ -114,14 +114,14 @@ msgid "System Status"
 msgstr ""
 
 #: admin/class-admin.php:487
-#: admin/class-admin.php:1716
+#: admin/class-admin.php:1717
 #: admin/views/consent-logs.php:27
 #: admin/views/consent-logs.php:52
 msgid "Accepted"
 msgstr ""
 
 #: admin/class-admin.php:488
-#: admin/class-admin.php:1720
+#: admin/class-admin.php:1721
 #: admin/views/consent-logs.php:34
 #: admin/views/consent-logs.php:53
 msgid "Rejected"
@@ -956,547 +956,551 @@ msgstr ""
 msgid "All %d detected service(s) are already selected."
 msgstr ""
 
+#: admin/class-admin.php:768
+msgid "Detected services left unticked, as you set them."
+msgstr ""
+
 #. translators: %1$d: number of newly pre-ticked services, %2$d: number of services already selected
-#: admin/class-admin.php:769
+#: admin/class-admin.php:770
 #, php-format
 msgid "Pre-ticked %1$d new service(s), %2$d were already selected. Click Save to commit."
 msgstr ""
 
-#: admin/class-admin.php:770
+#: admin/class-admin.php:771
 msgid "Auto-detect failed"
 msgstr ""
 
-#: admin/class-admin.php:772
+#: admin/class-admin.php:773
 msgid "Analytics"
 msgstr ""
 
-#: admin/class-admin.php:773
+#: admin/class-admin.php:774
 msgid "Heatmaps & session recording"
 msgstr ""
 
-#: admin/class-admin.php:774
+#: admin/class-admin.php:775
 msgid "Advertising pixels"
 msgstr ""
 
-#: admin/class-admin.php:775
+#: admin/class-admin.php:776
 msgid "CDN, edge & performance"
 msgstr ""
 
-#: admin/class-admin.php:776
+#: admin/class-admin.php:777
 msgid "Anti-bot & forms"
 msgstr ""
 
-#: admin/class-admin.php:777
+#: admin/class-admin.php:778
 msgid "Maps, embeds & media"
 msgstr ""
 
-#: admin/class-admin.php:778
+#: admin/class-admin.php:779
 msgid "Chat & support"
 msgstr ""
 
-#: admin/class-admin.php:779
+#: admin/class-admin.php:780
 msgid "Email & marketing automation"
 msgstr ""
 
-#: admin/class-admin.php:780
+#: admin/class-admin.php:781
 msgid "Payments & commerce"
 msgstr ""
 
-#: admin/class-admin.php:781
+#: admin/class-admin.php:782
 msgid "Social sign-in & auth"
 msgstr ""
 
-#: admin/class-admin.php:782
+#: admin/class-admin.php:783
 msgid "Error & RUM monitoring"
 msgstr ""
 
-#: admin/class-admin.php:783
+#: admin/class-admin.php:784
 msgid "Personalisation & A/B testing"
 msgstr ""
 
-#: admin/class-admin.php:784
+#: admin/class-admin.php:785
 msgid "Push notifications"
 msgstr ""
 
-#: admin/class-admin.php:788
+#: admin/class-admin.php:789
 msgid "Google Analytics 4"
 msgstr ""
 
-#: admin/class-admin.php:789
+#: admin/class-admin.php:790
 msgid "Google Tag Manager"
 msgstr ""
 
-#: admin/class-admin.php:790
+#: admin/class-admin.php:791
 msgid "Matomo Analytics"
 msgstr ""
 
-#: admin/class-admin.php:791
+#: admin/class-admin.php:792
 msgid "Plausible Analytics"
 msgstr ""
 
-#: admin/class-admin.php:792
+#: admin/class-admin.php:793
 msgid "Mixpanel"
 msgstr ""
 
-#: admin/class-admin.php:793
+#: admin/class-admin.php:794
 msgid "Amplitude"
 msgstr ""
 
-#: admin/class-admin.php:794
+#: admin/class-admin.php:795
 msgid "Heap"
 msgstr ""
 
-#: admin/class-admin.php:795
+#: admin/class-admin.php:796
 msgid "Fathom Analytics"
 msgstr ""
 
-#: admin/class-admin.php:796
+#: admin/class-admin.php:797
 msgid "Statcounter"
 msgstr ""
 
-#: admin/class-admin.php:798
+#: admin/class-admin.php:799
 msgid "Hotjar"
 msgstr ""
 
-#: admin/class-admin.php:799
+#: admin/class-admin.php:800
 #: admin/views/system-status.php:90
 msgid "Microsoft Clarity"
 msgstr ""
 
-#: admin/class-admin.php:800
+#: admin/class-admin.php:801
 msgid "Mouseflow"
 msgstr ""
 
-#: admin/class-admin.php:801
+#: admin/class-admin.php:802
 msgid "Smartlook"
 msgstr ""
 
-#: admin/class-admin.php:802
+#: admin/class-admin.php:803
 msgid "Lucky Orange"
 msgstr ""
 
-#: admin/class-admin.php:803
+#: admin/class-admin.php:804
 msgid "FullStory"
 msgstr ""
 
-#: admin/class-admin.php:804
+#: admin/class-admin.php:805
 msgid "LogRocket"
 msgstr ""
 
-#: admin/class-admin.php:805
+#: admin/class-admin.php:806
 msgid "Crazy Egg"
 msgstr ""
 
-#: admin/class-admin.php:807
+#: admin/class-admin.php:808
 msgid "Google Ads"
 msgstr ""
 
-#: admin/class-admin.php:808
+#: admin/class-admin.php:809
 msgid "Meta (Facebook) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:809
+#: admin/class-admin.php:810
 msgid "TikTok Pixel"
 msgstr ""
 
-#: admin/class-admin.php:810
+#: admin/class-admin.php:811
 msgid "LinkedIn Insight Tag"
 msgstr ""
 
-#: admin/class-admin.php:811
+#: admin/class-admin.php:812
 #: admin/views/system-status.php:89
 msgid "Microsoft UET"
 msgstr ""
 
-#: admin/class-admin.php:812
+#: admin/class-admin.php:813
 msgid "Twitter (X) Pixel"
 msgstr ""
 
-#: admin/class-admin.php:813
+#: admin/class-admin.php:814
 msgid "Pinterest Tag"
 msgstr ""
 
-#: admin/class-admin.php:814
+#: admin/class-admin.php:815
 msgid "Reddit Pixel"
 msgstr ""
 
-#: admin/class-admin.php:815
+#: admin/class-admin.php:816
 msgid "Snapchat Pixel"
 msgstr ""
 
-#: admin/class-admin.php:816
+#: admin/class-admin.php:817
 msgid "Quora Pixel"
 msgstr ""
 
-#: admin/class-admin.php:817
+#: admin/class-admin.php:818
 msgid "Outbrain"
 msgstr ""
 
-#: admin/class-admin.php:818
+#: admin/class-admin.php:819
 msgid "Taboola"
 msgstr ""
 
-#: admin/class-admin.php:819
+#: admin/class-admin.php:820
 msgid "Criteo"
 msgstr ""
 
-#: admin/class-admin.php:821
+#: admin/class-admin.php:822
 msgid "Cloudflare"
 msgstr ""
 
-#: admin/class-admin.php:822
+#: admin/class-admin.php:823
 msgid "Fastly"
 msgstr ""
 
-#: admin/class-admin.php:823
+#: admin/class-admin.php:824
 msgid "Akamai"
 msgstr ""
 
-#: admin/class-admin.php:824
+#: admin/class-admin.php:825
 msgid "Amazon CloudFront"
 msgstr ""
 
-#: admin/class-admin.php:825
+#: admin/class-admin.php:826
 msgid "BunnyCDN"
 msgstr ""
 
-#: admin/class-admin.php:826
+#: admin/class-admin.php:827
 msgid "jsDelivr"
 msgstr ""
 
-#: admin/class-admin.php:828
+#: admin/class-admin.php:829
 msgid "Google reCAPTCHA"
 msgstr ""
 
-#: admin/class-admin.php:829
+#: admin/class-admin.php:830
 msgid "hCaptcha"
 msgstr ""
 
-#: admin/class-admin.php:830
+#: admin/class-admin.php:831
 msgid "Cloudflare Turnstile"
 msgstr ""
 
-#: admin/class-admin.php:831
+#: admin/class-admin.php:832
 msgid "Akismet"
 msgstr ""
 
-#: admin/class-admin.php:833
+#: admin/class-admin.php:834
 msgid "Google Maps"
 msgstr ""
 
-#: admin/class-admin.php:834
+#: admin/class-admin.php:835
 msgid "Mapbox"
 msgstr ""
 
-#: admin/class-admin.php:835
+#: admin/class-admin.php:836
 msgid "OpenStreetMap"
 msgstr ""
 
-#: admin/class-admin.php:836
+#: admin/class-admin.php:837
 msgid "YouTube (embed)"
 msgstr ""
 
-#: admin/class-admin.php:837
+#: admin/class-admin.php:838
 msgid "Vimeo (embed)"
 msgstr ""
 
-#: admin/class-admin.php:838
+#: admin/class-admin.php:839
 msgid "Twitter / X (embed)"
 msgstr ""
 
-#: admin/class-admin.php:839
+#: admin/class-admin.php:840
 msgid "Instagram (embed)"
 msgstr ""
 
-#: admin/class-admin.php:840
+#: admin/class-admin.php:841
 msgid "Spotify (embed)"
 msgstr ""
 
-#: admin/class-admin.php:841
+#: admin/class-admin.php:842
 msgid "SoundCloud (embed)"
 msgstr ""
 
-#: admin/class-admin.php:842
+#: admin/class-admin.php:843
 msgid "Wistia"
 msgstr ""
 
-#: admin/class-admin.php:843
+#: admin/class-admin.php:844
 msgid "Brightcove"
 msgstr ""
 
-#: admin/class-admin.php:844
+#: admin/class-admin.php:845
 msgid "JW Player"
 msgstr ""
 
-#: admin/class-admin.php:846
+#: admin/class-admin.php:847
 msgid "Intercom"
 msgstr ""
 
-#: admin/class-admin.php:847
+#: admin/class-admin.php:848
 msgid "Zendesk Chat"
 msgstr ""
 
-#: admin/class-admin.php:848
+#: admin/class-admin.php:849
 msgid "Crisp"
 msgstr ""
 
-#: admin/class-admin.php:849
+#: admin/class-admin.php:850
 msgid "LiveChat"
 msgstr ""
 
-#: admin/class-admin.php:850
+#: admin/class-admin.php:851
 msgid "Tawk.to"
 msgstr ""
 
-#: admin/class-admin.php:851
+#: admin/class-admin.php:852
 msgid "Drift"
 msgstr ""
 
-#: admin/class-admin.php:852
+#: admin/class-admin.php:853
 msgid "HubSpot Chat"
 msgstr ""
 
-#: admin/class-admin.php:853
+#: admin/class-admin.php:854
 msgid "Tidio"
 msgstr ""
 
-#: admin/class-admin.php:855
+#: admin/class-admin.php:856
 msgid "Mailchimp"
 msgstr ""
 
-#: admin/class-admin.php:856
+#: admin/class-admin.php:857
 msgid "ActiveCampaign"
 msgstr ""
 
-#: admin/class-admin.php:857
+#: admin/class-admin.php:858
 msgid "ConvertKit / Kit"
 msgstr ""
 
-#: admin/class-admin.php:858
+#: admin/class-admin.php:859
 msgid "HubSpot"
 msgstr ""
 
-#: admin/class-admin.php:859
+#: admin/class-admin.php:860
 msgid "Brevo (Sendinblue)"
 msgstr ""
 
-#: admin/class-admin.php:860
+#: admin/class-admin.php:861
 msgid "Klaviyo"
 msgstr ""
 
-#: admin/class-admin.php:861
+#: admin/class-admin.php:862
 msgid "Salesforce Pardot"
 msgstr ""
 
-#: admin/class-admin.php:862
+#: admin/class-admin.php:863
 msgid "Adobe Marketo Engage"
 msgstr ""
 
-#: admin/class-admin.php:863
+#: admin/class-admin.php:864
 msgid "Adobe Analytics"
 msgstr ""
 
-#: admin/class-admin.php:865
+#: admin/class-admin.php:866
 msgid "Stripe"
 msgstr ""
 
-#: admin/class-admin.php:866
+#: admin/class-admin.php:867
 msgid "PayPal"
 msgstr ""
 
-#: admin/class-admin.php:867
+#: admin/class-admin.php:868
 msgid "Square"
 msgstr ""
 
-#: admin/class-admin.php:868
+#: admin/class-admin.php:869
 msgid "Shopify"
 msgstr ""
 
-#: admin/class-admin.php:870
+#: admin/class-admin.php:871
 msgid "Sign in with Google"
 msgstr ""
 
-#: admin/class-admin.php:871
+#: admin/class-admin.php:872
 msgid "Sign in with Apple"
 msgstr ""
 
-#: admin/class-admin.php:872
+#: admin/class-admin.php:873
 msgid "Sign in with Facebook"
 msgstr ""
 
-#: admin/class-admin.php:873
+#: admin/class-admin.php:874
 msgid "Auth0"
 msgstr ""
 
-#: admin/class-admin.php:874
+#: admin/class-admin.php:875
 msgid "Okta"
 msgstr ""
 
-#: admin/class-admin.php:876
+#: admin/class-admin.php:877
 msgid "Sentry"
 msgstr ""
 
-#: admin/class-admin.php:877
+#: admin/class-admin.php:878
 msgid "New Relic"
 msgstr ""
 
-#: admin/class-admin.php:878
+#: admin/class-admin.php:879
 msgid "Datadog"
 msgstr ""
 
-#: admin/class-admin.php:879
+#: admin/class-admin.php:880
 msgid "Bugsnag"
 msgstr ""
 
-#: admin/class-admin.php:880
+#: admin/class-admin.php:881
 msgid "Raygun"
 msgstr ""
 
-#: admin/class-admin.php:882
+#: admin/class-admin.php:883
 msgid "Optimizely"
 msgstr ""
 
-#: admin/class-admin.php:883
+#: admin/class-admin.php:884
 msgid "VWO"
 msgstr ""
 
-#: admin/class-admin.php:884
+#: admin/class-admin.php:885
 msgid "Convert.com"
 msgstr ""
 
-#: admin/class-admin.php:885
+#: admin/class-admin.php:886
 msgid "AB Tasty"
 msgstr ""
 
-#: admin/class-admin.php:887
+#: admin/class-admin.php:888
 msgid "OneSignal"
 msgstr ""
 
-#: admin/class-admin.php:888
+#: admin/class-admin.php:889
 msgid "Pushwoosh"
 msgstr ""
 
-#: admin/class-admin.php:889
+#: admin/class-admin.php:890
 msgid "Firebase Cloud Messaging"
 msgstr ""
 
-#: admin/class-admin.php:1147
 #: admin/class-admin.php:1148
-#: admin/class-admin.php:1177
+#: admin/class-admin.php:1149
 #: admin/class-admin.php:1178
+#: admin/class-admin.php:1179
 msgid "FAZ Cookie"
 msgstr ""
 
-#: admin/class-admin.php:1199
+#: admin/class-admin.php:1200
 msgid "FAZ Cookie Manager — Network"
 msgstr ""
 
-#: admin/class-admin.php:1201
+#: admin/class-admin.php:1202
 msgid "Multisite Configuration"
 msgstr ""
 
-#: admin/class-admin.php:1202
+#: admin/class-admin.php:1203
 msgid "FAZ Cookie Manager is network-activated. Each subsite has its own independent configuration."
 msgstr ""
 
-#: admin/class-admin.php:1203
+#: admin/class-admin.php:1204
 msgid "Navigate to each subsite's admin panel to configure the cookie banner, categories, and settings."
 msgstr ""
 
-#: admin/class-admin.php:1205
+#: admin/class-admin.php:1206
 msgid "Active Sites"
 msgstr ""
 
-#: admin/class-admin.php:1209
+#: admin/class-admin.php:1210
 msgid "Site"
 msgstr ""
 
-#: admin/class-admin.php:1210
+#: admin/class-admin.php:1211
 #: admin/views/banner.php:110
 msgid "Banner Status"
 msgstr ""
 
-#: admin/class-admin.php:1211
+#: admin/class-admin.php:1212
 #: admin/views/cookies.php:92
 #: admin/views/cookies.php:149
 msgid "Actions"
 msgstr ""
 
-#: admin/class-admin.php:1230
+#: admin/class-admin.php:1231
 msgid "Active"
 msgstr ""
 
-#: admin/class-admin.php:1232
+#: admin/class-admin.php:1233
 msgid "Inactive"
 msgstr ""
 
-#: admin/class-admin.php:1235
+#: admin/class-admin.php:1236
 msgid "Configure"
 msgstr ""
 
-#: admin/class-admin.php:1478
+#: admin/class-admin.php:1479
 msgid "WooCommerce detected"
 msgstr ""
 
-#: admin/class-admin.php:1479
+#: admin/class-admin.php:1480
 msgid "FAZ Cookie Manager automatically whitelists WooCommerce core scripts and payment gateway scripts (PayPal, Stripe, Mollie, etc.) on checkout and cart pages so your store keeps working. This can be customised via the"
 msgstr ""
 
-#: admin/class-admin.php:1480
+#: admin/class-admin.php:1481
 msgid "and"
 msgstr ""
 
-#: admin/class-admin.php:1481
+#: admin/class-admin.php:1482
 msgid "filters."
 msgstr ""
 
-#: admin/class-admin.php:1511
+#: admin/class-admin.php:1512
 msgid "Cookie definitions are using the built-in snapshot. Download the latest version from GitHub for improved categorization."
 msgstr ""
 
-#: admin/class-admin.php:1513
+#: admin/class-admin.php:1514
 msgid "Update Cookie Definitions"
 msgstr ""
 
 #. translators: %d: number of new cookies found
-#: admin/class-admin.php:1536
+#: admin/class-admin.php:1537
 #, php-format
 msgid "Scheduled scan found %d new cookie(s)."
 msgstr ""
 
-#: admin/class-admin.php:1540
+#: admin/class-admin.php:1541
 msgid "Review now"
 msgstr ""
 
 #. translators: %s: comma-separated list of service names
-#: admin/class-admin.php:1576
+#: admin/class-admin.php:1577
 #, php-format
 msgid "FAZ Cookie Manager detected services on your site that are not covered by any selected IAB vendor: %s."
 msgstr ""
 
-#: admin/class-admin.php:1580
+#: admin/class-admin.php:1581
 msgid "Add the matching vendors to ensure proper TCF consent for these services."
 msgstr ""
 
-#: admin/class-admin.php:1582
+#: admin/class-admin.php:1583
 msgid "Go to Vendor List"
 msgstr ""
 
-#: admin/class-admin.php:1584
+#: admin/class-admin.php:1585
 msgid "Dismiss"
 msgstr ""
 
-#: admin/class-admin.php:1666
+#: admin/class-admin.php:1667
 msgid "Cookie Consent Overview"
 msgstr ""
 
 #. translators: %d: number of consent interactions in last 30 days
-#: admin/class-admin.php:1727
+#: admin/class-admin.php:1728
 #, php-format
 msgid "%d consent interactions in the last 30 days."
 msgstr ""
 
-#: admin/class-admin.php:1731
+#: admin/class-admin.php:1732
 msgid "View details"
 msgstr ""
 

--- a/tests/e2e/specs/cookie-policy-service-auto-detect.spec.ts
+++ b/tests/e2e/specs/cookie-policy-service-auto-detect.spec.ts
@@ -677,4 +677,86 @@ test.describe('Cookie Policy third-party auto-detect from cookies', () => {
     expect(b.newly_suggested).toEqual(a.newly_suggested);
     expect(b.scan_available).toEqual(a.scan_available);
   });
+
+  test('27. F009: Auto-detect does NOT re-tick a detected service the admin unticked in-session (and still ticks the others)', async () => {
+    // Two detected-but-unsaved services. The admin manually adds then
+    // removes one (gtm) before saving; the other (stripe) is left alone.
+    plantCookies([
+      { name: 'cp_gtm', slug: 'cp-auto-f009-gtm', domain: '.googletagmanager.com' },
+      { name: 'cp_st',  slug: 'cp-auto-f009-st',  domain: '.js.stripe.com' },
+    ]);
+    await adminPage.reload({ waitUntil: 'domcontentloaded' });
+    await adminPage.locator('summary', { hasText: 'Third-party services' }).click();
+    // Hydration must finish (writeForm clears the in-session untick map and
+    // enables the button) before we interact, or the manual untick we record
+    // would be wiped.
+    await expect(adminPage.locator('#cp-services-auto-detect')).toBeEnabled({ timeout: 10_000 });
+
+    const gtm = adminPage.locator('#cp-services-list input[data-service-id="gtm"]');
+    const stripe = adminPage.locator('#cp-services-list input[data-service-id="stripe"]');
+    // Both start unchecked — they are detected (newly) but not saved.
+    await expect(gtm).not.toBeChecked();
+    await expect(stripe).not.toBeChecked();
+
+    // Admin manually ticks gtm, then unticks it — a deliberate in-session
+    // removal. Each click fires 'change', which the delegated listener records.
+    await gtm.click();
+    await expect(gtm).toBeChecked();
+    await gtm.click();
+    await expect(gtm).not.toBeChecked();
+
+    // Run Auto-detect.
+    await adminPage.click('#cp-services-auto-detect');
+    // gtm stays UNCHECKED (skipped — the admin removed it); stripe IS ticked
+    // (auto-detect still works for services the admin didn't touch).
+    await expect(stripe).toBeChecked({ timeout: 10_000 });
+    await expect(gtm).not.toBeChecked();
+    // Status reflects only the one actually pre-ticked, not the raw count.
+    await expect(adminPage.locator('#cp-services-auto-detect-status')).toContainText(
+      /Pre-ticked 1 new service\(s\)/i,
+      { timeout: 10_000 },
+    );
+  });
+
+  test('28. F009: a successful save resets the baseline — a later Auto-detect re-suggests the removed service', async () => {
+    plantCookies([
+      { name: 'cp_gtm', slug: 'cp-auto-f009b-gtm', domain: '.googletagmanager.com' },
+    ]);
+    await adminPage.reload({ waitUntil: 'domcontentloaded' });
+    await adminPage.locator('summary', { hasText: 'Third-party services' }).click();
+    await expect(adminPage.locator('#cp-services-auto-detect')).toBeEnabled({ timeout: 10_000 });
+
+    const gtm = adminPage.locator('#cp-services-list input[data-service-id="gtm"]');
+    await expect(gtm).not.toBeChecked();
+
+    // Tick then untick gtm → in-session removal recorded. Await the checked
+    // state BETWEEN the two clicks so each toggle's 'change' event is
+    // processed before the next (a rapid double-click can drop the second
+    // 'change', leaving the untick unrecorded).
+    await gtm.click();
+    await expect(gtm).toBeChecked();
+    await gtm.click();
+    await expect(gtm).not.toBeChecked();
+
+    // First Auto-detect: gtm is skipped, nothing pre-ticked.
+    await adminPage.click('#cp-services-auto-detect');
+    await expect(adminPage.locator('#cp-services-auto-detect-status')).toContainText(
+      /left unticked/i,
+      { timeout: 10_000 },
+    );
+    await expect(gtm).not.toBeChecked();
+
+    // Save (persists third_party_services = [] — gtm stays unselected).
+    await adminPage.click('button[type=submit]');
+    await expect(adminPage.locator('#cp-save-status')).toContainText(/Saved/i, { timeout: 10_000 });
+
+    // Saved state is the new baseline: the in-session untick is cleared, so a
+    // second Auto-detect re-suggests gtm and ticks it.
+    await adminPage.click('#cp-services-auto-detect');
+    await expect(gtm).toBeChecked({ timeout: 10_000 });
+    await expect(adminPage.locator('#cp-services-auto-detect-status')).toContainText(
+      /Pre-ticked 1 new service\(s\)/i,
+      { timeout: 10_000 },
+    );
+  });
 });


### PR DESCRIPTION
## What

Closes the F009 review finding: the Cookie Policy **Auto-detect from cookie scan** re-ticked a detected service the admin had manually **unticked** in-session (before saving), silently reversing their unsaved intent.

The handler already re-ticked only `newly_suggested` (not `already_selected`), but it ignored the admin's live checkbox state.

## Fix (`admin/assets/js/pages/cookie-policy.js`)

- Track service IDs the admin manually unticks this session in a null-prototype set, via a delegated `change` listener on `#cp-services-list`. Programmatic `writeForm()` ticks do not fire `change`, so hydration never pollutes it.
- Auto-detect skips any `newly_suggested` id in that set — a deliberate in-session removal survives, while every untouched service is still auto-ticked.
- The status count reports services **actually** pre-ticked (`newly − skipped`), so it can no longer over-report. New `svcAutoDetectNoneAdded` string for the all-skipped case.
- The set resets on hydration (`writeForm`) and after a successful save — the saved state becomes the new baseline, so a later Auto-detect re-suggests a removed service freely.

## Tests (`cookie-policy-service-auto-detect.spec.ts`)

- **27** — Auto-detect does NOT re-tick a service the admin unticked, but still ticks the ones they left alone.
- **28** — a successful save resets the baseline: a later Auto-detect re-suggests the removed service.

Both use the `cp-auto-*` slug prefix so `beforeEach`'s `resetCookies()` clears them between runs. Full cookie-policy auto-detect spec green (**28/28**); `cookie-policy-integration` green (**10/10**). `POT`/`PO` refreshed.

## Notes

- Branches off `feat/iab-vendor-auto-detect` (depends on the auto-detect feature that lives only there).
- Admin-only JS/i18n change — no frontend impact.