### PR TITLE
fix: blocked embed placeholder no longer doubles responsive-embed figure height (wp.org youtube-38)

### DIFF
--- a/frontend/includes/class-placeholder-builder.php
+++ b/frontend/includes/class-placeholder-builder.php
@@ -336,6 +336,16 @@ class Placeholder_Builder {
 	public static function get_css() {
 		return '.faz-placeholder{position:relative;width:100%;min-height:200px;background:#f6f7f9;border:1px solid #e5e7eb;border-radius:14px;overflow:hidden;display:flex;align-items:center;justify-content:center;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;box-sizing:border-box;margin:16px 0}'
 			. '.faz-placeholder *{box-sizing:border-box}'
+			/* When the blocked embed sits inside WordPress's responsive-embed */
+			/* wrapper (figure.wp-has-aspect-ratio), core already reserves the */
+			/* 16:9 height with a ::before padding-top hack and absolutely */
+			/* positions the iframe to fill it. Our placeholder replaced that */
+			/* iframe but stayed in normal flow, so its own height stacked on */
+			/* top of the reserved space and the figure rendered ~twice as */
+			/* tall (a large empty gap above the card). Fill the reserved box */
+			/* exactly the way core fills it for the iframe. Reported on */
+			/* wp.org ("youtube-38"). */
+			. '.wp-embed-responsive .wp-has-aspect-ratio .faz-placeholder{position:absolute;top:0;left:0;width:100%;height:100%;min-height:0;margin:0;aspect-ratio:auto}'
 			/* `min-height: 200px` (kept from the base rule) is the floor; */
 			/* `aspect-ratio: 16/9` applies on top so the placeholder gets a */
 			/* video-shaped height when its container provides a real width. */


### PR DESCRIPTION
## Summary

Fixes a layout bug reported on wp.org (topic **youtube-38**, by @james-feaver): after the 1.19.2 placeholder-flash fix, blocked YouTube/Vimeo embeds render with a **large empty gap above the card**.

## Cause

When a blocked embed sits inside WordPress's responsive-embed wrapper — `figure.wp-block-embed.wp-embed-aspect-16-9.wp-has-aspect-ratio` (any oEmbed video block) — core already reserves the 16:9 height with a `::before { padding-top: 56.25% }` hack and absolutely positions the iframe to fill it. Our placeholder replaced the iframe but stayed in **normal flow**, so its own height stacked *on top of* the reserved space:

- reserved box: 56.25% → ~506px
- placeholder (`position:relative`, `aspect-ratio:16/9`): another ~506px
- → figure ≈ **1090px** for a 900px-wide 16:9 embed (the reporter's exact numbers), instead of ~506px.

The placeholder itself was correctly proportioned (900×506) — the gap was the unfilled reservation above it.

## Fix

One CSS rule in the persistent placeholder style block (`Placeholder_Builder::get_css()`): fill the reserved aspect-ratio box exactly the way core fills it for the iframe.

```css
.wp-embed-responsive .wp-has-aspect-ratio .faz-placeholder{position:absolute;top:0;left:0;width:100%;height:100%;min-height:0;margin:0;aspect-ratio:auto}
```

Scoped to the `.wp-embed-responsive .wp-has-aspect-ratio` selector (mirrors core's own `… iframe` selector) so it applies **only** where core's reservation is active. Standalone placeholders (page builders, raw iframes) keep their own `aspect-ratio:16/9` sizing — untouched.

## Verification

Reproduced core's responsive-embed CSS on a Twenty Twenty-Five post (same theme as the reporter) with marketing cookies rejected:

| | figure height | placeholder height |
|---|---|---|
| with core CSS, before fix | **742px** (~2×) | 363px |
| with core CSS, after fix | **363px** | 363px |

Figure height collapses back to match the placeholder; the placeholder computes to `position:absolute`. No gap. CSS-only, no PHP/JS behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Miglioramento del rendering dei placeholder**: Corretto il posizionamento dei placeholder all'interno dei contenitori responsive di WordPress per garantire che occupino correttamente lo spazio riservato senza creare spaziature indesiderate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->