### PR TITLE
fix(i18n): correct European Portuguese (pt-PT) banner content

### DIFF
--- a/admin/modules/banners/includes/contents/pt.json
+++ b/admin/modules/banners/includes/contents/pt.json
@@ -3,15 +3,15 @@
         "notice": {
             "elements": {
                 "title": "Valorizamos a sua privacidade",
-                "description": "<p>Utilizamos cookies para melhorar a sua experiência de navegação, apresentar anúncios ou conteúdos personalizados e analisar o nosso tráfego. Ao clicar em \"Aceitar Todos\", concorda com a utilização de cookies. Pode alterar ou retirar o seu consentimento a qualquer momento clicando no ícone de preferências.</p>",
+                "description": "<p>Utilizamos cookies para melhorar a sua experiência de navegação, apresentar anúncios ou conteúdos personalizados e analisar o nosso tráfego. Ao clicar em \"Aceitar tudo\", concorda com a utilização de cookies. Pode alterar ou retirar o seu consentimento a qualquer momento clicando no ícone de preferências.</p>",
                 "privacyLink": "",
                 "buttons": {
                     "elements": {
-                        "accept": "Aceite tudo",
-                        "reject": "Rejeitar",
+                        "accept": "Aceitar tudo",
+                        "reject": "Rejeitar tudo",
                         "settings": "Personalizar",
-                        "readMore": "Política de Cookies",
-                        "donotSell": "Não Vendam ou Partilhem a Minha Informação Pessoal"
+                        "readMore": "Política de cookies",
+                        "donotSell": "Não vender nem partilhar as minhas informações pessoais"
                     }
                 },
                 "closeButton": "Fechar"
@@ -21,29 +21,29 @@
             "elements": {
                 "buttons": {
                     "elements": {
-                        "save": "Salvar minhas preferências"
+                        "save": "Guardar as minhas preferências"
                     }
                 }
             }
         },
         "preferenceCenter": {
             "elements": {
-                "title": "Personalizar as Preferências de Consentimento",
-                "description": "<p>Utilizamos cookies para ajudá-lo a navegar com eficácia e executar certas funções. Encontrará informações detalhadas sobre todos os cookies em cada categoria de consentimento abaixo.</p><p>Os cookies categorizados como \"Necessários\" são armazenados no seu navegador, pois são essenciais para ativar as funcionalidades básicas do site.</p><p>Também utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site, armazenam as suas preferências e fornecem o conteúdo e os anúncios que são relevantes para si. Estes cookies apenas serão armazenados no seu navegador com o seu consentimento prévio.</p><p>Pode escolher ativar ou desativar alguns ou todos estes cookies, mas desativar alguns deles pode afetar a sua experiência de navegação.</p>",
+                "title": "Personalizar as preferências de consentimento",
+                "description": "<p>Utilizamos cookies para o ajudar a navegar de forma eficiente e a executar determinadas funções. Encontrará informações detalhadas sobre todos os cookies em cada categoria de consentimento abaixo.</p><p>Os cookies categorizados como \"Necessários\" são armazenados no seu navegador, pois são essenciais para ativar as funcionalidades básicas do site.</p><p>Também utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site, a armazenar as suas preferências e a fornecer os conteúdos e os anúncios que são relevantes para si. Estes cookies só serão armazenados no seu navegador com o seu consentimento prévio.</p><p>Pode optar por ativar ou desativar alguns ou todos estes cookies, mas desativar alguns deles pode afetar a sua experiência de navegação.</p>",
                 "showMore": "Mostrar mais",
                 "showLess": "Mostrar menos",
                 "category": {
                     "elements": {
-                        "alwaysEnabled": "Sempre Ativo",
+                        "alwaysEnabled": "Sempre ativo",
                         "enable": "Ativar",
                         "disable": "Desativar"
                     }
                 },
                 "buttons": {
                     "elements": {
-                        "accept": "Aceite tudo",
-                        "save": "Salvar minhas preferências",
-                        "reject": "Rejeitar"
+                        "accept": "Aceitar tudo",
+                        "save": "Guardar as minhas preferências",
+                        "reject": "Rejeitar tudo"
                     }
                 },
                 "closeButton": "Fechar"
@@ -51,18 +51,18 @@
         },
         "optoutPopup": {
             "elements": {
-                "title": "Preferências de autoexclusão",
-                "description": "<p>Utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site web, a armazenar as suas preferências e a fornecer conteúdo e anúncios que são relevantes para si. No entanto, pode optar por não aceitar estes cookies, assinalando a opção \"Não Vendam ou Partilhem a Minha Informação Pessoal\" e clicando no botão \"Salvar minhas preferências\". Se optar por se excluir, pode sempre aderir novamente a qualquer altura, desmarcando a opção \"Não Vendam ou Partilhem a Minha Informação Pessoal\" e clicando no botão \"Salvar minhas preferências\".</p>",
+                "title": "Preferências de exclusão",
+                "description": "<p>Utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site, a armazenar as suas preferências e a fornecer conteúdos e anúncios que são relevantes para si. No entanto, pode recusar estes cookies assinalando a opção \"Não vender nem partilhar as minhas informações pessoais\" e clicando no botão \"Guardar as minhas preferências\". Depois de optar pela exclusão, pode voltar a aderir a qualquer momento, desmarcando a opção \"Não vender nem partilhar as minhas informações pessoais\" e clicando no botão \"Guardar as minhas preferências\".</p>",
                 "optOption": {
                     "elements": {
-                        "title": "Não Vendam ou Partilhem a Minha Informação Pessoal",
+                        "title": "Não vender nem partilhar as minhas informações pessoais",
                         "enable": "Ativar",
                         "disable": "Desativar"
                     }
                 },
                 "gpcOption": {
                     "elements": {
-                        "description": "<p>As suas definições de autoexclusão para este site web foram respeitadas, uma vez que detetámos um sinal global de controlo de privacidade do seu navegador e, por conseguinte, não é possível alterar esta definição.</p>"
+                        "description": "<p>As suas definições de exclusão para este site foram respeitadas, uma vez que detetámos um sinal global de controlo de privacidade do seu navegador e, por conseguinte, não é possível alterar esta definição.</p>"
                     }
                 },
                 "showLess": "Mostrar menos",
@@ -70,7 +70,7 @@
                 "buttons": {
                     "elements": {
                         "cancel": "Cancelar",
-                        "confirm": "Salvar minhas preferências"
+                        "confirm": "Guardar as minhas preferências"
                     }
                 },
                 "closeButton": "Fechar",
@@ -84,7 +84,7 @@
         },
         "revisitConsent": {
             "elements": {
-                "title": "Preferências de Consentimento"
+                "title": "Preferências de consentimento"
             }
         },
         "auditTable": {
@@ -96,12 +96,12 @@
                         "description": "Descrição"
                     }
                 },
-                "message": "Bem cookies para exibir."
+                "message": "Não existem cookies para mostrar."
             }
         },
         "videoPlaceholder": {
             "elements": {
-                "title": "Por favor, aceite o consentimento do cookie"
+                "title": "Aceite os cookies para aceder a este conteúdo"
             }
         }
     },
