### PR TITLE
fix(geo): align "Geo source not configured" notice with the resolver

### DIFF
--- a/admin/views/banner.php
+++ b/admin/views/banner.php
@@ -751,12 +751,14 @@ defined( 'ABSPATH' ) || exit;
 		// Mirror what the resolver actually uses: Geolocation::has_database()
 		// wraps get_database_path(), which honours FAZ_MAXMIND_DB_PATH and any
 		// .mmdb the plugin downloaded into wp-content/uploads/faz-cookie-manager/.
-		// Previously this notice only checked the maxmind_key option and the
-		// FAZ_MAXMIND_DB_PATH constant inline, so a site whose database had been
-		// downloaded through the plugin still saw "Geo source not configured"
-		// even though geo-detection worked — a false negative. A saved key also
-		// counts as configured (the plugin downloads + auto-updates the DB).
-		$faz_has_maxmind  = ! empty( $faz_geo_settings['geolocation']['maxmind_key'] )
+		// Previously this notice only checked an inline option/constant test, so a
+		// site whose database had been downloaded through the plugin still saw
+		// "Geo source not configured" even though geo-detection worked — a false
+		// negative. A saved license key also counts as configured (the plugin
+		// downloads + auto-updates the DB). The option key is maxmind_license_key
+		// — the value written by Settings → Geolocation (class-settings.php) — not
+		// maxmind_key, which the prior code checked and which is never set.
+		$faz_has_maxmind  = ! empty( $faz_geo_settings['geolocation']['maxmind_license_key'] )
 			|| \FazCookie\Includes\Geolocation::has_database();
 		$faz_has_cf       = (bool) apply_filters( 'faz_trust_cf_ipcountry_header', false );
 		if ( ! $faz_has_maxmind && ! $faz_has_cf ) :

--- a/admin/views/banner.php
+++ b/admin/views/banner.php
@@ -748,8 +748,16 @@ defined( 'ABSPATH' ) || exit;
 		// countries, instead of letting them discover later that the feature
 		// they thought they enabled is a no-op.
 		$faz_geo_settings = get_option( 'faz_settings', array() );
+		// Mirror what the resolver actually uses: Geolocation::has_database()
+		// wraps get_database_path(), which honours FAZ_MAXMIND_DB_PATH and any
+		// .mmdb the plugin downloaded into wp-content/uploads/faz-cookie-manager/.
+		// Previously this notice only checked the maxmind_key option and the
+		// FAZ_MAXMIND_DB_PATH constant inline, so a site whose database had been
+		// downloaded through the plugin still saw "Geo source not configured"
+		// even though geo-detection worked — a false negative. A saved key also
+		// counts as configured (the plugin downloads + auto-updates the DB).
 		$faz_has_maxmind  = ! empty( $faz_geo_settings['geolocation']['maxmind_key'] )
-			|| ( defined( 'FAZ_MAXMIND_DB_PATH' ) && FAZ_MAXMIND_DB_PATH && file_exists( FAZ_MAXMIND_DB_PATH ) );
+			|| \FazCookie\Includes\Geolocation::has_database();
 		$faz_has_cf       = (bool) apply_filters( 'faz_trust_cf_ipcountry_header', false );
 		if ( ! $faz_has_maxmind && ! $faz_has_cf ) :
 			?>

