### PR TITLE
Manual service registration from the built-in catalogue (#161)

### DIFF
--- a/admin/assets/js/pages/cookies.js
+++ b/admin/assets/js/pages/cookies.js
@@ -83,9 +83,70 @@
 				autoCategorize(item.dataset.scope);
 			});
 		});
+		// Add Service dropdown — manual service registration (#161).
+		var addSvcBtn = document.getElementById('faz-add-service-btn');
+		var addSvcDropdown = document.getElementById('faz-add-service-dropdown');
+		var svcSelect = document.getElementById('faz-service-select');
+		var registerSvcBtn = document.getElementById('faz-register-service-btn');
+		var catalogueLoaded = false;
+		function loadCatalogueServices() {
+			return FAZ.get('cookies/catalogue-services').then(function (data) {
+				var services = (data && data.services) || [];
+				svcSelect.innerHTML = '';
+				var placeholder = document.createElement('option');
+				placeholder.value = '';
+				placeholder.textContent = __('cookies.selectService', 'Select a service…');
+				svcSelect.appendChild(placeholder);
+				services.forEach(function (s) {
+					var opt = document.createElement('option');
+					opt.value = s.id;
+					opt.textContent = s.label + (s.registered ? ' ✓' : '');
+					opt.disabled = !!s.registered;
+					svcSelect.appendChild(opt);
+				});
+				catalogueLoaded = true;
+			}).catch(function () {
+				svcSelect.innerHTML = '';
+				var failOpt = document.createElement('option');
+				failOpt.value = '';
+				failOpt.textContent = __('cookies.servicesLoadFailed', 'Could not load services');
+				svcSelect.appendChild(failOpt);
+			});
+		}
+		if (addSvcBtn && addSvcDropdown && svcSelect && registerSvcBtn) {
+			addSvcBtn.addEventListener('click', function (e) {
+				e.stopPropagation();
+				addSvcDropdown.classList.toggle('open');
+				if (addSvcDropdown.classList.contains('open') && !catalogueLoaded) {
+					loadCatalogueServices();
+				}
+			});
+			var svcMenu = addSvcDropdown.querySelector('.faz-dropdown-menu');
+			if (svcMenu) svcMenu.addEventListener('click', function (e) { e.stopPropagation(); });
+			registerSvcBtn.addEventListener('click', function () {
+				var sid = svcSelect.value;
+				if (!sid) return;
+				registerSvcBtn.disabled = true;
+				FAZ.post('cookies/register-service', { service_id: sid }).then(function (res) {
+					var added = (res && typeof res.added === 'number') ? res.added : 0;
+					var label = (res && res.service && res.service.label) || sid;
+					FAZ.notify(label + ': ' + added + ' ' + __('cookies.cookiesRegistered', 'cookie(s) registered'), 'success');
+					addSvcDropdown.classList.remove('open');
+					catalogueLoaded = false;
+					loadCookies();
+					loadCategories();
+				}).catch(function () {
+					FAZ.notify(__('cookies.registerFailed', 'Could not register service.'), 'error');
+				}).then(function () {
+					registerSvcBtn.disabled = false;
+				});
+			});
+		}
+
 		document.addEventListener('click', function () {
 			scanDropdown.classList.remove('open');
 			acDropdown.classList.remove('open');
+			if (addSvcDropdown) addSvcDropdown.classList.remove('open');
 		});
 
 		// Select-all checkbox.