@@ -109,15 +109,15 @@
         "notice": {
             "elements": {
                 "title": "Valorizamos a sua privacidade",
-                "description": "<p>Este website ou as suas ferramentas de terceiros processam dados pessoais. Pode recusar a venda das suas informações pessoais clicando no link \"Não Vendam ou Partilhem a Minha Informação Pessoal\". Pode alterar ou retirar o seu consentimento a qualquer momento clicando no ícone de preferências.</p>",
+                "description": "<p>Este site ou as suas ferramentas de terceiros processam dados pessoais. Pode recusar a venda das suas informações pessoais clicando na ligação \"Não vender nem partilhar as minhas informações pessoais\". Pode alterar ou retirar o seu consentimento a qualquer momento clicando no ícone de preferências.</p>",
                 "privacyLink": "",
                 "buttons": {
                     "elements": {
-                        "accept": "Aceite tudo",
-                        "reject": "Rejeitar",
+                        "accept": "Aceitar tudo",
+                        "reject": "Rejeitar tudo",
                         "settings": "Personalizar",
-                        "readMore": "Política de Cookies",
-                        "donotSell": "Não Vendam ou Partilhem a Minha Informação Pessoal"
+                        "readMore": "Política de cookies",
+                        "donotSell": "Não vender nem partilhar as minhas informações pessoais"
                     }
                 },
                 "closeButton": "Fechar"
@@ -127,29 +127,29 @@
             "elements": {
                 "buttons": {
                     "elements": {
-                        "save": "Salvar minhas preferências"
+                        "save": "Guardar as minhas preferências"
                     }
                 }
             }
         },
         "preferenceCenter": {
             "elements": {
-                "title": "Personalizar as Preferências de Consentimento",
-                "description": "<p>Utilizamos cookies para ajudá-lo a navegar com eficácia e executar certas funções. Encontrará informações detalhadas sobre todos os cookies em cada categoria de consentimento abaixo.</p><p>Os cookies categorizados como \"Necessários\" são armazenados no seu navegador, pois são essenciais para ativar as funcionalidades básicas do site.</p><p>Também utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site, armazenam as suas preferências e fornecem o conteúdo e os anúncios que são relevantes para si. Estes cookies apenas serão armazenados no seu navegador com o seu consentimento prévio.</p><p>Pode escolher ativar ou desativar alguns ou todos estes cookies, mas desativar alguns deles pode afetar a sua experiência de navegação.</p>",
+                "title": "Personalizar as preferências de consentimento",
+                "description": "<p>Utilizamos cookies para o ajudar a navegar de forma eficiente e a executar determinadas funções. Encontrará informações detalhadas sobre todos os cookies em cada categoria de consentimento abaixo.</p><p>Os cookies categorizados como \"Necessários\" são armazenados no seu navegador, pois são essenciais para ativar as funcionalidades básicas do site.</p><p>Também utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site, a armazenar as suas preferências e a fornecer os conteúdos e os anúncios que são relevantes para si. Estes cookies só serão armazenados no seu navegador com o seu consentimento prévio.</p><p>Pode optar por ativar ou desativar alguns ou todos estes cookies, mas desativar alguns deles pode afetar a sua experiência de navegação.</p>",
                 "showMore": "Mostrar mais",
                 "showLess": "Mostrar menos",
                 "category": {
                     "elements": {
-                        "alwaysEnabled": "Sempre Ativo",
+                        "alwaysEnabled": "Sempre ativo",
                         "enable": "Ativar",
                         "disable": "Desativar"
                     }
                 },
                 "buttons": {
                     "elements": {
-                        "accept": "Aceite tudo",
-                        "save": "Salvar minhas preferências",
-                        "reject": "Rejeitar"
+                        "accept": "Aceitar tudo",
+                        "save": "Guardar as minhas preferências",
+                        "reject": "Rejeitar tudo"
                     }
                 },
                 "closeButton": "Fechar"
@@ -157,18 +157,18 @@
         },
         "optoutPopup": {
             "elements": {
-                "title": "Preferências de autoexclusão",
-                "description": "<p>Utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site web, a armazenar as suas preferências e a fornecer conteúdo e anúncios que são relevantes para si. No entanto, pode optar por não aceitar estes cookies, assinalando a opção \"Não Vendam ou Partilhem a Minha Informação Pessoal\" e clicando no botão \"Salvar minhas preferências\". Se optar por se excluir, pode sempre aderir novamente a qualquer altura, desmarcando a opção \"Não Vendam ou Partilhem a Minha Informação Pessoal\" e clicando no botão \"Salvar minhas preferências\".</p>",
+                "title": "Preferências de exclusão",
+                "description": "<p>Utilizamos cookies de terceiros que nos ajudam a analisar a forma como utiliza este site, a armazenar as suas preferências e a fornecer conteúdos e anúncios que são relevantes para si. No entanto, pode recusar estes cookies assinalando a opção \"Não vender nem partilhar as minhas informações pessoais\" e clicando no botão \"Guardar as minhas preferências\". Depois de optar pela exclusão, pode voltar a aderir a qualquer momento, desmarcando a opção \"Não vender nem partilhar as minhas informações pessoais\" e clicando no botão \"Guardar as minhas preferências\".</p>",
                 "optOption": {
                     "elements": {
-                        "title": "Não Vendam ou Partilhem a Minha Informação Pessoal",
+                        "title": "Não vender nem partilhar as minhas informações pessoais",
                         "enable": "Ativar",
                         "disable": "Desativar"
                     }
                 },
                 "gpcOption": {
                     "elements": {
-                        "description": "<p>As suas definições de autoexclusão para este site web foram respeitadas, uma vez que detetámos um sinal global de controlo de privacidade do seu navegador e, por conseguinte, não é possível alterar esta definição.</p>"
+                        "description": "<p>As suas definições de exclusão para este site foram respeitadas, uma vez que detetámos um sinal global de controlo de privacidade do seu navegador e, por conseguinte, não é possível alterar esta definição.</p>"
                     }
                 },
                 "showLess": "Mostrar menos",
@@ -176,7 +176,7 @@
                 "buttons": {
                     "elements": {
                         "cancel": "Cancelar",
-                        "confirm": "Salvar minhas preferências"
+                        "confirm": "Guardar as minhas preferências"
                     }
                 },
                 "closeButton": "Fechar",
@@ -190,7 +190,7 @@
         },
         "revisitConsent": {
             "elements": {
-                "title": "Preferências de Consentimento"
+                "title": "Preferências de consentimento"
             }
         },
         "auditTable": {
@@ -202,12 +202,12 @@
                         "description": "Descrição"
                     }
                 },
-                "message": "Bem cookies para exibir."
+                "message": "Não existem cookies para mostrar."
             }
         },
         "videoPlaceholder": {
             "elements": {
-                "title": "Por favor, aceite o consentimento do cookie"
+                "title": "Aceite os cookies para aceder a este conteúdo"
             }
         }
     }