--- a/includes/class-geolocation.php
+++ b/includes/class-geolocation.php
@@ -390,6 +390,7 @@ class Geolocation {
 	 * Get the path to the MMDB database file, if it exists.
 	 *
 	 * Checks (in order):
+	 *   0. The FAZ_MAXMIND_DB_PATH constant (operator-provided own .mmdb)
 	 *   1. The configured GeoLite2 edition (Country or City)
 	 *   2. The other GeoLite2 edition as a legacy fallback
 	 *   3. wp-content/uploads/faz-cookie-manager/dbip-country-lite.mmdb
@@ -397,17 +398,25 @@ class Geolocation {
 	 * Honouring the configured edition also keeps activation deterministic if
 	 * an obsolete file cannot be deleted after a Country/City switch.
 	 *
+	 * The FAZ_MAXMIND_DB_PATH constant is checked first so that an operator who
+	 * points it at their own database actually gets that file used by the
+	 * resolver — previously the constant only silenced the admin "Geo source
+	 * not configured" notice without ever being read here, so a site that set
+	 * it still resolved every visitor to "unknown".
+	 *
 	 * @return string Full path to the database file, or empty string.
 	 */
 	public static function get_database_path() {
 		$upload_dir = self::get_data_dir();
 		$preferred  = self::geolite2_edition();
 		$alternate  = ( 'GeoLite2-City' === $preferred ) ? 'GeoLite2-Country' : 'GeoLite2-City';
-		$candidates = array(
-			$upload_dir . $preferred . '.mmdb',
-			$upload_dir . $alternate . '.mmdb',
-			$upload_dir . 'dbip-country-lite.mmdb',
-		);
+		$candidates = array();
+		if ( defined( 'FAZ_MAXMIND_DB_PATH' ) && FAZ_MAXMIND_DB_PATH ) {
+			$candidates[] = (string) FAZ_MAXMIND_DB_PATH;
+		}
+		$candidates[] = $upload_dir . $preferred . '.mmdb';
+		$candidates[] = $upload_dir . $alternate . '.mmdb';
+		$candidates[] = $upload_dir . 'dbip-country-lite.mmdb';
 
 		foreach ( $candidates as $path ) {
 			if ( file_exists( $path ) && is_readable( $path ) ) {

--- a/includes/class-geolocation.php
+++ b/includes/class-geolocation.php
@@ -419,12 +419,54 @@ class Geolocation {
 		$candidates[] = $upload_dir . 'dbip-country-lite.mmdb';
 
 		foreach ( $candidates as $path ) {
-			if ( file_exists( $path ) && is_readable( $path ) ) {
+			if ( file_exists( $path ) && is_readable( $path ) && self::is_valid_mmdb( $path ) ) {
 				return $path;
 			}
 		}
 
 		return '';
+	}
+
+	/**
+	 * The marker that ends every MMDB metadata section (MaxMind DB format,
+	 * also used by the DB-IP lite distribution). Mirrors
+	 * Mmdb_Reader::METADATA_MARKER; duplicated here so this static check has no
+	 * dependency on the reader being autoloaded yet.
+	 */
+	const MMDB_METADATA_MARKER = "\xab\xcd\xefMaxMind.com";
+
+	/**
+	 * Cheap sanity check that a candidate file is an MMDB database.
+	 *
+	 * The resolver previously returned the first existing, readable candidate —
+	 * so a FAZ_MAXMIND_DB_PATH (or downloaded file) that exists but is corrupt or
+	 * the wrong format was preferred over a valid database, and Mmdb_Reader then
+	 * threw on first lookup with no fallback (every visitor resolved to
+	 * "unknown"). Skipping invalid candidates lets get_database_path() fall
+	 * through to the next valid database instead.
+	 *
+	 * The metadata marker lives in the last 128 KB of an MMDB file per the spec,
+	 * so this only reads that tail — never the whole multi-MB database.
+	 *
+	 * @param string $path Candidate file path.
+	 * @return bool True when the file ends with a recognisable MMDB metadata marker.
+	 */
+	private static function is_valid_mmdb( $path ) {
+		$size = @filesize( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === $size || $size < strlen( self::MMDB_METADATA_MARKER ) ) {
+			return false;
+		}
+		$tail_len = (int) min( $size, 131072 );
+		$handle   = @fopen( $path, 'rb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( false === $handle ) {
+			return false;
+		}
+		if ( $tail_len < $size ) {
+			@fseek( $handle, -$tail_len, SEEK_END ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		}
+		$tail = @fread( $handle, $tail_len ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fread, WordPress.PHP.NoSilencedErrors.Discouraged
+		@fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose, WordPress.PHP.NoSilencedErrors.Discouraged
+		return is_string( $tail ) && false !== strpos( $tail, self::MMDB_METADATA_MARKER );
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "full-test-codex": "playwright test -c tests/e2e/playwright.config.ts tests/e2e/specs/full-test-codex.spec.ts",
     "test:e2e": "playwright test -c tests/e2e/playwright.config.ts",
     "test:e2e:headed": "playwright test -c tests/e2e/playwright.config.ts --headed",
-    "test:e2e:report": "playwright show-report tests/e2e/reports/html"
+    "test:e2e:report": "playwright show-report tests/e2e/reports/html",
+    "test:unit": "bash scripts/run-unit-tests.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# run-unit-tests.sh — run every standalone PHP unit test under tests/unit/.
+#
+# Each tests/unit/test-*.php is a self-contained CLI runner (it stubs the WP
+# functions it needs and exits 0 on success / 1 on failure). This wrapper runs
+# them all, prints one line per suite, dumps output for any that fail, and exits
+# non-zero if any suite failed.
+#
+# Usage:
+#   scripts/run-unit-tests.sh           # run all suites
+#   npm run test:unit                   # same, via package.json
+#
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 2
+
+php_bin="${PHP_BIN:-php}"
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+pass=0
+fail=0
+failed=()
+
+shopt -s nullglob
+suites=( tests/unit/test-*.php )
+shopt -u nullglob
+
+if [ "${#suites[@]}" -eq 0 ]; then
+	echo "No unit test suites found under tests/unit/." >&2
+	exit 2
+fi
+
+for f in "${suites[@]}"; do
+	if "$php_bin" "$f" >"$log" 2>&1; then
+		# Surface the suite's own PASS/total tail line when it prints one.
+		summary="$(grep -E 'ALL PASS|PASS|passed' "$log" | tail -1)"
+		printf '  \033[32mPASS\033[0m  %-44s %s\n' "${f#tests/unit/}" "$summary"
+		pass=$((pass + 1))
+	else
+		printf '  \033[31mFAIL\033[0m  %s\n' "${f#tests/unit/}"
+		sed 's/^/        /' "$log"
+		fail=$((fail + 1))
+		failed+=( "$f" )
+	fi
+done
+
+echo "────────────────────────────────────────────────────────────"
+echo "unit suites: ${pass} passed, ${fail} failed (of ${#suites[@]})"
+if [ "$fail" -ne 0 ]; then
+	printf 'failed suites:\n'
+	printf '  - %s\n' "${failed[@]}"
+	exit 1
+fi

--- a/tests/unit/test-geolocation-db-path.php
+++ b/tests/unit/test-geolocation-db-path.php
@@ -79,6 +79,13 @@ function faz_clear_mmdb( $dir ) {
 	}
 }
 
+// Helper: write a minimal MMDB-shaped file. get_database_path() now validates a
+// candidate by looking for the MaxMind metadata marker in the file tail, so the
+// stub must carry that marker to be accepted as a real database.
+function faz_write_mmdb_stub( $path ) {
+	file_put_contents( $path, str_repeat( "\x00", 32 ) . "\xab\xcd\xefMaxMind.com" . str_repeat( "\x00", 8 ) );
+}
+
 echo "Geolocation::get_database_path() / has_database()\n";
 
 // ---- Case 1: nothing installed -> empty / false ----
@@ -88,18 +95,25 @@ faz_ok( false === Geolocation::has_database(), 'no database -> has_database() is
 
 // ---- Case 2: plugin-downloaded DB in uploads -> resolved (the false-negative case) ----
 $country_db = $data_dir . 'GeoLite2-Country.mmdb';
-file_put_contents( $country_db, 'fake-mmdb' );
+faz_write_mmdb_stub( $country_db );
 faz_ok( $country_db === Geolocation::get_database_path(), 'uploaded GeoLite2-Country.mmdb -> get_database_path() returns it' );
 faz_ok( true === Geolocation::has_database(), 'uploaded database -> has_database() is true' );
 
 // ---- Case 3: FAZ_MAXMIND_DB_PATH is honoured AND takes precedence over uploads ----
 $own_db = $faz_test_uploads . '/my-own-GeoLite2-City.mmdb';
-file_put_contents( $own_db, 'fake-mmdb' );
+faz_write_mmdb_stub( $own_db );
 define( 'FAZ_MAXMIND_DB_PATH', $own_db ); // constant is permanent for the rest of the run
 faz_ok( $own_db === Geolocation::get_database_path(), 'FAZ_MAXMIND_DB_PATH is honoured by the resolver and wins over uploads' );
 faz_ok( true === Geolocation::has_database(), 'FAZ_MAXMIND_DB_PATH present -> has_database() is true' );
 
-// ---- Case 4: a defined-but-MISSING FAZ_MAXMIND_DB_PATH falls through to the
+// ---- Case 4: a FAZ_MAXMIND_DB_PATH that exists but is CORRUPT (no MMDB marker)
+//      is skipped, and the resolver falls through to the valid uploads DB
+//      instead of preferring a database the reader would choke on. ----
+file_put_contents( $own_db, 'not-an-mmdb-file' );
+faz_ok( $country_db === Geolocation::get_database_path(), 'corrupt FAZ_MAXMIND_DB_PATH is skipped; falls through to the valid uploads database' );
+faz_ok( true === Geolocation::has_database(), 'corrupt constant + valid uploads -> has_database() is true' );
+
+// ---- Case 5: a defined-but-MISSING FAZ_MAXMIND_DB_PATH falls through to the
 //      uploads DB. The constant stays defined (PHP constants are permanent), but
 //      its target file is removed, so the file_exists guard must skip that
 //      candidate and the resolver must return the still-present uploads DB. ----

--- a/tests/unit/test-geolocation-db-path.php
+++ b/tests/unit/test-geolocation-db-path.php
@@ -99,10 +99,13 @@ define( 'FAZ_MAXMIND_DB_PATH', $own_db ); // constant is permanent for the rest 
 faz_ok( $own_db === Geolocation::get_database_path(), 'FAZ_MAXMIND_DB_PATH is honoured by the resolver and wins over uploads' );
 faz_ok( true === Geolocation::has_database(), 'FAZ_MAXMIND_DB_PATH present -> has_database() is true' );
 
-// ---- Case 4: with the constant set, removing it still leaves the uploads DB resolving ----
-// (FAZ_MAXMIND_DB_PATH still points at $own_db which exists, so this asserts the
-//  uploads file remains valid as a candidate behind the constant.)
-faz_ok( file_exists( $country_db ), 'uploads database untouched by the constant lookup' );
+// ---- Case 4: a defined-but-MISSING FAZ_MAXMIND_DB_PATH falls through to the
+//      uploads DB. The constant stays defined (PHP constants are permanent), but
+//      its target file is removed, so the file_exists guard must skip that
+//      candidate and the resolver must return the still-present uploads DB. ----
+@unlink( $own_db );
+faz_ok( $country_db === Geolocation::get_database_path(), 'missing FAZ_MAXMIND_DB_PATH file falls through to the uploads database' );
+faz_ok( true === Geolocation::has_database(), 'fallback to uploads -> has_database() is still true' );
 
 // ---------- Cleanup + result ----------
 faz_clear_mmdb( $data_dir );

--- a/tests/unit/test-geolocation-db-path.php
+++ b/tests/unit/test-geolocation-db-path.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Standalone unit tests for FazCookie\Includes\Geolocation database resolution:
+ *
+ *   - get_database_path()  (FAZ_MAXMIND_DB_PATH > uploads GeoLite2 > dbip)
+ *   - has_database()       (true iff get_database_path() resolves)
+ *
+ * Regression guard for the "Geo source not configured" false negative: the
+ * admin notice on the Geo Targeting tab used to check only the maxmind_key
+ * option and an inline FAZ_MAXMIND_DB_PATH file_exists() test, while the live
+ * resolver looked at wp-content/uploads/faz-cookie-manager/*.mmdb — so a site
+ * that downloaded the database through the plugin still saw the warning. The
+ * notice now calls Geolocation::has_database(), and FAZ_MAXMIND_DB_PATH is now
+ * honoured by get_database_path() (previously it was read only by the notice,
+ * never by the resolver). These tests pin both behaviours.
+ *
+ * Run from project root:
+ *   php tests/unit/test-geolocation-db-path.php
+ *
+ * Exit code 0 = all pass; 1 = at least one failure. Not a PHPUnit suite —
+ * mirrors the lightweight CLI runner pattern of test-geo-runtime-defaults.php.
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+// ---------- Bootstrap ----------
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+// Per-run temp "uploads" directory that wp_upload_dir() points at.
+$faz_test_uploads = sys_get_temp_dir() . '/faz-geo-test-' . getmypid();
+@mkdir( $faz_test_uploads, 0777, true );
+
+if ( ! function_exists( 'wp_upload_dir' ) ) {
+	function wp_upload_dir() { // phpcs:ignore
+		global $faz_test_uploads;
+		return array( 'basedir' => $faz_test_uploads );
+	}
+}
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $string ) { // phpcs:ignore
+		return rtrim( (string) $string, '/\\' ) . '/';
+	}
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) { // phpcs:ignore
+		return $value;
+	}
+}
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-geolocation.php';
+
+use FazCookie\Includes\Geolocation;
+
+// ---------- Tiny assertion harness ----------
+
+$faz_pass = 0;
+$faz_fail = 0;
+function faz_ok( $cond, $label ) {
+	global $faz_pass, $faz_fail;
+	if ( $cond ) {
+		++$faz_pass;
+		echo "  [PASS] $label\n";
+	} else {
+		++$faz_fail;
+		echo "  [FAIL] $label\n";
+	}
+}
+
+$data_dir = $faz_test_uploads . '/faz-cookie-manager/';
+@mkdir( $data_dir, 0777, true );
+
+// Helper: remove any .mmdb files between cases.
+function faz_clear_mmdb( $dir ) {
+	foreach ( glob( $dir . '*.mmdb' ) ?: array() as $f ) {
+		@unlink( $f );
+	}
+}
+
+echo "Geolocation::get_database_path() / has_database()\n";
+
+// ---- Case 1: nothing installed -> empty / false ----
+faz_clear_mmdb( $data_dir );
+faz_ok( '' === Geolocation::get_database_path(), 'no database -> get_database_path() returns ""' );
+faz_ok( false === Geolocation::has_database(), 'no database -> has_database() is false' );
+
+// ---- Case 2: plugin-downloaded DB in uploads -> resolved (the false-negative case) ----
+$country_db = $data_dir . 'GeoLite2-Country.mmdb';
+file_put_contents( $country_db, 'fake-mmdb' );
+faz_ok( $country_db === Geolocation::get_database_path(), 'uploaded GeoLite2-Country.mmdb -> get_database_path() returns it' );
+faz_ok( true === Geolocation::has_database(), 'uploaded database -> has_database() is true' );
+
+// ---- Case 3: FAZ_MAXMIND_DB_PATH is honoured AND takes precedence over uploads ----
+$own_db = $faz_test_uploads . '/my-own-GeoLite2-City.mmdb';
+file_put_contents( $own_db, 'fake-mmdb' );
+define( 'FAZ_MAXMIND_DB_PATH', $own_db ); // constant is permanent for the rest of the run
+faz_ok( $own_db === Geolocation::get_database_path(), 'FAZ_MAXMIND_DB_PATH is honoured by the resolver and wins over uploads' );
+faz_ok( true === Geolocation::has_database(), 'FAZ_MAXMIND_DB_PATH present -> has_database() is true' );
+
+// ---- Case 4: with the constant set, removing it still leaves the uploads DB resolving ----
+// (FAZ_MAXMIND_DB_PATH still points at $own_db which exists, so this asserts the
+//  uploads file remains valid as a candidate behind the constant.)
+faz_ok( file_exists( $country_db ), 'uploads database untouched by the constant lookup' );
+
+// ---------- Cleanup + result ----------
+faz_clear_mmdb( $data_dir );
+@unlink( $own_db );
+@rmdir( $data_dir );
+@rmdir( $faz_test_uploads );
+
+echo "\n" . ( 0 === $faz_fail ? "ALL PASS ($faz_pass)\n" : "FAILED: $faz_fail, passed: $faz_pass\n" );
+exit( 0 === $faz_fail ? 0 : 1 );

--- a/tests/unit/test-geolocation-db-path.php
+++ b/tests/unit/test-geolocation-db-path.php
@@ -1,24 +1,32 @@
 <?php
 /**
- * Standalone unit tests for FazCookie\Includes\Geolocation database resolution:
+ * Standalone unit tests for FazCookie\Includes\Geolocation database resolution.
  *
- *   - get_database_path()  (FAZ_MAXMIND_DB_PATH > uploads GeoLite2 > dbip)
- *   - has_database()       (true iff get_database_path() resolves)
+ * Covers get_database_path() / has_database() and, through them, the private
+ * is_valid_mmdb() candidate check:
  *
- * Regression guard for the "Geo source not configured" false negative: the
- * admin notice on the Geo Targeting tab used to check only the maxmind_key
- * option and an inline FAZ_MAXMIND_DB_PATH file_exists() test, while the live
- * resolver looked at wp-content/uploads/faz-cookie-manager/*.mmdb — so a site
- * that downloaded the database through the plugin still saw the warning. The
- * notice now calls Geolocation::has_database(), and FAZ_MAXMIND_DB_PATH is now
- * honoured by get_database_path() (previously it was read only by the notice,
- * never by the resolver). These tests pin both behaviours.
+ *   - candidate ordering: FAZ_MAXMIND_DB_PATH > configured edition
+ *     (GeoLite2-Country here, since no Settings class is loaded) > the other
+ *     edition > the DB-IP lite fallback;
+ *   - the false-negative fix: a database the plugin downloaded into
+ *     wp-content/uploads/faz-cookie-manager/ is resolved even without a saved
+ *     license key or the FAZ_MAXMIND_DB_PATH constant;
+ *   - the F-C fix: a candidate that exists but is corrupt / not an MMDB file
+ *     (no MaxMind metadata marker in its 128 KB tail) is skipped, so the
+ *     resolver falls through to the next valid database instead of handing a
+ *     broken file to Mmdb_Reader (which would throw and resolve every visitor
+ *     to "unknown" with no fallback);
+ *   - FAZ_MAXMIND_DB_PATH precedence, and the same validity guard applied to it.
+ *
+ * 25 assertions. PHP constants are permanent for the process, so every
+ * FAZ_MAXMIND_DB_PATH-independent case runs first (cases 1–19); the constant is
+ * defined once (case 20) and the remaining cases vary only its target file.
  *
  * Run from project root:
  *   php tests/unit/test-geolocation-db-path.php
  *
- * Exit code 0 = all pass; 1 = at least one failure. Not a PHPUnit suite —
- * mirrors the lightweight CLI runner pattern of test-geo-runtime-defaults.php.
+ * Exit code 0 = all pass; 1 = at least one failure. Lightweight CLI runner,
+ * not a PHPUnit suite — mirrors test-geo-runtime-defaults.php.
  *
  * @package FazCookie\Tests\Unit
  */
@@ -29,7 +37,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', __DIR__ );
 }
 
-// Per-run temp "uploads" directory that wp_upload_dir() points at.
 $faz_test_uploads = sys_get_temp_dir() . '/faz-geo-test-' . getmypid();
 @mkdir( $faz_test_uploads, 0777, true );
 
@@ -54,7 +61,7 @@ require_once dirname( __DIR__, 2 ) . '/includes/class-geolocation.php';
 
 use FazCookie\Includes\Geolocation;
 
-// ---------- Tiny assertion harness ----------
+// ---------- Assertion harness ----------
 
 $faz_pass = 0;
 $faz_fail = 0;
@@ -69,61 +76,166 @@ function faz_ok( $cond, $label ) {
 	}
 }
 
+// ---------- Fixtures ----------
+
 $data_dir = $faz_test_uploads . '/faz-cookie-manager/';
 @mkdir( $data_dir, 0777, true );
 
-// Helper: remove any .mmdb files between cases.
+const FAZ_TEST_MARKER = "\xab\xcd\xefMaxMind.com";
+
+/** Remove every .mmdb file in the uploads data dir between cases. */
 function faz_clear_mmdb( $dir ) {
 	foreach ( glob( $dir . '*.mmdb' ) ?: array() as $f ) {
 		@unlink( $f );
 	}
 }
 
-// Helper: write a minimal MMDB-shaped file. get_database_path() now validates a
-// candidate by looking for the MaxMind metadata marker in the file tail, so the
-// stub must carry that marker to be accepted as a real database.
+/** Minimal valid MMDB stub: padding + the MaxMind metadata marker near EOF. */
 function faz_write_mmdb_stub( $path ) {
-	file_put_contents( $path, str_repeat( "\x00", 32 ) . "\xab\xcd\xefMaxMind.com" . str_repeat( "\x00", 8 ) );
+	file_put_contents( $path, str_repeat( "\x00", 32 ) . FAZ_TEST_MARKER . str_repeat( "\x00", 8 ) );
 }
 
-echo "Geolocation::get_database_path() / has_database()\n";
+/** A non-MMDB file (no marker) — must be rejected as corrupt. */
+function faz_write_corrupt( $path ) {
+	file_put_contents( $path, 'this-is-not-an-mmdb-database-file' );
+}
 
-// ---- Case 1: nothing installed -> empty / false ----
+/**
+ * A large (~200 KB) file. $where='end' puts the marker at EOF (found by the
+ * 128 KB tail read); $where='head' puts it at the very start only (NOT in the
+ * tail, so it must be rejected — documents the tail-read scope).
+ */
+function faz_write_large( $path, $where = 'end' ) {
+	$pad = str_repeat( "\x00", 200 * 1024 );
+	file_put_contents( $path, 'head' === $where ? FAZ_TEST_MARKER . $pad : $pad . FAZ_TEST_MARKER );
+}
+
+echo "Geolocation::get_database_path() / has_database()  (25 assertions)\n";
+
+$country = $data_dir . 'GeoLite2-Country.mmdb';
+$city    = $data_dir . 'GeoLite2-City.mmdb';
+$dbip    = $data_dir . 'dbip-country-lite.mmdb';
+
+// === Part A — FAZ_MAXMIND_DB_PATH undefined (uploads-only resolution) =========
+
+// 1–2: nothing installed.
 faz_clear_mmdb( $data_dir );
-faz_ok( '' === Geolocation::get_database_path(), 'no database -> get_database_path() returns ""' );
-faz_ok( false === Geolocation::has_database(), 'no database -> has_database() is false' );
+faz_ok( '' === Geolocation::get_database_path(), '01 no database -> path is ""' );
+faz_ok( false === Geolocation::has_database(), '02 no database -> has_database() false' );
 
-// ---- Case 2: plugin-downloaded DB in uploads -> resolved (the false-negative case) ----
-$country_db = $data_dir . 'GeoLite2-Country.mmdb';
-faz_write_mmdb_stub( $country_db );
-faz_ok( $country_db === Geolocation::get_database_path(), 'uploaded GeoLite2-Country.mmdb -> get_database_path() returns it' );
-faz_ok( true === Geolocation::has_database(), 'uploaded database -> has_database() is true' );
+// 3–4: a valid downloaded GeoLite2-Country.mmdb (the false-negative case).
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $country );
+faz_ok( $country === Geolocation::get_database_path(), '03 valid Country.mmdb -> resolved' );
+faz_ok( true === Geolocation::has_database(), '04 valid Country.mmdb -> has_database() true' );
 
-// ---- Case 3: FAZ_MAXMIND_DB_PATH is honoured AND takes precedence over uploads ----
-$own_db = $faz_test_uploads . '/my-own-GeoLite2-City.mmdb';
-faz_write_mmdb_stub( $own_db );
-define( 'FAZ_MAXMIND_DB_PATH', $own_db ); // constant is permanent for the rest of the run
-faz_ok( $own_db === Geolocation::get_database_path(), 'FAZ_MAXMIND_DB_PATH is honoured by the resolver and wins over uploads' );
-faz_ok( true === Geolocation::has_database(), 'FAZ_MAXMIND_DB_PATH present -> has_database() is true' );
+// 5: only the City edition present -> alternate fallback.
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $city );
+faz_ok( $city === Geolocation::get_database_path(), '05 only City.mmdb -> alternate edition resolved' );
 
-// ---- Case 4: a FAZ_MAXMIND_DB_PATH that exists but is CORRUPT (no MMDB marker)
-//      is skipped, and the resolver falls through to the valid uploads DB
-//      instead of preferring a database the reader would choke on. ----
-file_put_contents( $own_db, 'not-an-mmdb-file' );
-faz_ok( $country_db === Geolocation::get_database_path(), 'corrupt FAZ_MAXMIND_DB_PATH is skipped; falls through to the valid uploads database' );
-faz_ok( true === Geolocation::has_database(), 'corrupt constant + valid uploads -> has_database() is true' );
+// 6: both editions -> the configured (Country) edition wins.
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $country );
+faz_write_mmdb_stub( $city );
+faz_ok( $country === Geolocation::get_database_path(), '06 Country + City -> preferred edition wins' );
 
-// ---- Case 5: a defined-but-MISSING FAZ_MAXMIND_DB_PATH falls through to the
-//      uploads DB. The constant stays defined (PHP constants are permanent), but
-//      its target file is removed, so the file_exists guard must skip that
-//      candidate and the resolver must return the still-present uploads DB. ----
-@unlink( $own_db );
-faz_ok( $country_db === Geolocation::get_database_path(), 'missing FAZ_MAXMIND_DB_PATH file falls through to the uploads database' );
-faz_ok( true === Geolocation::has_database(), 'fallback to uploads -> has_database() is still true' );
+// 7: corrupt Country + valid City -> corrupt one skipped, City resolved.
+faz_clear_mmdb( $data_dir );
+faz_write_corrupt( $country );
+faz_write_mmdb_stub( $city );
+faz_ok( $city === Geolocation::get_database_path(), '07 corrupt Country + valid City -> City resolved' );
+
+// 8: corrupt Country + corrupt City + valid dbip -> dbip resolved.
+faz_clear_mmdb( $data_dir );
+faz_write_corrupt( $country );
+faz_write_corrupt( $city );
+faz_write_mmdb_stub( $dbip );
+faz_ok( $dbip === Geolocation::get_database_path(), '08 two corrupt editions + valid dbip -> dbip resolved' );
+
+// 9: only the DB-IP lite fallback present.
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $dbip );
+faz_ok( $dbip === Geolocation::get_database_path(), '09 only dbip-country-lite.mmdb -> resolved' );
+
+// 10–11: a single corrupt candidate -> nothing valid.
+faz_clear_mmdb( $data_dir );
+faz_write_corrupt( $country );
+faz_ok( '' === Geolocation::get_database_path(), '10 lone corrupt Country -> path "" (skipped)' );
+faz_ok( false === Geolocation::has_database(), '11 lone corrupt Country -> has_database() false' );
+
+// 12: an empty (0-byte) file is rejected.
+faz_clear_mmdb( $data_dir );
+file_put_contents( $country, '' );
+faz_ok( '' === Geolocation::get_database_path(), '12 empty Country.mmdb -> rejected' );
+
+// 13: a file shorter than the marker is rejected.
+faz_clear_mmdb( $data_dir );
+file_put_contents( $country, 'abc' );
+faz_ok( '' === Geolocation::get_database_path(), '13 sub-marker-length file -> rejected' );
+
+// 14: a large file with the marker at EOF is found via the 128 KB tail read.
+faz_clear_mmdb( $data_dir );
+faz_write_large( $country, 'end' );
+faz_ok( $country === Geolocation::get_database_path(), '14 large file, marker at EOF -> resolved (tail read)' );
+
+// 15: a large file with the marker only at the head (outside the last 128 KB)
+//     is rejected — documents the tail-read scope (a real MMDB ends with it).
+faz_clear_mmdb( $data_dir );
+faz_write_large( $country, 'head' );
+faz_ok( '' === Geolocation::get_database_path(), '15 large file, marker only at head -> rejected (tail scope)' );
+
+// 16: marker followed by trailing metadata bytes (still inside the tail) -> valid.
+faz_clear_mmdb( $data_dir );
+file_put_contents( $country, str_repeat( "\x00", 100 ) . FAZ_TEST_MARKER . str_repeat( "\x01", 1024 ) );
+faz_ok( $country === Geolocation::get_database_path(), '16 marker + trailing data in tail -> resolved' );
+
+// 17: an unrelated .mmdb name is not a candidate.
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $data_dir . 'random-other.mmdb' );
+faz_ok( '' === Geolocation::get_database_path(), '17 unrelated .mmdb filename -> not a candidate' );
+
+// 18: a valid Country alongside an unrelated file -> Country resolved.
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $country );
+faz_write_mmdb_stub( $data_dir . 'random-other.mmdb' );
+faz_ok( $country === Geolocation::get_database_path(), '18 valid Country + unrelated file -> Country resolved' );
+
+// 19: has_database() agrees with get_database_path() on a resolved state.
+faz_ok(
+	Geolocation::has_database() === ( '' !== Geolocation::get_database_path() ),
+	'19 has_database() consistent with get_database_path()'
+);
+
+// === Part B — FAZ_MAXMIND_DB_PATH defined (operator override) ================
+
+$own = $faz_test_uploads . '/operator-GeoLite2-City.mmdb'; // outside $data_dir
+faz_clear_mmdb( $data_dir );
+faz_write_mmdb_stub( $country ); // a valid uploads DB to fall back to
+faz_write_mmdb_stub( $own );
+define( 'FAZ_MAXMIND_DB_PATH', $own ); // permanent for the rest of the run
+
+// 20–21: valid constant wins over a valid uploads database.
+faz_ok( $own === Geolocation::get_database_path(), '20 valid FAZ_MAXMIND_DB_PATH wins over uploads' );
+faz_ok( true === Geolocation::has_database(), '21 valid constant -> has_database() true' );
+
+// 22: corrupt constant is skipped; resolver falls through to valid uploads (F-C).
+faz_write_corrupt( $own );
+faz_ok( $country === Geolocation::get_database_path(), '22 corrupt constant -> falls through to uploads' );
+faz_ok( true === Geolocation::has_database(), '23 corrupt constant + valid uploads -> has_database() true' );
+
+// 24: empty constant file is skipped; uploads used.
+file_put_contents( $own, '' );
+faz_ok( $country === Geolocation::get_database_path(), '24 empty constant file -> falls through to uploads' );
+
+// 25: missing constant file AND no uploads DB -> nothing valid.
+@unlink( $own );
+faz_clear_mmdb( $data_dir );
+faz_ok( '' === Geolocation::get_database_path(), '25 missing constant + no uploads -> path ""' );
 
 // ---------- Cleanup + result ----------
 faz_clear_mmdb( $data_dir );
-@unlink( $own_db );
+@unlink( $own );
 @rmdir( $data_dir );
 @rmdir( $faz_test_uploads );
 


### PR DESCRIPTION
## Problem

The **Geo Targeting** tab shows an amber *"Geo source not configured"* notice whenever the `maxmind_key` option is empty and the `FAZ_MAXMIND_DB_PATH` constant is unset. But the live resolver (`Geolocation::get_database_path()`) reads the database from `wp-content/uploads/faz-cookie-manager/*.mmdb` — exactly where the plugin's **own GeoLite2 downloader** (and the DB-IP lite fallback) put the file.

So a site that downloaded the database **through the plugin** still saw the warning and assumed geo-targeting was broken, even though detection worked. **False negative.** (This is what a user hit on the support forum: "I do have MaxMind GeoLite2 setup, but it still doesn't allow me to do targeting.")

The inverse was also wrong: `FAZ_MAXMIND_DB_PATH` was read **only** by this notice, never by `get_database_path()` — so defining it silenced the warning while the resolver kept ignoring that file and resolving every visitor to `unknown`. **False positive.**

## Fix

- **`includes/class-geolocation.php`** — `get_database_path()` now honours `FAZ_MAXMIND_DB_PATH` as the first candidate (with precedence over the uploads copies), so the documented constant actually feeds the resolver.
- **`admin/views/banner.php`** — `$faz_has_maxmind` is now derived from `Geolocation::has_database()` (which wraps `get_database_path()`) instead of the inline option/constant check, so the notice mirrors what detection actually uses. A saved `maxmind_key` still counts as configured (the plugin downloads + auto-updates the DB).

Net effect: the notice and the resolver finally agree, and the documented constant works.

## Tests

- New `tests/unit/test-geolocation-db-path.php`: no DB → empty/false; uploaded `GeoLite2-Country.mmdb` (the false-negative case) → resolved/true; `FAZ_MAXMIND_DB_PATH` honoured + precedence. **7/7 pass.**
- Verified live: dropping `GeoLite2-Country.mmdb` into `wp-content/uploads/faz-cookie-manager/` flips `has_database()` to `true` with no fatal in the admin context; removing it flips back. `php -l` clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata la rilevazione della disponibilità di MaxMind nel geo-targeting
  * Aggiunta validazione della conformità del database geolocalizzazione per prevenire errori

* **Tests**
  * Aggiunto script automatico per l'esecuzione di test unitari con gestione dei risultati e reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->