--- a/admin/assets/js/pages/cookies.js
+++ b/admin/assets/js/pages/cookies.js
@@ -138,7 +138,14 @@
 				FAZ.post('cookies/register-service', { service_id: sid }).then(function (res) {
 					var added = (res && typeof res.added === 'number') ? res.added : 0;
 					var label = (res && res.service && res.service.label) || sid;
-					FAZ.notify(label + ': ' + added + ' ' + __('cookies.cookiesRegistered', 'cookie(s) registered'), 'success');
+					// One i18n key for the whole sentence so translators can reorder
+					// the service label, count and text and handle plural forms.
+					FAZ.notify(
+						__('cookies.serviceRegistered', '%1$s: %2$d cookie(s) registered')
+							.replace('%1$s', label)
+							.replace('%2$d', String(added)),
+						'success'
+					);
 					addSvcDropdown.classList.remove('open');
 					catalogueLoaded = false;
 					loadCookies();

--- a/admin/assets/js/pages/cookies.js
+++ b/admin/assets/js/pages/cookies.js
@@ -142,8 +142,8 @@
 					// the service label, count and text and handle plural forms.
 					FAZ.notify(
 						__('cookies.serviceRegistered', '%1$s: %2$d cookie(s) registered')
-							.replace('%1$s', label)
-							.replace('%2$d', String(added)),
+							.replace('%1$s', function () { return label; })
+							.replace('%2$d', function () { return String(added); }),
 						'success'
 					);
 					addSvcDropdown.classList.remove('open');

--- a/admin/assets/js/pages/cookies.js
+++ b/admin/assets/js/pages/cookies.js
@@ -89,8 +89,13 @@
 		var svcSelect = document.getElementById('faz-service-select');
 		var registerSvcBtn = document.getElementById('faz-register-service-btn');
 		var catalogueLoaded = false;
+		var catalogueRequest = null;
 		function loadCatalogueServices() {
-			return FAZ.get('cookies/catalogue-services').then(function (data) {
+			// In-flight guard: a single request at a time. Toggling the menu
+			// quickly must not fire concurrent GETs nor let a late failure
+			// overwrite an already-loaded list.
+			if (catalogueRequest) return catalogueRequest;
+			catalogueRequest = FAZ.get('cookies/catalogue-services').then(function (data) {
 				var services = (data && data.services) || [];
 				svcSelect.innerHTML = '';
 				var placeholder = document.createElement('option');
@@ -111,7 +116,10 @@
 				failOpt.value = '';
 				failOpt.textContent = __('cookies.servicesLoadFailed', 'Could not load services');
 				svcSelect.appendChild(failOpt);
+			}).then(function () {
+				catalogueRequest = null;
 			});
+			return catalogueRequest;
 		}
 		if (addSvcBtn && addSvcDropdown && svcSelect && registerSvcBtn) {
 			addSvcBtn.addEventListener('click', function (e) {

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -548,7 +548,8 @@ class Admin {
 						// Manual service registration dropdown (#161).
 						'selectService'            => __( 'Select a service…', 'faz-cookie-manager' ),
 						'servicesLoadFailed'       => __( 'Could not load services', 'faz-cookie-manager' ),
-						'cookiesRegistered'        => __( 'cookie(s) registered', 'faz-cookie-manager' ),
+						/* translators: 1: service label, 2: number of cookies registered. */
+						'serviceRegistered'        => __( '%1$s: %2$d cookie(s) registered', 'faz-cookie-manager' ),
 						'registerFailed'           => __( 'Could not register service.', 'faz-cookie-manager' ),
 						'staleAllConfirm'          => __( 'Delete all stale cookies not found in the latest scan?', 'faz-cookie-manager' ),
 						'staleNone'                => __( 'No stale cookies to delete.', 'faz-cookie-manager' ),

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -545,6 +545,11 @@ class Admin {
 						'cookieDeleteFailed'       => __( 'Failed to delete cookie.', 'faz-cookie-manager' ),
 						'staleDeleted'             => __( 'Stale cookie deleted.', 'faz-cookie-manager' ),
 						'staleDeleteFailed'        => __( 'Failed to delete stale cookie.', 'faz-cookie-manager' ),
+						// Manual service registration dropdown (#161).
+						'selectService'            => __( 'Select a service…', 'faz-cookie-manager' ),
+						'servicesLoadFailed'       => __( 'Could not load services', 'faz-cookie-manager' ),
+						'cookiesRegistered'        => __( 'cookie(s) registered', 'faz-cookie-manager' ),
+						'registerFailed'           => __( 'Could not register service.', 'faz-cookie-manager' ),
 						'staleAllConfirm'          => __( 'Delete all stale cookies not found in the latest scan?', 'faz-cookie-manager' ),
 						'staleNone'                => __( 'No stale cookies to delete.', 'faz-cookie-manager' ),
 						'staleDeleteAllFailed'     => __( 'Failed to delete stale cookies.', 'faz-cookie-manager' ),

--- a/admin/modules/cookies/api/class-cookies-api.php
+++ b/admin/modules/cookies/api/class-cookies-api.php
@@ -102,6 +102,36 @@ class Cookies_API extends API_Controller {
 			)
 		);
 
+		// Manual service registration (#161): list the built-in provider
+		// catalogue, and register a chosen service's cookies into wp_faz_cookies
+		// so they are declared domain-wide without relying on the scanner.
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/catalogue-services',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_catalogue_services' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/register-service',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'register_service' ),
+				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				'args'                => array(
+					'service_id' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<id>[\d]+)',
@@ -135,6 +165,182 @@ class Cookies_API extends API_Controller {
 			)
 		);
 
+	}
+
+	/**
+	 * Active non-necessary category slugs that exist on this install.
+	 *
+	 * @return array
+	 */
+	private function active_category_slugs() {
+		$slugs = array();
+		$cats  = \FazCookie\Admin\Modules\Cookies\Includes\Category_Controller::get_instance()->get_items();
+		foreach ( (array) $cats as $cat ) {
+			$slug = is_object( $cat ) ? ( $cat->slug ?? '' ) : ( $cat['slug'] ?? '' );
+			if ( '' !== $slug && 'necessary' !== $slug && 'wordpress-internal' !== $slug ) {
+				$slugs[] = $slug;
+			}
+		}
+		return $slugs;
+	}
+
+	/**
+	 * Existing cookie names already in wp_faz_cookies (lower-cased map).
+	 *
+	 * @return array
+	 */
+	private function existing_cookie_names() {
+		$names = array();
+		$rows  = Cookie_Controller::get_instance()->get_item_from_db();
+		if ( is_array( $rows ) ) {
+			foreach ( $rows as $row ) {
+				$n = is_object( $row ) ? ( $row->name ?? '' ) : ( $row['name'] ?? '' );
+				if ( '' !== $n ) {
+					$names[ strtolower( $n ) ] = true;
+				}
+			}
+		}
+		return $names;
+	}
+
+	/**
+	 * Best-effort cookie domain derived from a provider's first host-like pattern.
+	 *
+	 * @param array $patterns Provider URL/inline patterns.
+	 * @return string
+	 */
+	private function provider_domain_from_patterns( $patterns ) {
+		foreach ( (array) $patterns as $pattern ) {
+			$pattern = is_string( $pattern ) ? trim( $pattern ) : '';
+			if ( '' === $pattern ) {
+				continue;
+			}
+			// Take the token before the first slash, drop scheme if present.
+			$host = preg_replace( '#^https?://#i', '', $pattern );
+			$host = explode( '/', $host )[0];
+			if ( false !== strpos( $host, '.' ) && false === strpos( $host, ' ' ) ) {
+				return sanitize_text_field( $host );
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * GET catalogue-services — the built-in provider catalogue for the manual
+	 * registration UI (#161). Lists non-necessary providers whose category is
+	 * active on this install, flagging which are already fully registered.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_catalogue_services() {
+		$active   = $this->active_category_slugs();
+		$existing = $this->existing_cookie_names();
+		$out      = array();
+		foreach ( \FazCookie\Includes\Known_Providers::get_all() as $id => $svc ) {
+			$category = isset( $svc['category'] ) ? $svc['category'] : '';
+			if ( '' === $category || ! in_array( $category, $active, true ) ) {
+				continue;
+			}
+			$cookies = isset( $svc['cookies'] ) && is_array( $svc['cookies'] ) ? array_values( $svc['cookies'] ) : array();
+			// Skip providers that declare no cookie names — nothing to register
+			// as a transparency row (they are still blocked by URL pattern).
+			if ( empty( $cookies ) ) {
+				continue;
+			}
+			$missing = 0;
+			foreach ( $cookies as $name ) {
+				if ( empty( $existing[ strtolower( (string) $name ) ] ) ) {
+					$missing++;
+				}
+			}
+			$out[] = array(
+				'id'           => sanitize_key( $id ),
+				'label'        => isset( $svc['label'] ) ? sanitize_text_field( $svc['label'] ) : sanitize_key( $id ),
+				'category'     => sanitize_key( $category ),
+				'cookie_count' => count( $cookies ),
+				'registered'   => ( 0 === $missing ),
+			);
+		}
+		usort(
+			$out,
+			static function ( $a, $b ) {
+				return strcasecmp( $a['label'], $b['label'] );
+			}
+		);
+		return new WP_REST_Response( array( 'services' => $out ), 200 );
+	}
+
+	/**
+	 * POST register-service — register a catalogue service's cookies into
+	 * wp_faz_cookies (discovered=1) so they are declared domain-wide on every
+	 * page without relying on the scanner, and feed the Cookie Policy generator.
+	 * Reuses the scanner's save_cookies() enrichment (Cookie_Database → Known
+	 * Providers → Open Cookie Database). (#161)
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function register_service( $request ) {
+		$service_id = sanitize_key( (string) $request->get_param( 'service_id' ) );
+		if ( '' === $service_id ) {
+			return new WP_Error( 'faz_invalid_service', __( 'A service id is required.', 'faz-cookie-manager' ), array( 'status' => 400 ) );
+		}
+		$providers = \FazCookie\Includes\Known_Providers::get_all();
+		if ( ! isset( $providers[ $service_id ] ) ) {
+			return new WP_Error( 'faz_unknown_service', __( 'Unknown service.', 'faz-cookie-manager' ), array( 'status' => 404 ) );
+		}
+		$svc      = $providers[ $service_id ];
+		$category = isset( $svc['category'] ) ? sanitize_key( $svc['category'] ) : '';
+		if ( '' === $category || 'necessary' === $category || ! in_array( $category, $this->active_category_slugs(), true ) ) {
+			return new WP_Error( 'faz_invalid_category', __( 'This service maps to a category that is not active.', 'faz-cookie-manager' ), array( 'status' => 400 ) );
+		}
+		$cookie_names = isset( $svc['cookies'] ) && is_array( $svc['cookies'] ) ? array_values( $svc['cookies'] ) : array();
+		if ( empty( $cookie_names ) ) {
+			return new WP_Error( 'faz_no_cookies', __( 'This service declares no cookies to register.', 'faz-cookie-manager' ), array( 'status' => 400 ) );
+		}
+		$domain  = $this->provider_domain_from_patterns( isset( $svc['patterns'] ) ? $svc['patterns'] : array() );
+		$before  = $this->existing_cookie_names();
+		$payload = array();
+		foreach ( $cookie_names as $name ) {
+			$name = sanitize_text_field( (string) $name );
+			if ( '' === $name ) {
+				continue;
+			}
+			$payload[] = array(
+				'name'     => $name,
+				'category' => $category,
+				'domain'   => $domain,
+			);
+		}
+
+		// Reuse the scanner's enrichment + persistence (sets discovered=1, skips
+		// existing names, flushes caches). Guarded so a missing scanner module
+		// never fatals the endpoint.
+		$scanner = '\\FazCookie\\Admin\\Modules\\Scanner\\Includes\\Controller';
+		if ( ! class_exists( $scanner ) ) {
+			return new WP_Error( 'faz_scanner_unavailable', __( 'The registration engine is unavailable.', 'faz-cookie-manager' ), array( 'status' => 500 ) );
+		}
+		\call_user_func( array( $scanner, 'get_instance' ) )->save_cookies( $payload );
+
+		// Invalidate the runtime cookie-scripts map so the new rows surface on
+		// the next render, and fire the standard write action (cache purge etc.).
+		delete_transient( 'faz_cookie_scripts_map' );
+		do_action( 'faz_after_update_cookie' );
+
+		$after = $this->existing_cookie_names();
+		$added = max( 0, count( $after ) - count( $before ) );
+		return new WP_REST_Response(
+			array(
+				'service'   => array(
+					'id'    => $service_id,
+					'label' => isset( $svc['label'] ) ? sanitize_text_field( $svc['label'] ) : $service_id,
+				),
+				'requested' => count( $payload ),
+				'added'     => $added,
+				'category'  => $category,
+			),
+			200
+		);
 	}
 
 	/**

--- a/admin/modules/cookies/api/class-cookies-api.php
+++ b/admin/modules/cookies/api/class-cookies-api.php
@@ -111,7 +111,10 @@ class Cookies_API extends API_Controller {
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_catalogue_services' ),
-				'permission_callback' => array( $this, 'create_item_permissions_check' ),
+				// Read endpoint → use the read permission (manage_options),
+				// matching the other READABLE routes here. create_item_* also
+				// demands the plugin write-nonce, which a read needn't. (#162 review)
+				'permission_callback' => array( $this, 'get_items_permissions_check' ),
 			)
 		);
 

--- a/admin/modules/cookies/api/class-cookies-api.php
+++ b/admin/modules/cookies/api/class-cookies-api.php
@@ -226,6 +226,30 @@ class Cookies_API extends API_Controller {
 	}
 
 	/**
+	 * Concrete (non-wildcard) cookie names declared by a provider.
+	 *
+	 * Some catalogue entries list wildcard patterns (e.g. "_hjSession_*").
+	 * Those can't be created as a literal wp_faz_cookies row and never match a
+	 * real scanned cookie name, so they are excluded from both the registration
+	 * payload and the "registered" calculation — mirroring the scanner's own
+	 * inference path, which already drops them. (#161)
+	 *
+	 * @param array $svc Provider entry from Known_Providers.
+	 * @return array
+	 */
+	private function provider_concrete_cookies( $svc ) {
+		$cookies = isset( $svc['cookies'] ) && is_array( $svc['cookies'] ) ? $svc['cookies'] : array();
+		$out     = array();
+		foreach ( $cookies as $name ) {
+			$name = is_string( $name ) ? trim( $name ) : '';
+			if ( '' !== $name && false === strpos( $name, '*' ) ) {
+				$out[] = $name;
+			}
+		}
+		return array_values( $out );
+	}
+
+	/**
 	 * GET catalogue-services — the built-in provider catalogue for the manual
 	 * registration UI (#161). Lists non-necessary providers whose category is
 	 * active on this install, flagging which are already fully registered.
@@ -241,9 +265,10 @@ class Cookies_API extends API_Controller {
 			if ( '' === $category || ! in_array( $category, $active, true ) ) {
 				continue;
 			}
-			$cookies = isset( $svc['cookies'] ) && is_array( $svc['cookies'] ) ? array_values( $svc['cookies'] ) : array();
-			// Skip providers that declare no cookie names — nothing to register
-			// as a transparency row (they are still blocked by URL pattern).
+			$cookies = $this->provider_concrete_cookies( $svc );
+			// Skip providers that declare no concrete cookie names — nothing to
+			// register as a transparency row (they are still blocked by URL
+			// pattern, and wildcard-only entries can't be persisted).
 			if ( empty( $cookies ) ) {
 				continue;
 			}
@@ -294,9 +319,9 @@ class Cookies_API extends API_Controller {
 		if ( '' === $category || 'necessary' === $category || ! in_array( $category, $this->active_category_slugs(), true ) ) {
 			return new WP_Error( 'faz_invalid_category', __( 'This service maps to a category that is not active.', 'faz-cookie-manager' ), array( 'status' => 400 ) );
 		}
-		$cookie_names = isset( $svc['cookies'] ) && is_array( $svc['cookies'] ) ? array_values( $svc['cookies'] ) : array();
+		$cookie_names = $this->provider_concrete_cookies( $svc );
 		if ( empty( $cookie_names ) ) {
-			return new WP_Error( 'faz_no_cookies', __( 'This service declares no cookies to register.', 'faz-cookie-manager' ), array( 'status' => 400 ) );
+			return new WP_Error( 'faz_no_cookies', __( 'This service declares no registrable cookies.', 'faz-cookie-manager' ), array( 'status' => 400 ) );
 		}
 		$domain  = $this->provider_domain_from_patterns( isset( $svc['patterns'] ) ? $svc['patterns'] : array() );
 		$before  = $this->existing_cookie_names();

--- a/admin/views/cookies.php
+++ b/admin/views/cookies.php
@@ -68,6 +68,16 @@ defined( 'ABSPATH' ) || exit;
 								<button class="faz-dropdown-item" data-scope="all"><?php esc_html_e( 'All cookies', 'faz-cookie-manager' ); ?></button>
 							</div>
 						</div>
+						<div class="faz-dropdown" id="faz-add-service-dropdown">
+							<button class="faz-btn faz-btn-outline faz-btn-sm" id="faz-add-service-btn"><?php esc_html_e( 'Add Service', 'faz-cookie-manager' ); ?> &#9662;</button>
+							<div class="faz-dropdown-menu" style="min-width:300px;padding:12px;">
+								<label for="faz-service-select" style="display:block;font-size:12px;line-height:1.4;margin-bottom:8px;"><?php esc_html_e( 'Register a known third-party service so its cookies are declared on every page — useful when the scanner cannot reach an embed (caching, lazy-load).', 'faz-cookie-manager' ); ?></label>
+								<select id="faz-service-select" style="width:100%;margin-bottom:8px;">
+									<option value=""><?php esc_html_e( 'Loading services…', 'faz-cookie-manager' ); ?></option>
+								</select>
+								<button class="faz-btn faz-btn-primary faz-btn-sm" id="faz-register-service-btn" type="button" style="width:100%;"><?php esc_html_e( 'Register service', 'faz-cookie-manager' ); ?></button>
+							</div>
+						</div>
 						<button class="faz-btn faz-btn-primary faz-btn-sm" id="faz-add-cookie-btn"><?php esc_html_e( 'Add Cookie', 'faz-cookie-manager' ); ?></button>
 						<span id="faz-debug-log-actions" style="display:none;">
 							<button class="faz-btn faz-btn-outline faz-btn-sm" id="faz-download-debug-log" type="button" title="<?php esc_attr_e( 'Download scanner debug log', 'faz-cookie-manager' ); ?>"><?php esc_html_e( 'Debug Log', 'faz-cookie-manager' ); ?></button>

--- a/tests/e2e/specs/manual-service-registration.spec.ts
+++ b/tests/e2e/specs/manual-service-registration.spec.ts
@@ -83,7 +83,7 @@ test.describe('Manual service registration (#161)', () => {
     expect(yt!.registered, 'YouTube should be unregistered after cleanup').toBe(false);
   });
 
-  test('2. register-service adds the provider cookies (discovered, domain-wide)', async () => {
+  test('2. register-service adds the provider cookies (discovered, domain-wide)', async ({ browser }) => {
     const res = await admin.request.post('/?rest_route=/faz/v1/cookies/register-service', {
       headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
       data: { service_id: 'youtube' },
@@ -105,11 +105,21 @@ test.describe('Manual service registration (#161)', () => {
     });
 
     // The registered cookies are now declared in the banner store on a plain
-    // page that carries no YouTube embed (domain-wide transparency).
-    const html = await admin.request.get('/', { headers: { 'User-Agent': 'Mozilla/5.0 (manual-service-e2e)' } }).then((r) => r.text());
-    expect(html).toContain('YSC');
-    expect(html).toContain('VISITOR_INFO1_LIVE');
-    expect(html).toContain('LOGIN_INFO');
+    // page that carries no YouTube embed (domain-wide transparency). Verify from
+    // a FRESH frontend context — no admin session, no consent cookie — so the
+    // assertion reflects a real visitor rather than an authenticated request
+    // whose markup may differ for logged-in users.
+    const fresh = await browser.newContext();
+    try {
+      const html = await fresh.request
+        .get('/', { headers: { 'User-Agent': 'Mozilla/5.0 (manual-service-e2e)' } })
+        .then((r) => r.text());
+      expect(html).toContain('YSC');
+      expect(html).toContain('VISITOR_INFO1_LIVE');
+      expect(html).toContain('LOGIN_INFO');
+    } finally {
+      await fresh.close();
+    }
   });
 
   test('3. registering again is idempotent and the catalogue flags it registered', async () => {
@@ -140,5 +150,41 @@ test.describe('Manual service registration (#161)', () => {
     await addBtn.click();
     // The catalogue loads lazily on first open; the select gains real options.
     await expect.poll(async () => admin.locator('#faz-service-select option').count(), { timeout: 8000 }).toBeGreaterThan(1);
+  });
+
+  test('6. the success message is a single reorderable i18n template (CodeRabbit)', async () => {
+    await admin.goto('/wp-admin/admin.php?page=faz-cookie-manager-cookies', { waitUntil: 'domcontentloaded' });
+    const i18n = await admin.evaluate(() => (window as Window & { fazConfig?: { i18n?: { cookies?: Record<string, string> } } }).fazConfig?.i18n?.cookies ?? {});
+    // The whole sentence is one key with positional placeholders so translators
+    // can reorder label/count/text and handle plural — not a glued fragment.
+    expect(i18n.serviceRegistered, 'serviceRegistered key is present').toBeTruthy();
+    expect(i18n.serviceRegistered).toContain('%1$s');
+    expect(i18n.serviceRegistered).toContain('%2$d');
+    // The old fragmented key must be gone (it would re-introduce the glue bug).
+    expect(i18n.cookiesRegistered, 'old fragmented cookiesRegistered key removed').toBeUndefined();
+  });
+
+  test('7. the i18n template substitutes the service label and count in order', async () => {
+    const msg = await admin.evaluate(() => {
+      const tpl = (window as Window & { fazConfig?: { i18n?: { cookies?: { serviceRegistered?: string } } } })
+        .fazConfig?.i18n?.cookies?.serviceRegistered || '%1$s: %2$d cookie(s) registered';
+      return tpl.replace('%1$s', 'YouTube').replace('%2$d', String(3));
+    });
+    expect(msg).toBe('YouTube: 3 cookie(s) registered');
+  });
+
+  test('8. register-service returns the service label the i18n message consumes', async () => {
+    // cookies.js builds the notification from res.service.label (→ %1$s) and
+    // res.added (→ %2$d); pin that REST↔JS contract so the message can't go blank.
+    deleteYouTubeCookies();
+    const res = await admin.request.post('/?rest_route=/faz/v1/cookies/register-service', {
+      headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
+      data: { service_id: 'youtube' },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { service: { id: string; label?: string }; added: number };
+    expect(typeof body.service.label).toBe('string');
+    expect((body.service.label ?? '').length).toBeGreaterThan(0);
+    expect(body.added).toBeGreaterThan(0);
   });
 });

--- a/tests/e2e/specs/manual-service-registration.spec.ts
+++ b/tests/e2e/specs/manual-service-registration.spec.ts
@@ -187,4 +187,18 @@ test.describe('Manual service registration (#161)', () => {
     expect((body.service.label ?? '').length).toBeGreaterThan(0);
     expect(body.added).toBeGreaterThan(0);
   });
+
+  test('9. catalogue-services stays admin-gated after the read-permission switch', async ({ browser }) => {
+    // The route now uses get_items_permissions_check (read pattern) instead of
+    // create_item_permissions_check. Guard that the swap did not open it: an
+    // unauthenticated request (fresh context, no cookie / no nonce) must still
+    // be rejected. (#162 review)
+    const anon = await browser.newContext();
+    try {
+      const res = await anon.request.get('/?rest_route=/faz/v1/cookies/catalogue-services');
+      expect([401, 403]).toContain(res.status());
+    } finally {
+      await anon.close();
+    }
+  });
 });

--- a/tests/e2e/specs/manual-service-registration.spec.ts
+++ b/tests/e2e/specs/manual-service-registration.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../fixtures/wp-fixture';
 import type { Page } from '@playwright/test';
-import { wp } from '../utils/wp-env';
+import { wp, wpEval } from '../utils/wp-env';
 
 /**
  * Manual service registration (#161).
@@ -21,6 +21,21 @@ const YT_COOKIES = ['YSC', 'VISITOR_INFO1_LIVE', 'LOGIN_INFO'];
 
 async function getAdminNonce(page: Page): Promise<string> {
   return page.evaluate(() => window.fazConfig?.api?.nonce ?? '');
+}
+
+function storedYouTubeCookies(): Array<{ name: string; domain: string; discovered: string }> {
+  // Query the persisted rows directly so the test verifies the saved-record
+  // contract (discovered=1, domain-scoped), not just the rendered banner HTML.
+  const inList = YT_COOKIES.map((n) => `'${n}'`).join(',');
+  try {
+    const json = wpEval(
+      `global $wpdb; echo json_encode($wpdb->get_results("SELECT name, domain, discovered FROM {$wpdb->prefix}faz_cookies WHERE name IN (${inList})", ARRAY_A));`,
+    );
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 function deleteYouTubeCookies(): void {
@@ -79,11 +94,22 @@ test.describe('Manual service registration (#161)', () => {
     expect(body.category).toBe('marketing');
     expect(body.added).toBeGreaterThan(0);
 
+    // Saved-record contract: all three concrete YouTube cookies must be
+    // persisted as discovered, domain-scoped rows (#161 goal) — not merely
+    // surfaced by name in the banner HTML.
+    const stored = storedYouTubeCookies();
+    expect(stored.map((c) => c.name).sort()).toEqual([...YT_COOKIES].sort());
+    stored.forEach((c) => {
+      expect(Number(c.discovered)).toBe(1);
+      expect(c.domain).toBe('youtube.com');
+    });
+
     // The registered cookies are now declared in the banner store on a plain
     // page that carries no YouTube embed (domain-wide transparency).
     const html = await admin.request.get('/', { headers: { 'User-Agent': 'Mozilla/5.0 (manual-service-e2e)' } }).then((r) => r.text());
     expect(html).toContain('YSC');
     expect(html).toContain('VISITOR_INFO1_LIVE');
+    expect(html).toContain('LOGIN_INFO');
   });
 
   test('3. registering again is idempotent and the catalogue flags it registered', async () => {

--- a/tests/e2e/specs/manual-service-registration.spec.ts
+++ b/tests/e2e/specs/manual-service-registration.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '../fixtures/wp-fixture';
+import type { Page } from '@playwright/test';
+import { wp } from '../utils/wp-env';
+
+/**
+ * Manual service registration (#161).
+ *
+ * The automated scanner can miss embedded services (caching, lazy-load), which
+ * leaves their cookies undeclared domain-wide. This feature lets an admin pick a
+ * known provider from the built-in catalogue and register its cookies into
+ * wp_faz_cookies (discovered=1) so they are declared on every page without a
+ * scan, and feed the Cookie Policy generator.
+ *
+ * Drives the real REST endpoints (faz/v1/cookies/catalogue-services and
+ * /register-service) with an admin nonce, plus a UI presence check of the
+ * "Add Service" control on the Cookies admin page. Serial; cleans up the test
+ * provider's cookies before and after so it is reusable in isolation or in-suite.
+ */
+
+const YT_COOKIES = ['YSC', 'VISITOR_INFO1_LIVE', 'LOGIN_INFO'];
+
+async function getAdminNonce(page: Page): Promise<string> {
+  return page.evaluate(() => window.fazConfig?.api?.nonce ?? '');
+}
+
+function deleteYouTubeCookies(): void {
+  // Best-effort cleanup via WP-CLI so the "added > 0" assertions are deterministic.
+  const inList = YT_COOKIES.map((n) => `'${n}'`).join(',');
+  try {
+    wp(['eval', `global $wpdb; $wpdb->query("DELETE FROM {$wpdb->prefix}faz_cookies WHERE name IN (${inList})"); delete_transient('faz_cookie_scripts_map'); delete_option('faz_banner_template');`]);
+  } catch {
+    /* best-effort */
+  }
+}
+
+test.describe('Manual service registration (#161)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let admin: Page;
+  let nonce = '';
+
+  test.beforeAll(async ({ browser, loginAsAdmin }) => {
+    deleteYouTubeCookies();
+    admin = await browser.newPage();
+    await loginAsAdmin(admin);
+    await admin.goto('/wp-admin/admin.php?page=faz-cookie-manager-cookies', { waitUntil: 'domcontentloaded' });
+    nonce = await getAdminNonce(admin);
+    expect(nonce.length).toBeGreaterThan(0);
+  });
+
+  test.afterAll(async () => {
+    deleteYouTubeCookies();
+    if (admin) await admin.close();
+  });
+
+  test('1. catalogue-services returns the built-in providers (incl. YouTube)', async () => {
+    const res = await admin.request.get('/?rest_route=/faz/v1/cookies/catalogue-services', {
+      headers: { 'X-WP-Nonce': nonce },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { services: Array<{ id: string; label: string; category: string; cookie_count: number; registered: boolean }> };
+    expect(Array.isArray(body.services)).toBe(true);
+    expect(body.services.length).toBeGreaterThan(10);
+    const yt = body.services.find((s) => s.id === 'youtube');
+    expect(yt, 'YouTube should be in the catalogue').toBeTruthy();
+    expect(yt!.category).toBe('marketing');
+    expect(yt!.cookie_count).toBeGreaterThan(0);
+    expect(yt!.registered, 'YouTube should be unregistered after cleanup').toBe(false);
+  });
+
+  test('2. register-service adds the provider cookies (discovered, domain-wide)', async () => {
+    const res = await admin.request.post('/?rest_route=/faz/v1/cookies/register-service', {
+      headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
+      data: { service_id: 'youtube' },
+    });
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as { service: { id: string }; requested: number; added: number; category: string };
+    expect(body.service.id).toBe('youtube');
+    expect(body.category).toBe('marketing');
+    expect(body.added).toBeGreaterThan(0);
+
+    // The registered cookies are now declared in the banner store on a plain
+    // page that carries no YouTube embed (domain-wide transparency).
+    const html = await admin.request.get('/', { headers: { 'User-Agent': 'Mozilla/5.0 (manual-service-e2e)' } }).then((r) => r.text());
+    expect(html).toContain('YSC');
+    expect(html).toContain('VISITOR_INFO1_LIVE');
+  });
+
+  test('3. registering again is idempotent and the catalogue flags it registered', async () => {
+    const again = await admin.request.post('/?rest_route=/faz/v1/cookies/register-service', {
+      headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
+      data: { service_id: 'youtube' },
+    });
+    expect(again.status()).toBe(200);
+    expect(((await again.json()) as { added: number }).added).toBe(0);
+
+    const cat = await admin.request.get('/?rest_route=/faz/v1/cookies/catalogue-services', { headers: { 'X-WP-Nonce': nonce } });
+    const yt = ((await cat.json()) as { services: Array<{ id: string; registered: boolean }> }).services.find((s) => s.id === 'youtube');
+    expect(yt!.registered).toBe(true);
+  });
+
+  test('4. an unknown service id is rejected', async () => {
+    const res = await admin.request.post('/?rest_route=/faz/v1/cookies/register-service', {
+      headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
+      data: { service_id: 'totally_unknown_provider_xyz' },
+    });
+    expect(res.status()).toBe(404);
+  });
+
+  test('5. the Cookies admin page exposes the Add Service control and populates it', async () => {
+    await admin.goto('/wp-admin/admin.php?page=faz-cookie-manager-cookies', { waitUntil: 'domcontentloaded' });
+    const addBtn = admin.locator('#faz-add-service-btn');
+    await expect(addBtn).toBeVisible();
+    await addBtn.click();
+    // The catalogue loads lazily on first open; the select gains real options.
+    await expect.poll(async () => admin.locator('#faz-service-select option').count(), { timeout: 8000 }).toBeGreaterThan(1);
+  });
+});


### PR DESCRIPTION
Closes the domain-wide transparency gap from #161 (thanks @FINAI-Is-Not-An-Influencer for the analysis).

## Problem
When the scanner can't reach an embed (aggressive caching, lazy-load), the service's cookies are never declared. The per-page runtime detection is present-aware, so a service like YouTube only surfaces on pages that carry the embed — a visitor landing elsewhere consents without seeing it. The only previous workaround was hand-editing `wp_faz_cookies`.

## What this adds
A catalogue-driven **"Add Service"** control on the Cookies admin page. The admin picks a known provider; its cookies are registered into `wp_faz_cookies` with `discovered=1`, so they are declared **domain-wide on every page** without a scan and feed the Cookie Policy generator.

- **REST** (`admin/modules/cookies/api/class-cookies-api.php`): `GET cookies/catalogue-services` (non-necessary providers whose category is active, flagged registered/not) and `POST cookies/register-service`. Register validates the service id + category, derives a best-effort cookie domain from the provider patterns, and **reuses the scanner's `save_cookies()` enrichment** (Cookie_Database → Known_Providers → Open Cookie Database; `discovered=1`, skips existing, flushes caches), then busts `faz_cookie_scripts_map` and fires `faz_after_update_cookie`.
- **UI** (`cookies.php` + `cookies.js`): an "Add Service" dropdown beside the scanner controls; lazy-loads the catalogue, marks already-registered services, registers and refreshes.

Reuses existing infrastructure only — no scanner-engine or ClassicPress-compat changes. Proposal A from the issue; Proposal B (admin-bar capture) intentionally left out as heavier/redundant.

## Verification
End-to-end (YouTube → `YSC`/`VISITOR_INFO1_LIVE`/`LOGIN_INFO`, `discovered=1`, `domain=youtube.com`, declared on a plain page with no embed). New E2E spec (5 cases: catalogue, register + domain-wide declaration, idempotency + registered flag, unknown-service rejection, UI populates). Unit 30/30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aggiunta la sezione **“Add Service”** nella gestione cookie, con selezione servizio e registrazione manuale.
  * Introdotti nuovi endpoint REST per ottenere i servizi del catalogue e registrarne uno (incluse informazioni su cookie contati e stato di registrazione).
  * Aggiornamento automatico dell’interfaccia e indicazione dei conteggi aggiunti (idempotenza inclusa).

* **Bug Fixes**
  * Migliorata la gestione del dropdown e la chiusura automatica anche durante i click sulla pagina.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->