### PR DESCRIPTION
## What

Corrects the European Portuguese (`pt.json`) banner content under `admin/modules/banners/includes/contents/`. The file was a mix of Brazilian Portuguese forms and machine-translation artifacts; this makes it read as proper **European Portuguese (pt-PT)**, consistent with the separate `pt-br.json` locale.

## Why

Installing the plugin on pt-PT sites currently shows Brazilian wording and one broken string, requiring per-site manual fixes. This corrects the bundled default once.

## Changes

| Key | Before | After |
|---|---|---|
| `accept` | Aceite tudo | Aceitar tudo |
| `reject` | Rejeitar | Rejeitar tudo |
| `save` / `confirm` | Salvar minhas preferências | Guardar as minhas preferências |
| `donotSell` / `optOption.title` | Não Vendam ou Partilhem a Minha Informação Pessoal | Não vender nem partilhar as minhas informações pessoais |
| `auditTable.message` | Bem cookies para exibir. *(broken)* | Não existem cookies para mostrar. |
| `videoPlaceholder.title` | Por favor, aceite o consentimento do cookie | Aceite os cookies para aceder a este conteúdo *(matches current en.json)* |
| `readMore` | Política de Cookies | Política de cookies |

- Button labels quoted **inside** the `notice` / `optoutPopup` descriptions were realigned to match the actual button strings.
- Applies to both the `gdpr` and `ccpa` blocks.
- Key structure is unchanged and identical to `en.json` (38 keys); only values changed. Valid JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localizzazione**
  * Aggiornate e migliorate le stringhe di testo in portoghese per le sezioni GDPR e CCPA, inclusi notice, etichette di pulsanti, titoli, descrizioni e messaggi del preference center, con correzioni di capitalizzazione e riformulazioni per una maggiore coerenza linguistica.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->