### PR TITLE
fix: translate banner chrome (Always Active / audit-table headers) on non-English single-language sites

### DIFF
--- a/admin/modules/banners/includes/class-template.php
+++ b/admin/modules/banners/includes/class-template.php
@@ -204,7 +204,7 @@ class Template {
 		// against the runtime locale, not the plugin's language setting.
 		// See GitHub issue tracking banner German-only regression.
 		$locale_switched = false;
-		$target_locale   = function_exists( 'faz_wp_locale' ) ? faz_wp_locale( $this->language ) : '';
+		$target_locale   = $this->resolve_build_locale();
 		if ( $target_locale && function_exists( 'switch_to_locale' ) && $target_locale !== get_locale() ) {
 			$locale_switched = switch_to_locale( $target_locale );
 		}
@@ -263,6 +263,49 @@ class Template {
 		if ( $locale_switched && function_exists( 'restore_previous_locale' ) ) {
 			restore_previous_locale();
 		}
+	}
+
+	/**
+	 * Resolve the WP locale to switch to while building the cached banner
+	 * template, so that bundled-default plugin strings wrapped in
+	 * `__( '...', 'faz-cookie-manager' )` (e.g. "Always Active" and the
+	 * cookie-audit-table headers "Cookie"/"Duration"/"Description") resolve
+	 * correctly.
+	 *
+	 * Normally this is the banner's own language ($this->language). But on a
+	 * single-language install left at the un-configured English default,
+	 * `faz_current_language()` returns 'en' regardless of the WordPress site
+	 * locale, so the template was force-built in en_US and those chrome
+	 * strings stayed English even on a sk_SK / de_DE site — while runtime
+	 * strings ("Show more"/"Show less", resolved outside the cache) DID
+	 * translate. Reported for sk_SK on wordpress.org.
+	 *
+	 * Fix: when the banner language is the un-configured 'en' default AND the
+	 * install is not running a URL-based multilingual plugin AND the WordPress
+	 * site locale is non-English, build in the WordPress site locale. The
+	 * banner *content* still comes from $this->language ('en' → bundled
+	 * English copy); only the gettext chrome follows the site language. An
+	 * explicit non-English banner language (e.g. FAZ default 'de' on a WP
+	 * en_US site) is untouched. The site locale is invariant per site, so
+	 * this stays full-page-cache safe.
+	 *
+	 * @return string Target WP locale (e.g. 'sk_SK'), or '' to skip switching.
+	 */
+	private function resolve_build_locale() {
+		$faz_locale = function_exists( 'faz_wp_locale' ) ? faz_wp_locale( $this->language ) : '';
+
+		if (
+			'en' === $this->language
+			&& function_exists( 'faz_i18n_is_multilingual' )
+			&& ! faz_i18n_is_multilingual()
+		) {
+			$wp_locale = get_locale();
+			if ( is_string( $wp_locale ) && '' !== $wp_locale && 0 !== strpos( $wp_locale, 'en' ) ) {
+				return $wp_locale;
+			}
+		}
+
+		return $faz_locale;
 	}
 
 	/**

--- a/admin/modules/banners/includes/class-template.php
+++ b/admin/modules/banners/includes/class-template.php
@@ -112,6 +112,18 @@ class Template {
 	protected $language = 'en';
 
 	/**
+	 * Memoized result of resolve_build_locale() for this request.
+	 *
+	 * Pinned on first call (which happens in get_layout_signature() before any
+	 * switch_to_locale()), so the cache-signature read in load(), the locale
+	 * generate() builds with, and the signature re-read in update() all agree
+	 * even if get_locale() shifts mid-request. null = not yet resolved.
+	 *
+	 * @var string|null
+	 */
+	private $resolved_build_locale = null;
+
+	/**
 	 * Instance of the current class
 	 *
 	 * @var object
@@ -292,7 +304,15 @@ class Template {
 	 * @return string Target WP locale (e.g. 'sk_SK'), or '' to skip switching.
 	 */
 	private function resolve_build_locale() {
+		// Memoize: pin the value on first call so the three callsites
+		// (load() signature, generate() switch, update() signature) cannot
+		// diverge if get_locale() shifts inside the switch_to_locale() window.
+		if ( null !== $this->resolved_build_locale ) {
+			return $this->resolved_build_locale;
+		}
+
 		$faz_locale = function_exists( 'faz_wp_locale' ) ? faz_wp_locale( $this->language ) : '';
+		$resolved   = $faz_locale;
 
 		if (
 			'en' === $this->language
@@ -301,11 +321,12 @@ class Template {
 		) {
 			$wp_locale = get_locale();
 			if ( is_string( $wp_locale ) && '' !== $wp_locale && 0 !== strpos( $wp_locale, 'en' ) ) {
-				return $wp_locale;
+				$resolved = $wp_locale;
 			}
 		}
 
-		return $faz_locale;
+		$this->resolved_build_locale = $resolved;
+		return $resolved;
 	}
 
 	/**

--- a/admin/modules/banners/includes/class-template.php
+++ b/admin/modules/banners/includes/class-template.php
@@ -670,6 +670,12 @@ class Template {
 					'per_service'    => ! empty( $banner_control['per_service_consent'] ),
 					'per_cookie'     => ! empty( $banner_control['per_cookie_consent'] ),
 					'description'    => md5( $notice_description ),
+					// The locale resolve_build_locale() picks drives the translated
+					// chrome (Always Active / audit-table headers). It can differ
+					// from $this->language (e.g. de_DE when the key is 'en'), so it
+					// must be in the signature or a WP locale switch would keep
+					// serving stale-language labels from cache. (CodeRabbit PR #164)
+					'build_locale'   => $this->resolve_build_locale(),
 				)
 			)
 		);

--- a/frontend/modules/shortcodes/class-shortcodes.php
+++ b/frontend/modules/shortcodes/class-shortcodes.php
@@ -242,9 +242,32 @@ class Shortcodes {
 				return __( 'Show more', 'faz-cookie-manager' );
 			case 'Show less':
 				return __( 'Show less', 'faz-cookie-manager' );
+			case 'Cookie':
+				return __( 'Cookie', 'faz-cookie-manager' );
+			case 'Duration':
+				return __( 'Duration', 'faz-cookie-manager' );
+			case 'Description':
+				return __( 'Description', 'faz-cookie-manager' );
 			default:
 				return $value;
 		}
+	}
+
+	/**
+	 * Translate a cookie-audit-table column header while preserving any
+	 * admin-customised text. The header value comes from the banner config
+	 * (en.json `auditTable.elements.headers.elements.{id,duration,description}`)
+	 * and was previously echoed raw, so it stayed English on the front end
+	 * even when the locale had a translation (reported for sk_SK).
+	 *
+	 * @param array  $contents Audit-table elements config array.
+	 * @param string $key      Header key (id|duration|description).
+	 * @param string $default  Bundled English default for that header.
+	 * @return string
+	 */
+	private function translate_header( $contents, $key, $default ) {
+		$value = isset( $contents['headers']['elements'][ $key ] ) ? (string) $contents['headers']['elements'][ $key ] : '';
+		return $this->translate_default_text( $value, $default );
 	}
 
 	private function merge_contents_deep( ...$layers ) {
@@ -595,15 +618,15 @@ class Shortcodes {
 			$description = isset( $description[ $this->language ] ) ? $description[ $this->language ] : '';
 			$duration    = isset( $duration[ $this->language ] ) ? $duration[ $this->language ] : '';
 			$table_body .= '<li>';
-			$table_body .= '<div>' . esc_html( isset( $contents['headers']['elements']['id'] ) ? $contents['headers']['elements']['id'] : '' ) . '</div>';
+			$table_body .= '<div>' . esc_html( $this->translate_header( $contents, 'id', 'Cookie' ) ) . '</div>';
 			$table_body .= '<div>' . esc_html( $cookie['name'] ) . '</div>';
 			$table_body .= '</li>';
 			$table_body .= '<li>';
-			$table_body .= '<div>' . esc_html( isset( $contents['headers']['elements']['duration'] ) ? $contents['headers']['elements']['duration'] : '' ) . '</div>';
+			$table_body .= '<div>' . esc_html( $this->translate_header( $contents, 'duration', 'Duration' ) ) . '</div>';
 			$table_body .= '<div>' . esc_html( $duration ) . '</div>';
 			$table_body .= '</li>';
 			$table_body .= '<li>';
-			$table_body .= '<div>' . esc_html( isset( $contents['headers']['elements']['description'] ) ? $contents['headers']['elements']['description'] : '' ) . '</div>';
+			$table_body .= '<div>' . esc_html( $this->translate_header( $contents, 'description', 'Description' ) ) . '</div>';
 			$table_body .= '<div>' . wp_kses( $description, faz_allowed_html() ) . '</div>';
 			$table_body .= '</li>';
 
@@ -895,9 +918,9 @@ class Shortcodes {
 		$contents   = isset( $this->contents['auditTable']['elements'] ) ? $this->contents['auditTable']['elements'] : '';
 		$html       = '';
 		$table_head = '<thead><tr>
-		<th>' . esc_html( isset( $contents['headers']['elements']['id'] ) ? $contents['headers']['elements']['id'] : '' ) . '</th>
-		<th>' . esc_html( isset( $contents['headers']['elements']['duration'] ) ? $contents['headers']['elements']['duration'] : '' ) . '</th>
-		<th>' . esc_html( isset( $contents['headers']['elements']['description'] ) ? $contents['headers']['elements']['description'] : '' ) . '</th>
+		<th>' . esc_html( $this->translate_header( $contents, 'id', 'Cookie' ) ) . '</th>
+		<th>' . esc_html( $this->translate_header( $contents, 'duration', 'Duration' ) ) . '</th>
+		<th>' . esc_html( $this->translate_header( $contents, 'description', 'Description' ) ) . '</th>
 		</tr></thead>';
 		$table_body = '<tbody>';
 		foreach ( $cookies as $cookie ) {

--- a/frontend/modules/shortcodes/class-shortcodes.php
+++ b/frontend/modules/shortcodes/class-shortcodes.php
@@ -260,13 +260,19 @@ class Shortcodes {
 	 * and was previously echoed raw, so it stayed English on the front end
 	 * even when the locale had a translation (reported for sk_SK).
 	 *
-	 * @param array  $contents Audit-table elements config array.
-	 * @param string $key      Header key (id|duration|description).
-	 * @param string $default  Bundled English default for that header.
+	 * @param array|string $contents Audit-table elements config array (may be an
+	 *                               empty string when the section is absent).
+	 * @param string       $key      Header key (id|duration|description).
+	 * @param string       $default  Bundled English default for that header.
 	 * @return string
 	 */
 	private function translate_header( $contents, $key, $default ) {
-		$value = isset( $contents['headers']['elements'][ $key ] ) ? (string) $contents['headers']['elements'][ $key ] : '';
+		// Guard is_array(): $contents is '' when the audit-table section is
+		// absent. Fall back to the default (not '') so the header still renders
+		// translated instead of vanishing.
+		$value = ( is_array( $contents ) && isset( $contents['headers']['elements'][ $key ] ) && '' !== $contents['headers']['elements'][ $key ] )
+			? (string) $contents['headers']['elements'][ $key ]
+			: $default;
 		return $this->translate_default_text( $value, $default );
 	}
 

--- a/tests/e2e/locale-banner-translation.mjs
+++ b/tests/e2e/locale-banner-translation.mjs
@@ -1,0 +1,95 @@
+/**
+ * Repro + regression guard for the banner-template build-locale bug
+ * (reported for sk_SK on wordpress.org, topic "Translation").
+ *
+ * Symptom: on a single-language install whose WordPress site locale is
+ * non-English but whose FAZ banner language is the un-configured 'en'
+ * default, the cached banner template is force-built in en_US. Strings
+ * baked into that cache — "Always Active" and the cookie-audit-table
+ * headers "Cookie"/"Duration"/"Description" — stayed English, while
+ * runtime strings resolved outside the cache ("Show more"/"Show less")
+ * DID translate to the site language. Confusing half-translated chrome.
+ *
+ * Root cause: Template::generate() switched to faz_wp_locale(
+ * faz_current_language() ), and faz_current_language() returns the FAZ
+ * default ('en'), ignoring get_locale(). Fix: Template::resolve_build_locale()
+ * follows the WP site locale when the banner language is the un-configured
+ * 'en' on a non-multilingual install. The audit-table headers were ALSO
+ * never wrapped in __(); class-shortcodes.php::translate_header() now routes
+ * them through translate_default_text().
+ *
+ * Uses de_DE as the proxy locale (its bundled .mo has all four strings).
+ * Drives wp-cli to flip the WP locale + FAZ default language, busts the
+ * template cache, renders the homepage, and asserts the chrome translates.
+ * Restores en_US / FAZ 'en' on exit.
+ *
+ * Run: WP_BASE_URL=http://127.0.0.1:9998 WP_PATH=/Users/fabio/Sites/faz-test \
+ *      node tests/e2e/locale-banner-translation.mjs
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, copyFileSync, rmSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WP = process.env.WP_BASE_URL || 'http://127.0.0.1:9998';
+const WP_PATH = process.env.WP_PATH || '/Users/fabio/Sites/faz-test';
+const PLUGIN_DIR = join(WP_PATH, 'wp-content', 'plugins', 'faz-cookie-manager');
+const MO_SRC = join(PLUGIN_DIR, 'languages', 'faz-cookie-manager-de_DE.mo');
+const MO_DST_DIR = join(WP_PATH, 'wp-content', 'languages', 'plugins');
+const MO_DST = join(MO_DST_DIR, 'faz-cookie-manager-de_DE.mo');
+
+function wp(args) {
+  return execFileSync('wp', [`--path=${WP_PATH}`, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+function bust() { try { wp(['db', 'query', "DELETE FROM wp_options WHERE option_name LIKE 'faz_banner_template%'"]); } catch { /* ignore */ } }
+function setFaz(selected, def) {
+  wp(['eval', `$s=get_option('faz_settings',array()); $s['languages']['selected']=${selected}; $s['languages']['default']='${def}'; update_option('faz_settings',$s); faz_current_language(true);`]);
+}
+async function fetchHome() {
+  const res = await fetch(WP + '/', { redirect: 'follow' });
+  return res.text();
+}
+const count = (h, s) => (h.match(new RegExp('>' + s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '<', 'g')) || []).length;
+
+let failures = 0;
+function assert(name, cond) { console.log(`  ${cond ? 'PASS' : 'FAIL'} ${name}`); if (!cond) failures++; }
+
+if (!existsSync(MO_SRC)) {
+  console.log(`SKIP — bundled de_DE .mo not found at ${MO_SRC}`);
+  process.exit(0);
+}
+
+try {
+  mkdirSync(MO_DST_DIR, { recursive: true });
+  copyFileSync(MO_SRC, MO_DST);
+
+  console.log('## Scenario 1 — WP de_DE + FAZ default "en" (the reported bug)');
+  wp(['language', 'core', 'activate', 'de_DE']);
+  setFaz("['en']", 'en');
+  bust();
+  let html = await fetchHome();
+  assert('"Always Active" translated to "Immer aktiv"', count(html, 'Immer aktiv') > 0 && count(html, 'Always Active') === 0);
+  assert('header "Description" translated to "Beschreibung"', count(html, 'Beschreibung') > 0 && count(html, 'Description') === 0);
+
+  console.log('## Scenario 2 — WP en_US + FAZ default "en" (no regression, all English)');
+  wp(['language', 'core', 'activate', 'en_US']);
+  setFaz("['en']", 'en');
+  bust();
+  html = await fetchHome();
+  assert('"Always Active" stays English', count(html, 'Always Active') > 0 && count(html, 'Immer aktiv') === 0);
+
+  console.log('## Scenario 3 — WP en_US + FAZ explicit "de" (deliberate case preserved)');
+  setFaz("['en','de']", 'de');
+  bust();
+  html = await fetchHome();
+  assert('explicit FAZ German still wins', count(html, 'Immer aktiv') > 0 && count(html, 'Always Active') === 0);
+} finally {
+  // Restore original state.
+  try { wp(['language', 'core', 'activate', 'en_US']); } catch { /* ignore */ }
+  try { setFaz("['en']", 'en'); } catch { /* ignore */ }
+  try { rmSync(MO_DST, { force: true }); } catch { /* ignore */ }
+  bust();
+}
+
+console.log(`\n=== ${failures === 0 ? 'ALL PASS' : failures + ' FAILURE(S)'} ===`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/e2e/locale-banner-translation.mjs
+++ b/tests/e2e/locale-banner-translation.mjs
@@ -32,7 +32,11 @@ import { existsSync, copyFileSync, rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const WP = process.env.WP_BASE_URL || 'http://127.0.0.1:9998';
-const WP_PATH = process.env.WP_PATH || '/Users/fabio/Sites/faz-test';
+const WP_PATH = process.env.WP_PATH;
+if (!WP_PATH) {
+  console.error('WP_PATH not set: export WP_PATH to the WordPress install root.');
+  process.exit(1);
+}
 const PLUGIN_DIR = join(WP_PATH, 'wp-content', 'plugins', 'faz-cookie-manager');
 const MO_SRC = join(PLUGIN_DIR, 'languages', 'faz-cookie-manager-de_DE.mo');
 const MO_DST_DIR = join(WP_PATH, 'wp-content', 'languages', 'plugins');
@@ -64,7 +68,9 @@ try {
   copyFileSync(MO_SRC, MO_DST);
 
   console.log('## Scenario 1 — WP de_DE + FAZ default "en" (the reported bug)');
-  wp(['language', 'core', 'activate', 'de_DE']);
+  // install --activate is the unified, non-deprecated path: it installs the
+  // language pack first (fresh CI installs lack it) then activates it.
+  wp(['language', 'core', 'install', 'de_DE', '--activate']);
   setFaz("['en']", 'en');
   bust();
   let html = await fetchHome();
@@ -72,7 +78,7 @@ try {
   assert('header "Description" translated to "Beschreibung"', count(html, 'Beschreibung') > 0 && count(html, 'Description') === 0);
 
   console.log('## Scenario 2 — WP en_US + FAZ default "en" (no regression, all English)');
-  wp(['language', 'core', 'activate', 'en_US']);
+  wp(['language', 'core', 'install', 'en_US', '--activate']);
   setFaz("['en']", 'en');
   bust();
   html = await fetchHome();
@@ -85,7 +91,7 @@ try {
   assert('explicit FAZ German still wins', count(html, 'Immer aktiv') > 0 && count(html, 'Always Active') === 0);
 } finally {
   // Restore original state.
-  try { wp(['language', 'core', 'activate', 'en_US']); } catch { /* ignore */ }
+  try { wp(['language', 'core', 'install', 'en_US', '--activate']); } catch { /* ignore */ }
   try { setFaz("['en']", 'en'); } catch { /* ignore */ }
   try { rmSync(MO_DST, { force: true }); } catch { /* ignore */ }
   bust();

--- a/tests/unit/test-build-locale-php.php
+++ b/tests/unit/test-build-locale-php.php
@@ -152,6 +152,15 @@ namespace {
 	eq( call_priv( faz_template( 'en' ), 'resolve_build_locale' ), 'en_US', "key 'en' multilingual → faz locale (explicit per-language build)" );
 	$GLOBALS['__faz_multilingual'] = false;
 
+	// Memoization: the value is pinned on first call, so a get_locale() shift
+	// later in the same request (the switch_to_locale window) can't make the
+	// stored signature diverge from the locale generate() actually builds with.
+	$GLOBALS['__faz_wp_locale'] = 'de_DE';
+	$tpl_memo                   = faz_template( 'en' );
+	eq( call_priv( $tpl_memo, 'resolve_build_locale' ), 'de_DE', 'memo: first call resolves de_DE' );
+	$GLOBALS['__faz_wp_locale'] = 'fr_FR';
+	eq( call_priv( $tpl_memo, 'resolve_build_locale' ), 'de_DE', 'memo: second call returns the pinned value despite a get_locale() change' );
+
 	// =====================================================================
 	// get_layout_signature() must change when the resolved locale changes.
 	// =====================================================================

--- a/tests/unit/test-build-locale-php.php
+++ b/tests/unit/test-build-locale-php.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Standalone unit tests for Template::resolve_build_locale() + its presence in
+ * the banner-template cache signature (#164 / CodeRabbit).
+ *
+ * Subsystem: build-locale-php
+ *
+ * On a single-language site whose FAZ "default language" is left at the stock
+ * 'en' key, the banner chrome (Always Active / audit-table headers) must follow
+ * the WordPress site locale rather than render in English. resolve_build_locale()
+ * encodes that rule:
+ *   - a real FAZ language key ('de', 'fr', …) → its mapped WP locale, always;
+ *   - the stock 'en' key on a monolingual site → the WP site locale, but only
+ *     when that locale is itself non-English (otherwise stay on the faz locale);
+ *   - multilingual sites are never second-guessed (explicit per-language build).
+ *
+ * The resolved locale also drives the translated output, so it MUST be part of
+ * get_layout_signature(): otherwise a WP locale switch leaves the cached banner
+ * serving stale-language labels. These tests pin both halves.
+ *
+ * Run: php tests/unit/test-build-locale-php.php
+ *  or: bash scripts/run-unit-tests.sh
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'FAZ_VERSION' ) ) {
+		define( 'FAZ_VERSION', '9.9.9-test' );
+	}
+
+	// Controllable environment for the stubbed WP/plugin functions.
+	$GLOBALS['__faz_wp_locale']      = 'en_US'; // get_locale()
+	$GLOBALS['__faz_multilingual']   = false;   // faz_i18n_is_multilingual()
+	$GLOBALS['__faz_options']        = array(); // get_option()
+
+	// faz_wp_locale(): FAZ language key → WP locale. Mirror the real mapping for
+	// the keys exercised here; unknown keys fall through to ''.
+	if ( ! function_exists( 'faz_wp_locale' ) ) {
+		function faz_wp_locale( $lang ) {
+			$map = array( 'en' => 'en_US', 'de' => 'de_DE', 'fr' => 'fr_FR', 'it' => 'it_IT' );
+			return isset( $map[ $lang ] ) ? $map[ $lang ] : '';
+		}
+	}
+	if ( ! function_exists( 'faz_i18n_is_multilingual' ) ) {
+		function faz_i18n_is_multilingual() {
+			return (bool) $GLOBALS['__faz_multilingual'];
+		}
+	}
+	if ( ! function_exists( 'get_locale' ) ) {
+		function get_locale() {
+			return $GLOBALS['__faz_wp_locale'];
+		}
+	}
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( $name, $default = false ) {
+			return array_key_exists( $name, $GLOBALS['__faz_options'] ) ? $GLOBALS['__faz_options'][ $name ] : $default;
+		}
+	}
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $data, $flags = 0 ) {
+			return json_encode( $data, $flags );
+		}
+	}
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $s ) {
+			return trim( (string) $s );
+		}
+	}
+	if ( ! function_exists( 'faz_current_language' ) ) {
+		function faz_current_language() {
+			return 'en';
+		}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/admin/modules/banners/includes/class-template.php';
+
+	use FazCookie\Admin\Modules\Banners\Includes\Template;
+
+	$tests_run = 0; $tests_passed = 0; $tests_failed = 0;
+	function eq( $actual, $expected, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $actual === $expected ) {
+			$tests_passed++;
+			echo "  \033[32m✓\033[0m " . $label . "\n";
+		} else {
+			$tests_failed++;
+			echo "  \033[31m✗\033[0m " . $label . "\n";
+			echo '      expected: ' . var_export( $expected, true ) . "\n";
+			echo '      actual:   ' . var_export( $actual, true ) . "\n";
+		}
+	}
+	function ok( $cond, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $cond ) { $tests_passed++; echo "  \033[32m✓\033[0m " . $label . "\n"; }
+		else { $tests_failed++; echo "  \033[31m✗\033[0m " . $label . "\n"; }
+	}
+
+	// Build a Template with a chosen FAZ language key, no constructor.
+	function faz_template( $language ) {
+		$rc = new ReflectionClass( Template::class );
+		$tpl = $rc->newInstanceWithoutConstructor();
+		$pl = $rc->getProperty( 'language' );
+		$pl->setAccessible( true );
+		$pl->setValue( $tpl, $language );
+		$pp = $rc->getProperty( 'properties' );
+		$pp->setAccessible( true );
+		$pp->setValue( $tpl, array() );
+		$pb = $rc->getProperty( 'banner' );
+		$pb->setAccessible( true );
+		$pb->setValue( $tpl, null );
+		return $tpl;
+	}
+	function call_priv( $tpl, $method ) {
+		$m = new ReflectionMethod( Template::class, $method );
+		$m->setAccessible( true );
+		return $m->invoke( $tpl );
+	}
+
+	// =====================================================================
+	// resolve_build_locale()
+	// =====================================================================
+	echo "resolve_build_locale()\n";
+
+	// A real language key → its mapped WP locale, regardless of site locale.
+	$GLOBALS['__faz_wp_locale'] = 'en_US';
+	eq( call_priv( faz_template( 'de' ), 'resolve_build_locale' ), 'de_DE', "key 'de' → de_DE (ignores site locale)" );
+	eq( call_priv( faz_template( 'fr' ), 'resolve_build_locale' ), 'fr_FR', "key 'fr' → fr_FR" );
+
+	// Stock 'en' key, monolingual, site locale is non-English → follow the site.
+	$GLOBALS['__faz_multilingual'] = false;
+	$GLOBALS['__faz_wp_locale']    = 'de_DE';
+	eq( call_priv( faz_template( 'en' ), 'resolve_build_locale' ), 'de_DE', "key 'en' + de_DE site → follows site locale" );
+	$GLOBALS['__faz_wp_locale']    = 'it_IT';
+	eq( call_priv( faz_template( 'en' ), 'resolve_build_locale' ), 'it_IT', "key 'en' + it_IT site → follows site locale" );
+
+	// Stock 'en' key but the site locale is itself English → stay on faz locale.
+	$GLOBALS['__faz_wp_locale'] = 'en_GB';
+	eq( call_priv( faz_template( 'en' ), 'resolve_build_locale' ), 'en_US', "key 'en' + en_GB site → faz locale (no English self-override)" );
+	$GLOBALS['__faz_wp_locale'] = '';
+	eq( call_priv( faz_template( 'en' ), 'resolve_build_locale' ), 'en_US', "key 'en' + empty site locale → faz locale" );
+
+	// Multilingual site → never second-guess, even with 'en' + non-English site.
+	$GLOBALS['__faz_multilingual'] = true;
+	$GLOBALS['__faz_wp_locale']    = 'de_DE';
+	eq( call_priv( faz_template( 'en' ), 'resolve_build_locale' ), 'en_US', "key 'en' multilingual → faz locale (explicit per-language build)" );
+	$GLOBALS['__faz_multilingual'] = false;
+
+	// =====================================================================
+	// get_layout_signature() must change when the resolved locale changes.
+	// =====================================================================
+	echo "\nget_layout_signature() includes build_locale\n";
+	$GLOBALS['__faz_wp_locale'] = 'de_DE';
+	$sig_de = call_priv( faz_template( 'en' ), 'get_layout_signature' );
+	$GLOBALS['__faz_wp_locale'] = 'it_IT';
+	$sig_it = call_priv( faz_template( 'en' ), 'get_layout_signature' );
+	$GLOBALS['__faz_wp_locale'] = 'de_DE';
+	$sig_de2 = call_priv( faz_template( 'en' ), 'get_layout_signature' );
+	ok( is_string( $sig_de ) && 32 === strlen( $sig_de ), 'signature is an md5 hash' );
+	ok( $sig_de !== $sig_it, 'a WP locale switch (de_DE→it_IT) changes the cache signature' );
+	eq( $sig_de2, $sig_de, 'same locale → identical signature (stable cache key)' );
+
+	echo "\n";
+	if ( 0 === $tests_failed ) {
+		echo "\033[32mALL PASS\033[0m — {$tests_passed}/{$tests_run}\n";
+		exit( 0 );
+	}
+	echo "\033[31m{$tests_failed} FAILED\033[0m — {$tests_passed}/{$tests_run} passed\n";
+	exit( 1 );
+}

--- a/tests/unit/test-template-cache-php.php
+++ b/tests/unit/test-template-cache-php.php
@@ -247,7 +247,15 @@ faz_ok( $sig_base === $service_zero->faz_signature(), '09 per_service_consent=0 
 //     yields a different md5 (proven by recomputing the same array with a bumped
 //     version, mirroring the builder exactly).
 $desc_md5 = md5( 'We value your privacy' );
-function faz_sig_for_version( $version, $base_settings, $desc_md5 ) {
+// Mirror the resolved build locale that get_layout_signature() now folds in
+// (#164). Read it from the real resolver so the mirror matches whatever the
+// environment yields (empty here: no faz_wp_locale stub) without hardcoding.
+function faz_build_locale( $tpl ) {
+	$m = new ReflectionMethod( Template::class, 'resolve_build_locale' );
+	$m->setAccessible( true );
+	return $m->invoke( $tpl );
+}
+function faz_sig_for_version( $version, $base_settings, $desc_md5, $build_locale ) {
 	return md5(
 		wp_json_encode(
 			array(
@@ -262,12 +270,14 @@ function faz_sig_for_version( $version, $base_settings, $desc_md5 ) {
 				'per_service'    => false,
 				'per_cookie'     => false,
 				'description'    => $desc_md5,
+				'build_locale'   => $build_locale,
 			)
 		)
 	);
 }
-$sig_v1 = faz_sig_for_version( FAZ_VERSION, $base_settings, $desc_md5 );
-$sig_v2 = faz_sig_for_version( '0.0.1-other', $base_settings, $desc_md5 );
+$base_build_locale = faz_build_locale( $a );
+$sig_v1 = faz_sig_for_version( FAZ_VERSION, $base_settings, $desc_md5, $base_build_locale );
+$sig_v2 = faz_sig_for_version( '0.0.1-other', $base_settings, $desc_md5, $base_build_locale );
 faz_ok( $sig_v1 === $sig_base, '10a recomputed builder matches real signature (version field present)' );
 faz_ok( $sig_v1 !== $sig_v2, '10b changing plugin_version changes the signature' );
 

--- a/tests/unit/test-translate-header-php.php
+++ b/tests/unit/test-translate-header-php.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Standalone unit tests for Shortcodes::translate_header() (#164 / review).
+ *
+ * Subsystem: translate-header-php
+ *
+ * The cookie-audit-table column headers (Cookie / Duration / Description) are
+ * translated through translate_header() → translate_default_text(): a value
+ * equal to the bundled English default is replaced with its translation, while
+ * an admin-customised value is preserved verbatim. The hardening pinned here:
+ * when the audit-table config is absent ($contents is the empty string, or the
+ * key is missing/empty), the header must fall back to the translated DEFAULT
+ * rather than vanishing — and is_array() must guard the empty-string case.
+ *
+ * Run: php tests/unit/test-translate-header-php.php
+ *  or: bash scripts/run-unit-tests.sh
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	// __() marks the strings it translates so the test can detect a real
+	// translation vs a passed-through custom value.
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = 'default' ) {
+			return 'XX-' . $text;
+		}
+	}
+
+	require_once dirname( __DIR__, 2 ) . '/frontend/modules/shortcodes/class-shortcodes.php';
+
+	use FazCookie\Frontend\Modules\Shortcodes\Shortcodes;
+
+	$tests_run = 0; $tests_passed = 0; $tests_failed = 0;
+	function eq( $actual, $expected, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $actual === $expected ) {
+			$tests_passed++;
+			echo "  \033[32m✓\033[0m " . $label . "\n";
+		} else {
+			$tests_failed++;
+			echo "  \033[31m✗\033[0m " . $label . "\n";
+			echo '      expected: ' . var_export( $expected, true ) . "\n";
+			echo '      actual:   ' . var_export( $actual, true ) . "\n";
+		}
+	}
+
+	$rc  = new ReflectionClass( Shortcodes::class );
+	$sc  = $rc->newInstanceWithoutConstructor();
+	$m   = new ReflectionMethod( Shortcodes::class, 'translate_header' );
+	$m->setAccessible( true );
+	$call = function ( $contents, $key, $default ) use ( $m, $sc ) {
+		return $m->invoke( $sc, $contents, $key, $default );
+	};
+
+	echo "translate_header()\n";
+
+	// Config present, value == default → translated.
+	$present_default = array( 'headers' => array( 'elements' => array( 'description' => 'Description' ) ) );
+	eq( $call( $present_default, 'description', 'Description' ), 'XX-Description', 'value == default → translated' );
+
+	// Config present, admin-customised value → preserved verbatim (not translated).
+	$present_custom = array( 'headers' => array( 'elements' => array( 'description' => 'Our cookies' ) ) );
+	eq( $call( $present_custom, 'description', 'Description' ), 'Our cookies', 'custom value → preserved (no translation)' );
+
+	// The hardened cases — header must render the translated default, not vanish:
+	// (a) $contents is the empty string (section absent).
+	eq( $call( '', 'description', 'Description' ), 'XX-Description', "absent config ('' string) → translated default (is_array guard)" );
+	// (b) $contents is an array but the key is missing.
+	eq( $call( array( 'headers' => array( 'elements' => array() ) ), 'description', 'Description' ), 'XX-Description', 'missing key → translated default' );
+	// (c) $contents has the key but it is an empty string.
+	$empty_val = array( 'headers' => array( 'elements' => array( 'description' => '' ) ) );
+	eq( $call( $empty_val, 'description', 'Description' ), 'XX-Description', 'empty value → translated default' );
+
+	// Other header keys behave the same.
+	eq( $call( '', 'id', 'Cookie' ), 'XX-Cookie', "absent config → translated 'Cookie' default" );
+	eq( $call( '', 'duration', 'Duration' ), 'XX-Duration', "absent config → translated 'Duration' default" );
+
+	echo "\n";
+	if ( 0 === $tests_failed ) {
+		echo "\033[32mALL PASS\033[0m — {$tests_passed}/{$tests_run}\n";
+		exit( 0 );
+	}
+	echo "\033[31m{$tests_failed} FAILED\033[0m — {$tests_passed}/{$tests_run} passed\n";
+	exit( 1 );
+}


### PR DESCRIPTION
## Problem

Reported for `sk_SK` on wordpress.org (topic *Translation*): after 1.21.0 made "Show more"/"Show less" translatable, three banner strings still rendered in English on the front end despite a translated locale — **"Always Active"**, **"Duration"**, **"Description"** — while "Show more"/"Show less" *did* translate. Reproduced locally in `de_DE` (which ships all four translations).

## Root cause (two distinct bugs)

1. **Audit-table headers were never wrapped.** `Cookie`/`Duration`/`Description` were echoed raw from the banner config (`auditTable.elements.headers`), never routed through gettext, so they could never translate even though they were in the POT (they appear there via the admin UI).

2. **The banner template is built in the wrong locale.** The template is server-rendered and cached (`faz_banner_template`), built by `Template::generate()` which switches the WP locale to `faz_wp_locale( faz_current_language() )`. On a non-multilingual install `faz_current_language()` returns the FAZ **default** language (`'en'`), ignoring the WordPress site locale — so the template, and every gettext string baked into it, was force-built in `en_US`. "Show more"/"Show less" translate because they are resolved at runtime *outside* the cached template, following the WP locale.

## Fix

- `class-shortcodes.php`: new `translate_header()` helper routes the three headers through `translate_default_text()`, plus the matching `switch` cases. Admin-customised header text is preserved (same caveat as the other defaults).
- `class-template.php`: new `resolve_build_locale()` — when the banner language is the un-configured `'en'` on a non-multilingual install and the WordPress site locale is non-English, build in the **WordPress site locale**. The banner *content* still comes from the `'en'` bundle (English copy); only the gettext chrome follows the site language. An explicit non-English FAZ language (e.g. default `de` on a WP `en_US` site) is untouched. The site locale is invariant per site, so the full-page cache stays safe.

## Tests

`tests/e2e/locale-banner-translation.mjs` covers:
- WP `de_DE` + FAZ default `en` → chrome translates (the reported bug) ✓
- WP `en_US` + FAZ default `en` → stays English (no regression) ✓
- WP `en_US` + FAZ explicit `de` → explicit language still wins ✓

Core banner/blocking E2E (`frontend-consent`, `settings-and-blocking`) green (8/8). In the default `en`/`en_US` path `resolve_build_locale()` returns `en_US` — byte-identical to prior behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata la selezione della lingua usata per generare i banner, soprattutto nei siti WordPress monolingua con lingua di sistema diversa dall’ინგlese.
  * Le intestazioni della tabella di audit cookie ora mostrano in modo più affidabile le traduzioni corrette, anche quando provengono dai valori predefiniti.
  * Risolti casi in cui alcune etichette potevano restare in inglese anziché seguire la lingua attiva o quella di WordPress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->