### PR TITLE
feat: complete per-cookie consent with server-side enforcement (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to FAZ Cookie Manager are documented in this file.
 
+## [1.20.0] — 2026-06-17
+
+### Added
+
+- **Per-cookie consent (#135).** With per-service consent enabled, a new "Enable per-cookie consent" setting adds a nested toggle for each individual cookie a service declares, so a visitor can keep an accepted service (e.g. YouTube) but opt out of specific cookies within it. The choice is stored as override-only `ck.<service>.<cookie>` tokens and is now **enforced on both sides**: the client-side cleanup and the server-side `send_headers` shredder both read the same tokens (`ck.*` > `svc.*` > category precedence), so a denied cookie is removed on every request — not only client-side at save time. Always-allowed payment-gateway cookies and admin-whitelisted cookies stay exempt. The control was previously gated off pending this server-side enforcement; it is now ungated, opt-in, and off by default.
+
 ## [1.19.2] — 2026-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -563,6 +563,9 @@ Value format: `consentid:{base64},consent:yes,action:yes,necessary:yes,functiona
 
 Only the most recent release is listed here. The complete history is in [CHANGELOG.md](CHANGELOG.md) (Keep-a-Changelog format) and on the [GitHub Releases page](https://github.com/fabiodalez-dev/FAZ-Cookie-Manager/releases).
 
+### 1.20.0 — 2026-06-17
+- **Added**: per-cookie consent (#135) — with per-service consent on, a new setting adds a nested toggle for each cookie a service declares, so a visitor can keep an accepted service but opt out of specific cookies within it. Stored as override-only `ck.<service>.<cookie>` tokens and enforced on both sides (client cleanup + the server-side `send_headers` shredder read the same tokens, `ck.*` > `svc.*` > category), so a denied cookie is removed on every request; payment-gateway and admin-whitelisted cookies stay exempt. Opt-in, off by default.
+
 ### 1.19.2 — 2026-06-17
 - **Fixed**: the consent-log user-agent migration no longer errors on SQLite-backed WordPress (e.g. WordPress Playground) — it previously used MySQL's `SHA2()`/`REGEXP` and now runs in PHP with the identical hash; the Google Consent Mode non-personalized-ads `npa` signal is now most-restrictive across regions (a single global value, non-personalized whenever any configured region denies ads, since `npa` cannot be region-scoped), leaving the region-scoped Consent Mode v2 states unaffected.
 

--- a/admin/modules/settings/includes/class-settings.php
+++ b/admin/modules/settings/includes/class-settings.php
@@ -295,10 +295,11 @@ class Settings extends Store {
 				$value = faz_sanitize_bool( $value );
 				break;
 			case 'per_cookie_consent':
-				// Hidden experimental sub-feature: reject direct REST/import
-				// attempts to enable it until the per-cookie enforcement rework
-				// is complete.
-				$value = false;
+				// Nested per-cookie toggles within an accepted service. Only
+				// meaningful alongside per_service_consent (the frontend store
+				// and the server-side shredder both gate it on per-service), but
+				// it is a plain boolean here.
+				$value = faz_sanitize_bool( $value );
 				break;
 			case 'scan_frequency':
 				$allowed = array( 'daily', 'weekly', 'monthly' );

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -59,13 +59,13 @@ defined( 'ABSPATH' ) || exit;
 				</label>
 				<div class="faz-help"><?php esc_html_e( 'When enabled, visitors can accept or reject individual services (e.g., Google Analytics, YouTube) instead of entire categories. The list shows only services detected by the cookie scanner, so run a scan first — until then the preference center stays on category-level toggles. This provides more granular privacy control but makes the preference center more complex.', 'faz-cookie-manager' ); ?></div>
 			</div>
-						<div class="faz-form-group">
-				<label class="faz-toggle">
-					<input type="checkbox" data-path="banner_control.per_cookie_consent">
-					<span class="faz-toggle-track"></span>
-					<span class="faz-toggle-label"><?php esc_html_e( 'Enable per-cookie consent', 'faz-cookie-manager' ); ?></span>
-				</label>
-				<div class="faz-help"><?php esc_html_e( 'Requires per-service consent. Adds a nested toggle for each individual cookie a service declares, so visitors can opt out of specific cookies within an accepted service. A rejected cookie is removed on every page load — client-side and server-side — rather than blocked before it is written: the service script is allowed to run, so the cookie may be set momentarily and is then shredded. Adds depth to the preference center; enable only if you need cookie-level control.', 'faz-cookie-manager' ); ?></div>
+			<div class="faz-form-group">
+	<label class="faz-toggle">
+		<input type="checkbox" data-path="banner_control.per_cookie_consent">
+		<span class="faz-toggle-track"></span>
+		<span class="faz-toggle-label"><?php esc_html_e( 'Enable per-cookie consent', 'faz-cookie-manager' ); ?></span>
+	</label>
+	<div class="faz-help"><?php esc_html_e( 'Requires per-service consent. Adds a nested toggle for each individual cookie a service declares, so visitors can opt out of specific cookies within an accepted service. A rejected cookie is removed on every page load — client-side and server-side — rather than blocked before it is written: the service script is allowed to run, so the cookie may be set momentarily and is then shredded. Adds depth to the preference center; enable only if you need cookie-level control.', 'faz-cookie-manager' ); ?></div>
 			</div>
 			<div class="faz-form-group">
 				<label class="faz-toggle">

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -59,24 +59,14 @@ defined( 'ABSPATH' ) || exit;
 				</label>
 				<div class="faz-help"><?php esc_html_e( 'When enabled, visitors can accept or reject individual services (e.g., Google Analytics, YouTube) instead of entire categories. The list shows only services detected by the cookie scanner, so run a scan first — until then the preference center stays on category-level toggles. This provides more granular privacy control but makes the preference center more complex.', 'faz-cookie-manager' ); ?></div>
 			</div>
-			<?php
-			// Per-cookie consent stays hidden pending a correctness rework: the
-			// per-cookie revocation it advertises cannot be enforced server-side
-			// (the service script controls what is written; the plugin can only
-			// delete the cookie afterwards, client-side). Per-service consent
-			// above is reintroduced; the per-cookie markup is kept (gated off)
-			// for an easy restore once that enforcement gap is closed.
-			if ( false ) :
-			?>
-			<div class="faz-form-group">
+						<div class="faz-form-group">
 				<label class="faz-toggle">
 					<input type="checkbox" data-path="banner_control.per_cookie_consent">
 					<span class="faz-toggle-track"></span>
 					<span class="faz-toggle-label"><?php esc_html_e( 'Enable per-cookie consent', 'faz-cookie-manager' ); ?></span>
 				</label>
-				<div class="faz-help"><?php esc_html_e( 'Requires per-service consent. Adds a nested toggle for each individual cookie a service declares, so visitors can opt out of specific cookies within an accepted service.', 'faz-cookie-manager' ); ?></div>
+				<div class="faz-help"><?php esc_html_e( 'Requires per-service consent. Adds a nested toggle for each individual cookie a service declares, so visitors can opt out of specific cookies within an accepted service. A rejected cookie is removed on every page load — client-side and server-side — rather than blocked before it is written: the service script is allowed to run, so the cookie may be set momentarily and is then shredded. Adds depth to the preference center; enable only if you need cookie-level control.', 'faz-cookie-manager' ); ?></div>
 			</div>
-			<?php endif; ?>
 			<div class="faz-form-group">
 				<label class="faz-toggle">
 					<input type="checkbox" data-path="banner_control.subdomain_sharing">

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -60,12 +60,12 @@ defined( 'ABSPATH' ) || exit;
 				<div class="faz-help"><?php esc_html_e( 'When enabled, visitors can accept or reject individual services (e.g., Google Analytics, YouTube) instead of entire categories. The list shows only services detected by the cookie scanner, so run a scan first — until then the preference center stays on category-level toggles. This provides more granular privacy control but makes the preference center more complex.', 'faz-cookie-manager' ); ?></div>
 			</div>
 			<div class="faz-form-group">
-	<label class="faz-toggle">
-		<input type="checkbox" data-path="banner_control.per_cookie_consent">
-		<span class="faz-toggle-track"></span>
-		<span class="faz-toggle-label"><?php esc_html_e( 'Enable per-cookie consent', 'faz-cookie-manager' ); ?></span>
-	</label>
-	<div class="faz-help"><?php esc_html_e( 'Requires per-service consent. Adds a nested toggle for each individual cookie a service declares, so visitors can opt out of specific cookies within an accepted service. A rejected cookie is removed on every page load — client-side and server-side — rather than blocked before it is written: the service script is allowed to run, so the cookie may be set momentarily and is then shredded. Adds depth to the preference center; enable only if you need cookie-level control.', 'faz-cookie-manager' ); ?></div>
+				<label class="faz-toggle">
+					<input type="checkbox" data-path="banner_control.per_cookie_consent">
+					<span class="faz-toggle-track"></span>
+					<span class="faz-toggle-label"><?php esc_html_e( 'Enable per-cookie consent', 'faz-cookie-manager' ); ?></span>
+				</label>
+				<div class="faz-help"><?php esc_html_e( 'Requires per-service consent. Adds a nested toggle for each individual cookie a service declares, so visitors can opt out of specific cookies within an accepted service. When script blocking is active for the page, a rejected cookie is removed on each load — client-side and server-side — rather than blocked before it is written: the service script is allowed to run, so the cookie may be set momentarily and is then shredded. Adds depth to the preference center; enable only if you need cookie-level control.', 'faz-cookie-manager' ); ?></div>
 			</div>
 			<div class="faz-form-group">
 				<label class="faz-toggle">

--- a/faz-cookie-manager.php
+++ b/faz-cookie-manager.php
@@ -16,10 +16,10 @@
  * Plugin Name:       FAZ Cookie Manager
  * Plugin URI:        https://github.com/fabiodalez-dev/faz-cookie-manager
  * Description:       A comprehensive GDPR/CCPA cookie consent manager with built-in cookie scanner, local consent logging, Google Consent Mode v2, and IAB TCF v2.3 support.
- * Version:           1.19.2
+ * Version:           1.20.0
  * Requires at least: 5.0
  * Tested up to:      7.0
- * Stable tag:        1.19.2
+ * Stable tag:        1.20.0
  * Requires PHP:      7.4
  * Author:            Fabio D'Alessandro
  * Author URI:        https://fabiodalez.it/
@@ -51,7 +51,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'FAZ_VERSION', '1.19.2' );
+define( 'FAZ_VERSION', '1.20.0' );
 define( 'FAZ_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 define( 'FAZ_PLUGIN_BASEPATH', plugin_dir_path( __FILE__ ) );
 define( 'FAZ_PLUGIN_FILENAME', __FILE__ );

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1581,15 +1581,14 @@ class Frontend {
 
 		// Per-service consent: pass service list to frontend.
 		// 1.18.3: per-service consent reintroduced — read the option again so the
-		// resolved service list reaches the frontend preference center. Per-COOKIE
-		// consent remains out (its admin toggle stays gated; see settings.php), so
-		// no nested per-cookie overrides are emitted here. The correctness gaps the
-		// 1.18.2 hotfix flagged are now closed: per-service (svc.*) decisions are
-		// logged (P1-3, see the inline consent logger — the ck.* branch is covered
-		// too but cannot fire while per-cookie consent stays gated), the consent
-		// cookie is hard-capped against the 4 KB browser limit (P1-4, see
-		// _fazSetInStore), and the list below is filtered to providers with a
-		// DETECTED cookie (P2, just here).
+		// resolved service list reaches the frontend preference center. 1.20.0:
+		// per-COOKIE consent ungated — when its toggle is on, nested per-cookie
+		// (ck.*) overrides are emitted below and enforced server-side too (see
+		// shred_non_consented_cookies). The 1.18.2-hotfix correctness gaps stay
+		// closed: per-service (svc.*) and per-cookie (ck.*) decisions are logged
+		// (P1-3, inline consent logger), the consent cookie is hard-capped against
+		// the 4 KB browser limit (P1-4, see _fazSetInStore), and the list below is
+		// filtered to providers with a DETECTED cookie (P2, just here).
 		$per_service = ! empty( $settings['banner_control']['per_service_consent'] );
 		if ( $per_service ) {
 			// P2: source the per-service toggle list from the cookies actually
@@ -4873,7 +4872,7 @@ class Frontend {
 		// Parse ck.* from the SAME validated (non-stale) consent string as svc.*,
 		// so a revision-bumped/expired cookie does not enforce old per-cookie picks.
 		$valid_consent_str = ( $per_cookie_enabled && function_exists( 'faz_get_valid_consent_cookie' ) ) ? (string) faz_get_valid_consent_cookie() : '';
-		$consent_cookie    = ( '' !== $valid_consent_str ) ? faz_parse_consent_cookie( $valid_consent_str ) : array();
+		$consent_cookie    = ( '' !== $valid_consent_str && function_exists( 'faz_parse_consent_cookie' ) ) ? faz_parse_consent_cookie( $valid_consent_str ) : array();
 		$svc_cookie_decisions = array(); // pattern => array( 'yes'|'no' ).
 		if ( ! empty( $service_consent ) || $per_cookie_enabled ) {
 			foreach ( $this->get_per_service_services() as $service ) {

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -1605,11 +1605,14 @@ class Frontend {
 			$services                    = $this->get_per_service_services( $valid_categories );
 			$store['_perServiceConsent'] = true;
 			$store['_services']         = $services;
-			// Per-cookie consent remains gated until its rework is complete.
-			// New writes can no longer persist it as true (the settings
-			// sanitiser forces it false on the REST/import path), so this is a
-			// defensive runtime guard for a pre-gate legacy DB row only.
-			$store['_perCookieConsent'] = false;
+			// Per-cookie consent: nested per-cookie toggles inside each accepted
+			// service. Enabled only when its admin toggle is on (and per-service
+			// is on, which it is in this branch). Enforcement is by cookie
+			// shredding on every request — client-side (_fazCleanupRevokedCookies)
+			// and server-side (shred_non_consented_cookies, which reads the same
+			// ck.* tokens) — since the service script, not the individual cookie,
+			// is the atomic unit that gets gated.
+			$store['_perCookieConsent'] = ! empty( $settings['banner_control']['per_cookie_consent'] );
 		}
 
 		/**
@@ -1636,11 +1639,6 @@ class Frontend {
 		if ( is_array( $filtered_store ) ) {
 			$store = $filtered_store;
 		}
-
-		// Per-cookie consent stays hard-off until its enforcement rework is
-		// complete — reassert it AFTER the faz_store_data filter so a third-party
-		// filter callback cannot re-enable the unsupported control.
-		$store['_perCookieConsent'] = false;
 
 		return $store;
 	}
@@ -4864,27 +4862,42 @@ class Frontend {
 		// Per-service consent overrides the category fallback for matching
 		// cookies. A denied service wins over an allowed service when providers
 		// share a cookie pattern.
-		$service_consent       = $this->get_service_consent();
+		$service_consent = $this->get_service_consent();
+		// Per-cookie consent (ck.<svc>.<cookie>) is the most-specific override on
+		// top of per-service: a cookie denied inside an otherwise-accepted service
+		// is shredded server-side too. Mirrors the client resolver
+		// _fazGetServiceCookieDecision (per-cookie > per-service > category).
+		$shred_settings       = $this->get_faz_settings();
+		$shred_banner_control = isset( $shred_settings['banner_control'] ) ? (array) $shred_settings['banner_control'] : array();
+		$per_cookie_enabled   = ! empty( $shred_banner_control['per_cookie_consent'] ) && ! empty( $shred_banner_control['per_service_consent'] );
+		// Parse ck.* from the SAME validated (non-stale) consent string as svc.*,
+		// so a revision-bumped/expired cookie does not enforce old per-cookie picks.
+		$valid_consent_str = ( $per_cookie_enabled && function_exists( 'faz_get_valid_consent_cookie' ) ) ? (string) faz_get_valid_consent_cookie() : '';
+		$consent_cookie    = ( '' !== $valid_consent_str ) ? faz_parse_consent_cookie( $valid_consent_str ) : array();
 		$svc_cookie_decisions = array(); // pattern => array( 'yes'|'no' ).
-		if ( ! empty( $service_consent ) ) {
+		if ( ! empty( $service_consent ) || $per_cookie_enabled ) {
 			foreach ( $this->get_per_service_services() as $service ) {
 				$svc_id = isset( $service['id'] ) ? sanitize_key( $service['id'] ) : '';
-				if ( '' === $svc_id || ! isset( $service_consent[ $svc_id ] ) || empty( $service['cookies'] ) ) {
+				if ( '' === $svc_id || empty( $service['cookies'] ) ) {
 					continue;
 				}
-				$decision = $service_consent[ $svc_id ];
-				if ( 'yes' !== $decision && 'no' !== $decision ) {
-					continue;
+				$svc_decision = isset( $service_consent[ $svc_id ] ) ? $service_consent[ $svc_id ] : '';
+				if ( 'yes' !== $svc_decision && 'no' !== $svc_decision ) {
+					$svc_decision = '';
 				}
 				foreach ( $service['cookies'] as $cookie_pattern ) {
 					$cookie_pattern = sanitize_text_field( (string) $cookie_pattern );
 					if ( '' === $cookie_pattern ) {
 						continue;
 					}
+					$pattern_decision = $this->resolve_service_cookie_decision( $svc_id, $cookie_pattern, $svc_decision, $consent_cookie, $per_cookie_enabled );
+					if ( 'yes' !== $pattern_decision && 'no' !== $pattern_decision ) {
+						continue; // No explicit svc/ck decision -> category fallback handles it.
+					}
 					if ( ! isset( $svc_cookie_decisions[ $cookie_pattern ] ) ) {
 						$svc_cookie_decisions[ $cookie_pattern ] = array();
 					}
-					$svc_cookie_decisions[ $cookie_pattern ][] = $decision;
+					$svc_cookie_decisions[ $cookie_pattern ][] = $pattern_decision;
 				}
 			}
 		}
@@ -4971,6 +4984,46 @@ class Frontend {
 				unset( $_COOKIE[ $name ] );
 			}
 		}
+	}
+
+	/**
+	 * Effective decision for one declared cookie of a service: the per-cookie
+	 * override (ck.<svc>.<cookie>) when present, else the per-service decision,
+	 * else '' (let category fallback decide). Mirrors the client-side
+	 * _fazCookieEffectiveConsent / _fazGetServiceCookieDecision precedence.
+	 *
+	 * @param string $svc_id             Sanitised service id.
+	 * @param string $cookie_pattern     Declared cookie name/pattern.
+	 * @param string $svc_decision       'yes'|'no'|'' per-service decision.
+	 * @param array  $consent_cookie     Parsed consent cookie (ck.* tokens).
+	 * @param bool   $per_cookie_enabled Whether per-cookie consent is active.
+	 * @return string 'yes'|'no'|''
+	 */
+	private function resolve_service_cookie_decision( $svc_id, $cookie_pattern, $svc_decision, $consent_cookie, $per_cookie_enabled ) {
+		$decision = ( 'yes' === $svc_decision || 'no' === $svc_decision ) ? $svc_decision : '';
+		if ( $per_cookie_enabled ) {
+			$ck_key = 'ck.' . $svc_id . '.' . $this->ck_escape_cookie_name( $cookie_pattern );
+			if ( isset( $consent_cookie[ $ck_key ] ) && in_array( $consent_cookie[ $ck_key ], array( 'yes', 'no' ), true ) ) {
+				$decision = $consent_cookie[ $ck_key ];
+			}
+		}
+		return $decision;
+	}
+
+	/**
+	 * Escape a cookie name for the ck.<service>.<cookie> consent token, matching
+	 * the client-side _fazCkKey() escaping so PHP reconstructs the exact key the
+	 * browser wrote. Percent first, so we never double-escape the % in %3A/%2C.
+	 *
+	 * @param string $cookie_name Raw declared cookie name/pattern.
+	 * @return string
+	 */
+	private function ck_escape_cookie_name( $cookie_name ) {
+		$cookie_name = (string) $cookie_name;
+		$cookie_name = str_replace( '%', '%25', $cookie_name );
+		$cookie_name = str_replace( ':', '%3A', $cookie_name );
+		$cookie_name = str_replace( ',', '%2C', $cookie_name );
+		return $cookie_name;
 	}
 
 	/**

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -413,6 +413,13 @@ class Activator {
 		// idempotent — they no-op when the category already exists.
 		self::ensure_uncategorized_category();
 		self::ensure_wordpress_internal_category();
+		// Neutralise a stale pre-1.18.2 per_cookie_consent=true on upgrade. This
+		// also runs in run_pending_migrations(), but that hook is admin_init-only;
+		// install() runs from check_version() on the `init` hook (frontend too),
+		// so the reset lands on the first request of ANY kind after the upgrade —
+		// closing the window where a rarely-admined site would re-activate
+		// per-cookie consent on the frontend before an admin ever loads wp-admin.
+		self::reset_stale_per_cookie_consent();
 		// Always clear the banner template cache on version upgrades so new
 		// CSS rules, shortcodes, and template HTML take effect immediately.
 		// Without this, users upgrading across multiple versions (e.g. 1.8 →

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -1311,21 +1311,30 @@ class Activator {
 	 * re-activate the nested per-cookie toggles on upgrade. Reset the stale flag
 	 * to false so per-cookie consent starts OFF for everyone and must be
 	 * re-enabled explicitly. Fresh installs already default to false, and no
-	 * deliberate current `true` can exist (the write-gate prevented it), so this
-	 * only ever clears a legacy value — it never clobbers an intentional choice.
+	 * deliberate current `true` can exist at 1.20.0 (the write-gate prevented
+	 * it), so this only ever clears a legacy value on that one upgrade.
+	 *
+	 * A one-time marker (`faz_reset_stale_per_cookie_consent_done`) makes the
+	 * reset fire exactly once: install() calls this on every version upgrade,
+	 * so without the marker a later release would re-clear a per_cookie_consent
+	 * an admin intentionally re-enabled after 1.20.0.
 	 *
 	 * @return void
 	 */
 	public static function reset_stale_per_cookie_consent() {
+		if ( get_option( 'faz_reset_stale_per_cookie_consent_done' ) ) {
+			return; // Already neutralised once — never clobber a later intentional choice.
+		}
 		$settings = get_option( 'faz_settings' );
 		if ( ! is_array( $settings ) || empty( $settings['banner_control'] ) || ! is_array( $settings['banner_control'] ) ) {
+			update_option( 'faz_reset_stale_per_cookie_consent_done', 1, false );
 			return;
 		}
-		if ( empty( $settings['banner_control']['per_cookie_consent'] ) ) {
-			return; // Already off or absent — nothing to do.
+		if ( ! empty( $settings['banner_control']['per_cookie_consent'] ) ) {
+			$settings['banner_control']['per_cookie_consent'] = false;
+			update_option( 'faz_settings', $settings );
 		}
-		$settings['banner_control']['per_cookie_consent'] = false;
-		update_option( 'faz_settings', $settings );
+		update_option( 'faz_reset_stale_per_cookie_consent_done', 1, false );
 	}
 
 	/**

--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -110,7 +110,7 @@ class Activator {
 	/**
 	 * Bump this only when adding/changing a migration in the sequence below.
 	 */
-	const MIGRATIONS_VERSION = '2026.06.14.1';
+	const MIGRATIONS_VERSION = '2026.06.17.1';
 
 	/**
 	 * Run all pending one-time data migrations in a single admin_init callback.
@@ -137,6 +137,7 @@ class Activator {
 			self::enable_gpc_on_ccpa_banners();
 			self::ensure_share_personal_data_column();
 			self::clear_necessary_optout_flags();
+			self::reset_stale_per_cookie_consent();
 		} catch ( \Throwable $e ) {
 			// Do not mark migrations complete — retry on next admin load.
 			return;
@@ -1290,6 +1291,34 @@ class Activator {
 		if ( $result > 0 ) {
 			Category_Controller::get_instance()->delete_cache();
 		}
+	}
+
+	/**
+	 * Make the per-cookie consent ungating (1.20.0) a surprise-free upgrade.
+	 *
+	 * Per-cookie consent was settable before 1.18.2, then hard-gated: 1.18.2
+	 * through 1.19.x forced banner_control.per_cookie_consent to false on every
+	 * write, so any stored `true` is necessarily a stale pre-gate value the
+	 * runtime was masking. 1.20.0 removes that mask and drives the feature from
+	 * the saved setting, so without this reset such installs would silently
+	 * re-activate the nested per-cookie toggles on upgrade. Reset the stale flag
+	 * to false so per-cookie consent starts OFF for everyone and must be
+	 * re-enabled explicitly. Fresh installs already default to false, and no
+	 * deliberate current `true` can exist (the write-gate prevented it), so this
+	 * only ever clears a legacy value — it never clobbers an intentional choice.
+	 *
+	 * @return void
+	 */
+	public static function reset_stale_per_cookie_consent() {
+		$settings = get_option( 'faz_settings' );
+		if ( ! is_array( $settings ) || empty( $settings['banner_control'] ) || ! is_array( $settings['banner_control'] ) ) {
+			return;
+		}
+		if ( empty( $settings['banner_control']['per_cookie_consent'] ) ) {
+			return; // Already off or absent — nothing to do.
+		}
+		$settings['banner_control']['per_cookie_consent'] = false;
+		update_option( 'faz_settings', $settings );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://buymeacoffee.com/fabiodalez
 Tags: cookie, gdpr, ccpa, consent, privacy
 Requires at least: 5.0
 Tested up to: 7.0
-Stable tag: 1.19.2
+Stable tag: 1.20.0
 Requires PHP: 7.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -324,6 +324,9 @@ The full changelog (every release back to 1.0.0) lives at:
 https://github.com/fabiodalez-dev/FAZ-Cookie-Manager/blob/main/CHANGELOG.md
 and on the GitHub Releases page:
 https://github.com/fabiodalez-dev/FAZ-Cookie-Manager/releases
+
+= 1.20.0 =
+* Feature: per-cookie consent (#135). With per-service consent enabled, a new "Enable per-cookie consent" setting adds a nested toggle for each individual cookie a service declares, so a visitor can keep an accepted service (e.g. YouTube) while opting out of specific cookies within it. The choice is now enforced on both sides — the client-side cleanup and the server-side shredder both read the same ck.<service>.<cookie> tokens (per-cookie > per-service > category), so a denied cookie is removed on every request. Payment-gateway and admin-whitelisted cookies stay exempt. Opt-in, off by default.
 
 = 1.19.2 =
 * Fix: the consent-log user-agent migration no longer errors on SQLite-backed WordPress (e.g. WordPress Playground). It previously used MySQL's SHA2()/REGEXP, which do not exist on SQLite, so the migration failed and emitted a database error on every request; it now runs in PHP with the identical hash.

--- a/tests/e2e/specs/per-cookie-consent.spec.ts
+++ b/tests/e2e/specs/per-cookie-consent.spec.ts
@@ -89,7 +89,21 @@ test.describe('Per-cookie consent (issue #135)', () => {
 
     // enable a category that has cookies; the cascade checks nested cookies
     const picked = await fp.evaluate(() => {
-      const ck = document.querySelector('.faz-cookie-toggle');
+      // Pick the first per-cookie toggle whose cookie is actually SHREDDABLE.
+      // Always-allowed / user-whitelisted cookies (e.g. the Stripe payment
+      // gateway's __stripe_mid) are exempt from shredding by design — removing
+      // them would break payment flows — so a per-cookie denial on one can
+      // never satisfy the "denied cookie is shredded on save" assertion below.
+      // Test environments that expose a gateway service render its toggle
+      // first, so an unfiltered querySelector would pick the one cookie the
+      // shredder must NOT touch.
+      const toggles = Array.from(document.querySelectorAll('.faz-cookie-toggle'));
+      const isWhitelisted = (window as unknown as { _fazIsCookieWhitelisted?: (n: string) => boolean })._fazIsCookieWhitelisted;
+      const ck =
+        toggles.find((el) => {
+          const nm = el.getAttribute('data-cookie-name') || '';
+          return nm && !(typeof isWhitelisted === 'function' && isWhitelisted(nm));
+        }) || toggles[0];
       if (!ck) return null;
       const cat = ck.getAttribute('data-category') || '';
       const svc = ck.getAttribute('data-service') || '';

--- a/tests/e2e/specs/per-cookie-consent.spec.ts
+++ b/tests/e2e/specs/per-cookie-consent.spec.ts
@@ -36,12 +36,10 @@ async function postSettings(page: Page, nonce: string, payload: FazSettings): Pr
   expect(res.status(), `settings update status ${res.status()}`).toBe(200);
 }
 
-// 1.18.2 HOTFIX: per-service / per-cookie consent is hard-disabled — the store
-// payload forces $per_service = false and the Settings toggles are gated off, so
-// the frontend never renders the nested per-cookie toggles this spec drives.
-// Skipped until the feature is reworked (server-side ck.* enforcement, granular
-// logging, 4 KB guard) and re-enabled; flip back to test.describe(...) then.
-test.describe.skip('Per-cookie consent (issue #135)', () => {
+// Re-enabled once per-cookie consent gained server-side ck.* enforcement
+// (Frontend::shred_non_consented_cookies reads the same ck.* tokens via
+// resolve_service_cookie_decision) and its admin toggle was ungated.
+test.describe('Per-cookie consent (issue #135)', () => {
   test.describe.configure({ mode: 'serial' });
 
   let original: FazSettings | null = null;
@@ -152,6 +150,23 @@ test.describe.skip('Per-cookie consent (issue #135)', () => {
     // enforcement: the denied cookie was shredded inside the save action
     const stillThere = await fp.evaluate((p) => document.cookie.indexOf(p.name + '=') !== -1, target);
     expect(stillThere, 'denied cookie is shredded on save').toBe(false);
+
+    // server-side enforcement persists across requests: re-plant the denied
+    // cookie so the browser sends it on the next request, reload, and confirm
+    // the send_headers shredder removes it again while the ck.*:no choice holds.
+    await fp.evaluate((p) => {
+      document.cookie = p.name + '=replanted; path=/';
+    }, target);
+    await fp.goto('/', { waitUntil: 'domcontentloaded' });
+    await fp.waitForTimeout(900);
+    const afterReload = await fp.evaluate((p) => document.cookie.indexOf(p.name + '=') !== -1, target);
+    expect(afterReload, 'denied cookie stays shredded across a reload').toBe(false);
+    const cookies2 = await ctx.cookies();
+    const consent2 = cookies2.find((c) => c.name === 'fazcookie-consent');
+    const decoded2 = consent2 ? decodeURIComponent(consent2.value) : '';
+    expect(decoded2, 'per-cookie denial persists after reload').toContain(
+      'ck.' + target.svc + '.' + target.name + ':no',
+    );
 
     await ctx.close();
 

--- a/tests/unit/test-percookie-php.php
+++ b/tests/unit/test-percookie-php.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Standalone unit tests for the per-cookie consent backend (#135).
+ *
+ * Subsystem: percookie-php
+ *
+ * Covers the two Frontend helpers that drive server-side per-cookie (ck.*)
+ * enforcement, extracted from shred_non_consented_cookies():
+ *   - Frontend::ck_escape_cookie_name()          (mirror of JS _fazCkKey escaping)
+ *   - Frontend::resolve_service_cookie_decision() (ck.* > svc.* > '' precedence)
+ *
+ * Pure-logic tests: no browser, DB, or live WordPress. The Frontend object is
+ * built with ReflectionClass::newInstanceWithoutConstructor() and the private
+ * methods are invoked via reflection. The full end-to-end shredder (cookie
+ * removal on a live request) is validated by the E2E suite.
+ *
+ * Run from project root:
+ *   php tests/unit/test-percookie-php.php
+ *
+ * Exit code 0 = all tests pass; 1 = at least one failure.
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+namespace FazCookie\Includes {
+
+	class Known_Providers {
+		public static function get_all() {
+			return array();
+		}
+		public static function get_cookie_map() {
+			return array();
+		}
+		public static function get_pattern_map() {
+			return array();
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+		define( 'HOUR_IN_SECONDS', 3600 );
+	}
+
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( $str ) {
+			return trim( preg_replace( '/<[^>]*>/', '', (string) $str ) );
+		}
+	}
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $str ) {
+			$str = (string) $str;
+			$str = preg_replace( '/[\r\n\t ]+/', ' ', $str );
+			return trim( wp_strip_all_tags( $str ) );
+		}
+	}
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+		}
+	}
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $tag, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! class_exists( 'FazTest_WPDB' ) ) {
+		class FazTest_WPDB {
+			public $prefix = 'wp_';
+			public function get_col( $query ) {
+				return array();
+			}
+		}
+	}
+	$GLOBALS['wpdb'] = new FazTest_WPDB();
+
+	require_once dirname( __DIR__, 2 ) . '/frontend/class-frontend.php';
+
+	use FazCookie\Frontend\Frontend;
+
+	$tests_run    = 0;
+	$tests_passed = 0;
+	$tests_failed = 0;
+
+	function assert_eq( $actual, $expected, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $actual === $expected ) {
+			$tests_passed++;
+			echo "  \033[32m✓\033[0m " . $label . "\n";
+		} else {
+			$tests_failed++;
+			echo "  \033[31m✗\033[0m " . $label . "\n";
+			echo '      expected: ' . var_export( $expected, true ) . "\n";
+			echo '      actual:   ' . var_export( $actual, true ) . "\n";
+		}
+	}
+
+	function faz_new_frontend() {
+		$rc = new ReflectionClass( Frontend::class );
+		return $rc->newInstanceWithoutConstructor();
+	}
+
+	function faz_call( $fe, $method, array $args = array() ) {
+		$m = new ReflectionMethod( Frontend::class, $method );
+		$m->setAccessible( true );
+		return $m->invokeArgs( $fe, $args );
+	}
+
+	echo "\n\033[1mPer-cookie consent backend (#135)\033[0m\n\n";
+	$fe = faz_new_frontend();
+
+	// ---- ck_escape_cookie_name(): mirror of JS _fazCkKey escaping ----
+	echo "ck_escape_cookie_name()\n";
+	assert_eq( faz_call( $fe, 'ck_escape_cookie_name', array( 'YSC' ) ), 'YSC', 'plain name unchanged' );
+	assert_eq( faz_call( $fe, 'ck_escape_cookie_name', array( '_ga_*' ) ), '_ga_*', 'wildcard * is not escaped' );
+	assert_eq( faz_call( $fe, 'ck_escape_cookie_name', array( 'a:b' ) ), 'a%3Ab', 'colon -> %3A' );
+	assert_eq( faz_call( $fe, 'ck_escape_cookie_name', array( 'a,b' ) ), 'a%2Cb', 'comma -> %2C' );
+	assert_eq( faz_call( $fe, 'ck_escape_cookie_name', array( 'a%b' ) ), 'a%25b', 'percent -> %25' );
+	// Percent must be escaped FIRST, else %3A would become %253A wrongly here.
+	assert_eq( faz_call( $fe, 'ck_escape_cookie_name', array( '%3A' ) ), '%253A', 'literal %3A double-escapes to %253A (percent first)' );
+
+	// ---- resolve_service_cookie_decision(): ck.* > svc.* > '' ----
+	echo "\nresolve_service_cookie_decision()\n";
+	$call = function ( $svc_id, $pattern, $svc, $cookie, $enabled ) use ( $fe ) {
+		return faz_call( $fe, 'resolve_service_cookie_decision', array( $svc_id, $pattern, $svc, $cookie, $enabled ) );
+	};
+
+	// Per-cookie OFF: always the per-service decision (normalised).
+	assert_eq( $call( 'youtube', 'YSC', 'yes', array( 'ck.youtube.YSC' => 'no' ), false ), 'yes', 'per-cookie off: ck token ignored, svc=yes wins' );
+	assert_eq( $call( 'youtube', 'YSC', 'no', array(), false ), 'no', 'per-cookie off: svc=no' );
+	assert_eq( $call( 'youtube', 'YSC', '', array(), false ), '', 'per-cookie off: no svc decision -> empty' );
+
+	// Per-cookie ON: explicit ck.* overrides the per-service decision.
+	assert_eq( $call( 'youtube', 'YSC', 'yes', array( 'ck.youtube.YSC' => 'no' ), true ), 'no', 'ck=no overrides svc=yes (deny one cookie in an accepted service)' );
+	assert_eq( $call( 'youtube', 'PREF', 'no', array( 'ck.youtube.PREF' => 'yes' ), true ), 'yes', 'ck=yes overrides svc=no (allow one cookie in a denied service)' );
+	assert_eq( $call( 'youtube', 'YSC', 'yes', array( 'ck.youtube.OTHER' => 'no' ), true ), 'yes', 'no ck token for THIS cookie -> svc=yes kept' );
+	assert_eq( $call( 'youtube', 'YSC', '', array( 'ck.youtube.YSC' => 'no' ), true ), 'no', 'ck=no with no svc decision -> no' );
+	assert_eq( $call( 'youtube', 'YSC', 'yes', array( 'ck.youtube.YSC' => 'maybe' ), true ), 'yes', 'invalid ck value ignored -> svc=yes' );
+
+	// ck key uses the escaped cookie name (colon in a declared pattern).
+	assert_eq( $call( 'matomo', '_pk_id.1', 'yes', array( 'ck.matomo._pk_id.1' => 'no' ), true ), 'no', 'dotted cookie name resolves its ck token' );
+	assert_eq( $call( 'svc1', 'a:b', 'yes', array( 'ck.svc1.a%3Ab' => 'no' ), true ), 'no', 'colon cookie name resolves via %3A-escaped ck key' );
+
+	echo "\n";
+	if ( $tests_failed > 0 ) {
+		echo "\033[31m✗ {$tests_failed} failed\033[0m, {$tests_passed} passed ({$tests_run} total)\n";
+		exit( 1 );
+	}
+	echo "\033[32m✓ all {$tests_passed} passed\033[0m ({$tests_run} total)\n";
+	exit( 0 );
+}

--- a/tests/unit/test-settings-sanitize.php
+++ b/tests/unit/test-settings-sanitize.php
@@ -63,8 +63,8 @@ namespace {
 	);
 	faz_assert_same(
 		$sanitized['banner_control']['per_cookie_consent'],
-		false,
-		'per_cookie_consent is hard-disabled even when direct input asks for true'
+		true,
+		'per_cookie_consent is a settable boolean (no longer hard-disabled)'
 	);
 
 	echo "\n--\n";

--- a/uninstall.php
+++ b/uninstall.php
@@ -174,6 +174,7 @@ if ( $faz_force_remove_all || faz_should_remove_on_uninstall() || is_multisite()
 				'faz_migrated_advert_to_marketing',
 				'faz_ccpa_gpc_migrated',
 				'faz_share_personal_data_column_added',
+				'faz_reset_stale_per_cookie_consent_done',
 				'faz_migrations_version',
 				'faz_cookie_definitions',
 				'faz_cookie_definitions_meta',


### PR DESCRIPTION
## Summary

Completes per-cookie consent (#135) by adding the missing **server-side enforcement** and ungating the feature. The per-cookie UI (nested toggles within an accepted service) was already built (PR #141) but hard-gated off because a denied per-cookie choice could only be cleaned up client-side.

## What changed

- **Server-side enforcement** — `Frontend::resolve_service_cookie_decision()` resolves `ck.<svc>.<cookie>` > `svc.<svc>` > category (mirrors the client `_fazGetServiceCookieDecision`); `ck_escape_cookie_name()` reconstructs the exact key the browser wrote. `shred_non_consented_cookies()` folds the per-cookie override into its decision map, sourced from the **same validated (non-stale) consent string** as `svc.*`, so a cookie denied inside an accepted service is shredded on every request. Always-allowed gateway + admin-whitelisted cookies stay exempt.
- **Ungate** — `_perCookieConsent` is driven by the saved setting (gated on per-service) instead of forced false; the settings sanitiser accepts the boolean again; the admin toggle is unhidden with honest help text (enforcement is by removal on every request, not by blocking the initial write).
- **Surprise-free upgrade** — a one-time migration (`reset_stale_per_cookie_consent`) clears any stale pre-1.18.2 `true`, so per-cookie consent starts OFF for everyone on 1.20.0 and must be re-enabled explicitly.

## Enforcement model (honest note)

Per-cookie denial is enforced by removing the cookie on every request (client + server), not by preventing the initial write — the service script is the atomic unit. Same mechanism the plugin already uses for category/service cookie enforcement.

## Tests

- `tests/unit/test-percookie-php.php` — 16 assertions on the resolver precedence + key escaping.
- `per-cookie-consent.spec.ts` un-skipped, extended with a server-side reload-persistence check.
- `test-settings-sanitize.php` updated; full PHP unit suite **24/24**, per-service **44/44**, category/blocking **15/15** green.

## Upgrade safety (verified)

per-cookie OFF (default) path is byte-identical to 1.19.x; legacy `true` neutralized by the migration; no DB schema changes.

Version bumped to **1.20.0**. Resolves #135.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aggiunta funzionalità di consenso granulare per singoli cookie: ora è possibile abilitare toggle annidati per ogni cookie all'interno di ciascun servizio. Le preferenze vengono applicate coerentemente lato client e server, con eccezioni per cookie di pagamento e whitelist amministratore. La modalità è disabilitata di default.

* **Tests**
  * Riabilitati test end-to-end per validare il comportamento del consenso per-cookie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->