### PR TITLE
Add compliance-testing artifacts: consent-log controller test + 47-legislation audit

### DIFF
--- a/docs/compliance-test-report-2026-06-19.md
+++ b/docs/compliance-test-report-2026-06-19.md
@@ -1,0 +1,284 @@
+# FAZ Cookie Manager — Full Compliance Test Report
+
+**Plugin version:** 1.20.0
+**Date:** 2026-06-19
+**Branch:** `claude/plugin-compliance-test-uv1j3o`
+**Scope:** Full compliance verification, all 47 legislations, per-service consent (latest PR #155, #134/#146).
+
+---
+
+## 1. Executive summary
+
+| Layer | Result |
+|-------|--------|
+| PHP unit suites (27) | ✅ **27/27 passed** (0 failed) |
+| Ruleset schema validation (48 files) | ✅ **48/48 valid** (`--strict`, 0 errors, 0 warnings) |
+| Legislation compliance-invariant audit (47 laws) | ✅ **47/47 conform** (0 ERROR, 0 WARN) |
+| Per-service consent flow (backend + frontend) | ✅ **Verified** against code + specs + unit tests |
+| PHP lint (core files) | ✅ No syntax errors |
+| E2E browser suite (85 specs / 841 tests) | ⚠️ **Requires a live WordPress stack** — not executable in this container (see §6) |
+
+**Verdict:** every layer that can be executed deterministically in this environment passes. The per-service consent feature is correctly implemented and matches its test contracts. The only unexecuted layer is the Playwright E2E suite, which is gated on a running WordPress instance (127.0.0.1:9998) not present here.
+
+---
+
+## 2. Unit test suites (PHP) — 26/26 ✅
+
+Run: `npm run test:unit` (`bash scripts/run-unit-tests.sh`). Each suite is a self-contained CLI runner (stubs WP, no DB/browser).
+
+Compliance / consent-relevant suites of note (all PASS):
+
+- `test-compliance-php.php` — consent-log sanitiser, DSAR exporter/eraser, pageview URL minimisation, DNSMPI sell/share gating, geo-ruleset integrity.
+- `test-compliance-hardening.php` — resolver routing, GPC flags, CIDR allowlist.
+- `test-per-service-php.php` / `test-per-service-embeds-php.php` — per-service (`svc.*`) enforcement, block-first embed path (#134/#146).
+- `test-percookie-php.php` — per-cookie (`ck.*`) enforcement (16/16).
+- `test-donotsell-php.php` — CCPA/DNSMPI opt-out.
+- `test-ruleset-resolver.php` / `test-resolver-validation.php` / `test-geo-*` — jurisdiction routing.
+- `test-pipl-audit-log.php` — PIPL (China) audit logging.
+
+---
+
+## 3. Ruleset schema validation — 48/48 ✅
+
+Run: `bash scripts/validate-rulesets.sh --strict` (Python `jsonschema`, Draft 2020-12).
+All 47 legislation rulesets + the GDPR fallback validate against `ruleset.schema.json`. 0 errors, 0 warnings.
+
+---
+
+## 4. Legislation compliance audit — 47/47 ✅
+
+A dedicated semantic audit (`tests/compliance-audit.py`) checks each ruleset against the **legal model it declares**, beyond mere schema validity:
+
+| ID | Check |
+|----|-------|
+| N1 | `necessary` is always `granted-locked` (never deniable) — **all laws** |
+| O1 | opt-in laws default analytics/marketing/profiling/functional to `denied` (ePrivacy/GDPR prior-blocking) |
+| O2 | opt-in laws set Consent Mode v2 `ad_storage`/`analytics_storage`/`ad_user_data`/`ad_personalization` to denied |
+| O3 | opt-in laws use `equal_weight_buttons` (EDPB no-dark-pattern) |
+| U1 | opt-out / sensitive-opt-in laws gate `profiling` (sensitive data → opt-in) |
+| U2 | US universal-opt-out states honour GPC (`gpc_honored=true`) |
+| U3 | US sale/share states require the "Do Not Sell" link |
+| G1 | `gpc_required` ⇒ `gpc_honored` |
+
+**Result: 0 ERROR, 0 WARN across all 47.** Distribution:
+
+- **opt-in (19):** GDPR Italy/Germany/France/Ireland/Netherlands/Poland/Spain + gdpr-strict, UK-GDPR/PECR, LGPD Brazil, India DPDPA, Korea PIPA, China PIPL, Turkey KVKK, UAE PDPL, KSA PDPL, Israel PPL, South Africa POPIA, Malaysia/Singapore/Thailand/Vietnam PDPA, New Zealand, fallback. → all non-necessary categories `denied` (no cookies before consent).
+- **opt-out-with-sensitive-opt-in (18 US states):** CCPA, Colorado, Connecticut, Texas, New Jersey, Minnesota, Maryland, New Hampshire, Oregon, Delaware, Montana, Virginia, Utah, Indiana, Iowa, Kentucky, Tennessee, Rhode Island, Florida. → analytics/marketing `granted`, `profiling` (sensitive) `denied-until-action`; UOOM states honour GPC.
+- **hybrid (4):** Quebec Law 25, PIPEDA Canada, Australia Privacy Act, Japan APPI → express opt-in for analytics/marketing/profiling where required.
+
+Full matrix is reproduced by running the script (see §7).
+
+---
+
+## 5. Per-service consent — flow verification ✅
+
+The recently merged feature (PR #155, resolving reopened #134/#146; built on per-cookie PR #153). Verified by tracing the **shipped code** and cross-checking each step against `tests/e2e/specs/per-service-consent.spec.ts` and the passing PHP unit suites.
+
+### Backend (`frontend/class-frontend.php`)
+1. **`get_enforceable_services()`** (L1331) — returns **every** `Known_Providers` entry in an active non-necessary category, *decoupled from scanner detection*. This is the #134/#146 fix: a block-first site never lets a provider's cookie exist, so detection alone would hide it.
+2. **`get_service_consent()`** (L3138) — gated on `banner_control.per_service_consent`; parses `svc.<id>:yes|no` tokens from the validated consent cookie, keeping only IDs in the enforceable set.
+3. **`get_pattern_service_map()`** (L3182) — builds pattern→service map from the broad enforceable set, so a real embed can be matched even if undetected.
+4. **`check_per_service_blocking()`** (L3214) — `svc.id:no` → **block**; `svc.id:yes` → **allow**; otherwise `null` → **category-level fallback** (unchanged behaviour for providers with no explicit choice).
+
+### Frontend (`frontend/js/script.js`)
+- Placeholder "Accept" handler (L4479) calls `window._fazAcceptService(serviceId, cat, true)`.
+- **`_fazAcceptService()`** (L5187) grants **only** that service via a synthetic `svc.<id>:yes` toggle — never the whole category. A forged/unrecognised service id is a **diagnosable no-op** (`_fazIsRecognizedService` allowlist), preventing silent over-consent. This is the core correctness contract the 1.18.2 hotfix flagged.
+
+### Contract checks mirrored by the E2E spec (assertions confirmed present in code)
+- **P2** — service list reflects *detected* cookies for the visible toggles, while *enforcement* uses the broad set.
+- **P1-4** — consent cookie hard-capped < 4 KB; core/category entries and explicit `svc.*` denials kept, low-priority `ck.*` overrides dropped first.
+- **P1-3** — `svc.*` decisions written to the consent log (GDPR accountability), alongside the category summary.
+- **category-only mode** — `per_service_consent=false` hides/disables all per-service toggles.
+
+### 5a. Service-vs-category divergence — server enforcement truth table
+
+Verified in `frontend/class-frontend.php` (`<script>` L2310-2326, `<iframe>` L2353-2364),
+driven by `check_per_service_blocking()` (L3214, returns `true`/`false`/`null`):
+
+| Visitor's `svc.<id>` | Category ALLOWED | Category BLOCKED |
+|---|---|---|
+| `yes` → `false` | runs | **runs** — service override beats the denied category |
+| `no` → `true` | **blocked** — service opt-out inside an accepted category | blocked |
+| *(none)* → `null` | runs (category allows) | blocked — **category fallback** |
+
+The same precedence is proved deterministically by `test-per-service-php.php` E1-E5
+(NO > YES > category; empty map → null; unmatched script → null).
+
+### 5b. Consent change (save) — what gets written
+
+`_fazAcceptCookies("custom")` → `_fazStoreCustomServiceConsent()` (`script.js` L2500):
+- writes `svc.<id>:yes|no` **only when a service toggle diverges** from its category
+  (`hasOverride`, L2515); convergent tokens are dropped by the store serialiser so the
+  cookie stays small. A service denied inside an accepted category keeps the category
+  ON (individual opt-out, change handler L2808/4808).
+- Same-session accept-then-reject of an *undetected* (block-first) provider is captured
+  via the `_fazServicesBeforeConsent` snapshot diff (L2525-2535) so the reload fires.
+
+### 5c. Immediate shred on save (service vs category divergence)
+
+After persistence, granular mode sweeps **every** category (not just rejected ones)
+via `_fazRemoveDeadCookies()` (L1865/2437): a cookie survives only if its effective
+decision is `yes`, computed `ck.* > svc.* > category` by `_fazGetServiceCookieDecision()`
+(L2656) — so a cookie already set by a service the visitor just denied **inside an
+accepted category** is shredded immediately on save, not left until the next request.
+Server-side, the request-time shredder enforces the same precedence on reload.
+
+### 5d. Return visit (restore) — state round-trips from the cookie
+
+On re-render the service toggle is restored from the stored override, else the category
+(`script.js` L4804-4806: `svcConsent ? svcConsent==='yes' : catConsent==='yes'`), and on
+revisit `_fazUpdateServiceToggleStates()` (L4895) re-applies `svc.* > category` to every
+toggle (and `ck.*` to nested per-cookie toggles via `_fazCookieEffectiveConsent`, L2640).
+The category→service sync (L4869) keeps a flipped category coherent with its services.
+On the next page load the server independently re-derives blocking from the `svc.*`
+tokens in the persisted cookie (`get_service_consent()` L3138), so the restored UI and
+the actual script/iframe gating agree.
+
+### 5e. Fallback (no explicit service choice)
+
+A service with no `svc.<id>` token defers to its category at **both** layers:
+JS `_fazServiceEffectiveConsent()` (L2546) returns the category value, and server
+`check_per_service_blocking()` returns `null` so the normal category branch decides
+(`test-per-service-php.php` E3/E4).
+
+---
+
+## 5f. Normal (production) consent-log path — executed against the real controller ✅
+
+To verify the *normal behaviour* of the per-service persistence path — not a
+replica and not a SQLite test shim — a new suite (`tests/unit/test-consentlog-controller-php.php`,
+**22/22**) loads and drives the **shipped** `Controller` class
+(`admin/modules/consentlogs/includes/class-controller.php`) against a `$wpdb`
+double that records inserts and replays them on read:
+
+- **`svc.*` / `ck.*` round-trip** — `log_consent()` → `categories` JSON →
+  `get_log_by_consent_id()` preserves `svc.google-analytics:no` (denied service
+  inside an accepted category), `svc.youtube:yes` (allowed service inside a denied
+  category) and `ck.google-analytics._ga:no`, alongside the category summary (P1-3).
+- **Hardening by the shipped sanitiser** — `maybe→drop`, markup→drop, nested→drop,
+  empty key→drop; 190-char key cap; 250-entry cap.
+- **DNSMPI scalar path** stores `''` (not `'[]'`); internal `dnsmpi_optout` status kept.
+- **Privacy** — user-agent and IP stored as `sha256(value + salt)`, raw UA never present.
+- **`status` allowlist** — unknown → `partial` (dashboard stat integrity).
+- **URL minimisation** — credentials, query string and fragment dropped.
+- **SQLite-portable migration (1.19.2)** — `hash_legacy_user_agents()` hashes legacy
+  plaintext UAs **in PHP** byte-identically to `hash_user_agent()`, and is idempotent
+  (64-hex rows skipped). This is the production-compat path the previous merge added;
+  the same code runs on MySQL and on SQLite-backed WordPress.
+
+> **Note on SQLite.** SQLite here is a *production* concern (WordPress can run on
+> SQLite via `sqlite-database-integration` / WordPress Playground), addressed by
+> release 1.19.2 — it is **not** a test-only shortcut. The Playwright harness happens
+> to use a Playground/SQLite WordPress, but the assertions above exercise the normal
+> production controller directly, so they hold on a standard MySQL install too.
+
+## 5g. Field-reported bugs (per-service-reveal branch) — diagnosed + fixed ✅
+
+A tester on the per-service branch (`build 1.20.0+per-service-reveal`) reported two
+defects, confirmed real (reproduced against the shipped helpers in
+`tests/unit/test-per-service-reveal-php.php`) and sharing one root cause:
+
+- **BUG-1** — the scanner never surfaces a block-first embed service (YouTube). Its
+  toggle only appears on the page currently carrying the blocked embed; the homepage
+  and the rest of the site report `services: []`.
+- **BUG-2** *(compliance-critical)* — after the visitor **accepts** the YouTube
+  placeholder the per-service/per-cookie toggles **disappear**, so the granted
+  service can no longer be **withdrawn** from the preference center — a GDPR
+  **Art. 7(3)** violation (withdrawal must be as easy as consent).
+
+**Root cause.** Two divergent lists: the VISIBLE toggle list
+(`get_per_service_services()`, `class-frontend.php`) is gated on a scanner-detected
+cookie (`provider_has_detected_cookie()`, `discovered = 1`), while ENFORCEMENT uses
+the broad `get_enforceable_services()`. A blocked iframe sets its cookies (`YSC`,
+`VISITOR_INFO1_LIVE`, …) only once it actually loads, which on a block-first site
+never happens — so YouTube is never in the visible list on any page. The toggle could
+only ever come from a page-level reveal keyed to the placeholder, which vanishes the
+moment the embed is accepted.
+
+**Fix (this branch, on the merged foundation).** `get_per_service_services()` now also
+surfaces any **enforceable service with an explicit `svc.<id>` decision** in the
+consent cookie (accept *or* reject), independent of cookie detection or placeholder
+presence. The granted/denied service therefore keeps its toggle (and its per-cookie
+sub-toggles) site-wide and stays reviewable/withdrawable. Only the *visible* list is
+affected — enforcement, parsing and shredding are untouched. Verified by the renamed
+regression suite (**8/8**) and the full unit run (**28/28**).
+
+**Portability review (works on any WordPress site).** The fix was reviewed for
+cross-site robustness:
+- *Page-cache safe* — `get_service_consent()` returns an empty map when there is no
+  consent cookie (or per-service is off), so the augmentation is a **no-op on the
+  cacheable anonymous request** and `_services` stays byte-identical to the
+  detection-only list. It only fires for requests already carrying a consent cookie —
+  output that is visitor-dependent under the plugin's existing per-service/per-cookie
+  server enforcement anyway. No new `DONOTCACHEPAGE` requirement is introduced.
+- *Custom/renamed/disabled categories* — a category-active guard re-checks each
+  surfaced service against the live `$valid_categories`, so a stale `svc.*` token for a
+  category the site removed never shows a toggle.
+- *No new dependencies* — uses only PHP built-ins plus two existing internal methods;
+  the `faz_get_valid_consent_cookie()` read is `function_exists()`-guarded inside
+  `get_service_consent()`. No fatal surface on a minimal install.
+- *Not shipped to clients* — the test files live under `tests/`, excluded from the
+  distributed zip via `.distignore`.
+
+> **Scope note.** The server fix guarantees the toggle is present on every page load
+> after a decision (so withdrawal is always possible). Full *same-session* persistence
+> right after the placeholder click also depends on the client-side reveal code, which
+> lives in the tester's unpushed `per-service-reveal` branch (not in any pushed ref);
+> BUG-1's *pre-decision* reveal on the embed page likewise stays with that client code.
+
+## 5h. YouTube (and all third-party embeds) — per-cookie enforceability ✅
+
+Reviewing the YouTube path surfaced a genuine, generalisable issue. What is
+**correct**: the iframe oEmbed is blocked into a placeholder (`process_iframe_tag`,
+`class-frontend.php`), the placeholder fetches **no remote thumbnail**
+(`class-placeholder-builder.php` — privacy), client matching is substring + boundary
+(not regex, so `youtu.be`/`ytimg.com` don't over-match), accept-from-placeholder works,
+and the service-level toggle now persists for withdrawal (§5g).
+
+What was **misleading**: YouTube's cookies (`YSC`, `VISITOR_INFO1_LIVE`, `LOGIN_INFO`)
+are set on **`youtube.com`**, a third-party domain. The shredder writes
+`document.cookie` for the **site's** root domain (`_fazSetCookie`, `script.js:529`), and
+same-origin rules forbid deleting another domain's cookie — so the per-cookie
+sub-toggles the preference center rendered for an embed implied a granular control the
+browser makes impossible. The only enforceable control for an embed is service-level
+(allow/block the whole iframe).
+
+**Fix (relabel, per decision).** A new `Placeholder_Builder::is_embed_service()`
+classifies embed services from the authoritative URL→service / video-service maps; the
+server tags each `_services` entry with `third_party` (via a `class_exists`-guarded
+`Frontend::is_third_party_service()` that degrades to `false`, never fatals); and the
+preference center prepends a clarifying note to the per-cookie list for those services
+(*"set by the embedded service on its own domain … controlled by allowing or blocking
+the embed above — cannot be removed individually"*), translatable via `_i18n`
+(`third_party_cookie_note`) with an English fallback. The toggles remain; the claim is
+now honest. Generalises to Vimeo, Maps, Facebook, X, etc. Verified by
+`test-per-service-reveal-php.php` (`third_party=true` for YouTube, `false` for
+first-party GA) and `test-per-service-embeds-php.php` (entry shape); 28/28 suites; min
+rebuilt.
+
+## 6. E2E browser suite — not executable here ⚠️
+
+`tests/e2e/` is a Playwright suite of **85 spec files / 841 test cases** (`npm run test:e2e`). `global-setup.ts` requires a reachable WordPress at `http://127.0.0.1:9998` with admin credentials and seeded fixtures (≈100 scanned cookies, GeoLite2 DB, `WP_PATH` for `wp-cli` eval).
+
+This managed container is a fresh checkout with **no WordPress, MySQL, or `wp-env`/Docker harness**, so the E2E layer cannot be run here. The relevant flows it would exercise are instead verified statically in §5 and by the passing PHP unit suites in §2.
+
+**To run the E2E layer in a proper environment:**
+```bash
+cp .env.e2e.example .env.e2e   # set WP_BASE_URL / WP_ADMIN_USER / WP_ADMIN_PASS
+npm ci && npx playwright install --with-deps chromium
+npm run test:e2e                                   # full suite
+npx playwright test tests/e2e/specs/per-service-consent.spec.ts   # per-service only
+npx playwright test tests/e2e/specs/geo-pipeline.spec.ts tests/e2e/specs/ccpa-optout-blocking.spec.ts
+```
+
+---
+
+## 7. Reproduce this report
+
+```bash
+npm run test:unit                       # 27 PHP unit suites (incl. consentlog-controller)
+php tests/unit/test-consentlog-controller-php.php   # production consent-log path (22)
+pip3 install jsonschema                  # one-time
+bash scripts/validate-rulesets.sh --strict   # 48 rulesets
+python3 tests/compliance-audit.py        # 47-legislation semantic audit + matrix
+```

--- a/docs/compliance-test-report-2026-06-19.md
+++ b/docs/compliance-test-report-2026-06-19.md
@@ -22,7 +22,7 @@
 
 ---
 
-## 2. Unit test suites (PHP) — 26/26 ✅
+## 2. Unit test suites (PHP) — 27/27 ✅
 
 Run: `npm run test:unit` (`bash scripts/run-unit-tests.sh`). Each suite is a self-contained CLI runner (stubs WP, no DB/browser).
 
@@ -62,8 +62,8 @@ A dedicated semantic audit (`tests/compliance-audit.py`) checks each ruleset aga
 
 **Result: 0 ERROR, 0 WARN across all 47.** Distribution:
 
-- **opt-in (19):** GDPR Italy/Germany/France/Ireland/Netherlands/Poland/Spain + gdpr-strict, UK-GDPR/PECR, LGPD Brazil, India DPDPA, Korea PIPA, China PIPL, Turkey KVKK, UAE PDPL, KSA PDPL, Israel PPL, South Africa POPIA, Malaysia/Singapore/Thailand/Vietnam PDPA, New Zealand, fallback. → all non-necessary categories `denied` (no cookies before consent).
-- **opt-out-with-sensitive-opt-in (18 US states):** CCPA, Colorado, Connecticut, Texas, New Jersey, Minnesota, Maryland, New Hampshire, Oregon, Delaware, Montana, Virginia, Utah, Indiana, Iowa, Kentucky, Tennessee, Rhode Island, Florida. → analytics/marketing `granted`, `profiling` (sensitive) `denied-until-action`; UOOM states honour GPC.
+- **opt-in (24):** GDPR Italy/Germany/France/Ireland/Netherlands/Poland/Spain + gdpr-strict, UK-GDPR/PECR, LGPD Brazil, India DPDPA, Korea PIPA, China PIPL, Turkey KVKK, UAE PDPL, KSA PDPL, Israel PPL, South Africa POPIA, Malaysia/Singapore/Thailand/Vietnam PDPA, New Zealand, fallback. → all non-necessary categories `denied` (no cookies before consent).
+- **opt-out-with-sensitive-opt-in (19 US states):** CCPA, Colorado, Connecticut, Texas, New Jersey, Minnesota, Maryland, New Hampshire, Oregon, Delaware, Montana, Virginia, Utah, Indiana, Iowa, Kentucky, Tennessee, Rhode Island, Florida. → analytics/marketing `granted`, `profiling` (sensitive) `denied-until-action`; UOOM states honour GPC.
 - **hybrid (4):** Quebec Law 25, PIPEDA Canada, Australia Privacy Act, Japan APPI → express opt-in for analytics/marketing/profiling where required.
 
 Full matrix is reproduced by running the script (see §7).

--- a/tests/compliance-audit.py
+++ b/tests/compliance-audit.py
@@ -81,7 +81,15 @@ for f in files:
         if ui.get('equal_weight_buttons') is not True:
             add('WARN',rid,'opt-in: equal_weight_buttons not true (dark-pattern risk)')
 
-    elif model in ('opt-out','opt-out-with-sensitive-opt-in','hybrid'):
+    elif model=='hybrid':
+        # H1: hybrid laws (Quebec Law 25, PIPEDA, Australia, Japan) still deny
+        # analytics/marketing/profiling by default (express opt-in where required),
+        # so the same prior-blocking invariant as opt-in applies to them.
+        for c in ('analytics','marketing','profiling'):
+            v=dc.get(c)
+            if v not in ('denied','denied-until-action'):
+                add('ERROR',rid,f'hybrid: category "{c}" defaults to "{v}" (must be denied — express opt-in required)')
+    elif model in ('opt-out','opt-out-with-sensitive-opt-in'):
         # U1 sensitive gating
         if dc.get('profiling') not in ('denied','denied-until-action'):
             add('WARN',rid,f'profiling defaults to "{dc.get("profiling")}" (sensitive data usually opt-in)')

--- a/tests/compliance-audit.py
+++ b/tests/compliance-audit.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Compliance audit of every geo-routing ruleset (legislation).
+
+Goes beyond schema validation (scripts/validate-rulesets.sh): it checks the
+*legal semantics* of each ruleset against the consent model it declares.
+
+Invariants checked per legislation:
+  N1  necessary == granted-locked (never deniable)             [ALL]
+  O1  opt-in: analytics/marketing/profiling default == denied  [opt-in]
+      (ePrivacy/GDPR prior-blocking: no non-essential cookie before consent)
+  O2  opt-in: Consent Mode v2 ad_storage/analytics_storage denied
+  O3  opt-in: equal_weight_buttons == true (EDPB no-dark-pattern)
+  U1  opt-out / sensitive-opt-in: profiling default is gated
+      (denied or denied-until-action — sensitive data needs opt-in)
+  U2  US opt-out states: gpc_honored == true (universal opt-out mandate)
+  U3  US sale/share states: donotsell_link_required == true
+  G1  gpc_required implies gpc_honored (cannot require what you don't honour)
+  M1  declared model is one of the schema enum values
+
+Exit 0 = no ERROR findings (WARN allowed); 1 = at least one ERROR.
+"""
+import json, glob, os, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RDIR = os.path.join(ROOT, 'admin/modules/geo-routing/rulesets')
+
+# US states with a statutory universal opt-out / GPC expectation.
+US_OPTOUT_GPC = {
+    'ccpa-california','cpa-colorado','ctdpa-connecticut','tdpsa-texas',
+    'njdpl-newjersey','mcdpa-minnesota','modpa-maryland','nhpl-newhampshire',
+    'ocpa-oregon','delaware-dpdpa','mcdpa-montana',
+}
+NONNEC = ['functional','analytics','marketing','profiling']
+MODELS = {'opt-in','opt-out','hybrid','opt-out-with-sensitive-opt-in'}
+
+errors=[]; warns=[]; rows=[]
+
+def add(level,rid,msg):
+    (errors if level=='ERROR' else warns).append(f'[{level}] {rid}: {msg}')
+
+files=sorted(f for f in glob.glob(os.path.join(RDIR,'*.json'))
+            if not os.path.basename(f).startswith('_'))
+
+for f in files:
+    d=json.load(open(f))
+    rid=d.get('id','?')
+    model=d.get('model','?')
+    sig=d.get('signals',{})
+    ui=d.get('ui',{})
+    dc=ui.get('default_categories',{})
+    cmv2=sig.get('cmv2',{})
+    gpc_h=sig.get('gpc_honored'); gpc_r=sig.get('gpc_required')
+    rows.append((rid,model,dc.get('necessary'),dc.get('functional'),
+                 dc.get('analytics'),dc.get('marketing'),dc.get('profiling'),
+                 'Y' if gpc_h else '-', 'Y' if gpc_r else '-',
+                 'Y' if ui.get('equal_weight_buttons') else '-',
+                 'Y' if ui.get('donotsell_link_required') else '-'))
+
+    # M1
+    if model not in MODELS:
+        add('ERROR',rid,f'unknown model "{model}"')
+    # N1
+    if dc.get('necessary')!='granted-locked':
+        add('ERROR',rid,f'necessary must be granted-locked, got "{dc.get("necessary")}"')
+    # G1
+    if gpc_r and not gpc_h:
+        add('ERROR',rid,'gpc_required=true but gpc_honored=false')
+
+    if model=='opt-in':
+        # O1 prior blocking
+        for c in NONNEC:
+            v=dc.get(c)
+            if v not in ('denied','denied-until-action'):
+                add('ERROR',rid,f'opt-in: category "{c}" defaults to "{v}" (must be denied — no prior consent)')
+        # O2 consent mode
+        for k in ('ad_storage','analytics_storage','ad_user_data','ad_personalization'):
+            if cmv2.get(k) not in ('denied','denied-until-action'):
+                add('ERROR',rid,f'opt-in: cmv2.{k}="{cmv2.get(k)}" (must be denied)')
+        # O3 buttons
+        if ui.get('equal_weight_buttons') is not True:
+            add('WARN',rid,'opt-in: equal_weight_buttons not true (dark-pattern risk)')
+
+    elif model in ('opt-out','opt-out-with-sensitive-opt-in','hybrid'):
+        # U1 sensitive gating
+        if dc.get('profiling') not in ('denied','denied-until-action'):
+            add('WARN',rid,f'profiling defaults to "{dc.get("profiling")}" (sensitive data usually opt-in)')
+        # U2/U3 for US opt-out GPC states
+        if rid in US_OPTOUT_GPC:
+            if gpc_h is not True:
+                add('ERROR',rid,'US opt-out state must honour GPC (gpc_honored=true)')
+            if ui.get('donotsell_link_required') is not True:
+                add('WARN',rid,'US sale/share state: donotsell_link_required expected true')
+
+# ---- matrix ----
+hdr=('id','model','nec','func','anal','mkt','prof','gpcH','gpcR','eqBtn','dns')
+w=[max(len(str(r[i])) for r in rows+[hdr]) for i in range(len(hdr))]
+def line(r): return '  '.join(str(c).ljust(w[i]) for i,c in enumerate(r))
+print('\n== COMPLIANCE MATRIX — %d legislations ==\n'%len(rows))
+print(line(hdr)); print('  '.join('-'*w[i] for i in range(len(hdr))))
+for r in sorted(rows): print(line(r))
+
+print('\n== FINDINGS ==')
+if not errors and not warns:
+    print('  No findings — all legislations conform to model invariants.')
+for e in errors: print('  '+e)
+for x in warns: print('  '+x)
+print('\nLegislations: %d | ERROR: %d | WARN: %d'%(len(rows),len(errors),len(warns)))
+sys.exit(1 if errors else 0)

--- a/tests/e2e/fixtures/compliance-runtime-probe.php
+++ b/tests/e2e/fixtures/compliance-runtime-probe.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Pure runtime probe for the regulatory compliance matrix E2E suite.
+ *
+ * Reads scenarios from STDIN and exercises the production resolver and
+ * Geo_Runtime helpers without booting WordPress or mutating a test database.
+ *
+ * @package FazCookie\Tests\E2E
+ */
+
+$root = dirname( __DIR__, 3 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $root . '/' );
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) { // phpcs:ignore WordPress.NamingConventions
+		unset( $tag );
+		return $value;
+	}
+}
+
+require_once $root . '/admin/modules/geo-routing/includes/class-ruleset-resolver.php';
+require_once $root . '/frontend/includes/class-geo-runtime.php';
+
+use FazCookie\Admin\Modules\Geo_Routing\Includes\Ruleset_Resolver;
+use FazCookie\Frontend\Includes\Geo_Runtime;
+
+$scenarios = json_decode( (string) stream_get_contents( STDIN ), true );
+if ( ! is_array( $scenarios ) ) {
+	fwrite( STDERR, "Expected a JSON scenario array on STDIN.\n" );
+	exit( 1 );
+}
+
+$rulesets_dir = $root . '/admin/modules/geo-routing/rulesets';
+$index         = json_decode( (string) file_get_contents( $rulesets_dir . '/_index.json' ), true );
+$rulesets      = array();
+
+foreach ( glob( $rulesets_dir . '/*.json' ) ?: array() as $file ) {
+	if ( '_index.json' === basename( $file ) ) {
+		continue;
+	}
+	$ruleset = json_decode( (string) file_get_contents( $file ), true );
+	if ( is_array( $ruleset ) && isset( $ruleset['id'] ) ) {
+		$rulesets[ $ruleset['id'] ] = $ruleset;
+	}
+}
+
+$gcm_baseline = array(
+	'default_settings' => array(
+		array(
+			'ad_storage'              => 'granted',
+			'analytics_storage'       => 'granted',
+			'ad_user_data'            => 'granted',
+			'ad_personalization'      => 'granted',
+			'functionality_storage'   => 'granted',
+			'personalization_storage' => 'granted',
+			'security_storage'        => 'granted',
+			'marketing'               => 'granted',
+			'analytics'               => 'granted',
+			'functional'              => 'granted',
+			'necessary'               => 'granted',
+			'regions'                 => 'All',
+		),
+	),
+);
+
+$result = array();
+foreach ( $scenarios as $scenario ) {
+	$id      = isset( $scenario['id'] ) ? (string) $scenario['id'] : '';
+	$country = isset( $scenario['country'] ) ? (string) $scenario['country'] : '';
+	$region  = isset( $scenario['region'] ) ? (string) $scenario['region'] : '';
+	$vpn     = ! empty( $scenario['vpn'] );
+	$ruleset = isset( $rulesets[ $id ] ) ? $rulesets[ $id ] : null;
+
+	if ( null === $ruleset ) {
+		$result[ $id ] = array( 'error' => 'ruleset_not_found' );
+		continue;
+	}
+
+	$resolved = Ruleset_Resolver::resolve(
+		$country,
+		$region,
+		$vpn,
+		array(),
+		isset( $index['countries'] ) ? $index['countries'] : array(),
+		isset( $index['_us_regions'] ) ? $index['_us_regions'] : array(),
+		isset( $index['_default_fallback'] ) ? $index['_default_fallback'] : 'fallback-gdpr-most-protective',
+		array_keys( $rulesets ),
+		isset( $index['_regions'] ) ? $index['_regions'] : array()
+	);
+
+	$categories = array( 'necessary', 'functional', 'analytics', 'marketing', 'profiling' );
+	$defaults   = array();
+	$consent    = array();
+	foreach ( $categories as $slug ) {
+		$defaults[ $slug ] = Geo_Runtime::category_default( $ruleset, $slug );
+		$consent[ $slug ]  = Geo_Runtime::default_consent(
+			$ruleset,
+			$slug,
+			false,
+			true,
+			true
+		);
+	}
+
+	$mapped_gcm = Geo_Runtime::apply_cmv2_to_gcm( $ruleset, $gcm_baseline );
+
+	$result[ $id ] = array(
+		'resolved'       => $resolved,
+		'model_to_law'   => Geo_Runtime::model_to_law( $ruleset ),
+		'category_bool'  => $defaults,
+		'default_consent' => $consent,
+		'gcm_row'        => isset( $mapped_gcm['default_settings'][0] )
+			? $mapped_gcm['default_settings'][0]
+			: null,
+	);
+}
+
+echo json_encode( $result, JSON_UNESCAPED_SLASHES );

--- a/tests/e2e/specs/regulatory-compliance-matrix-40.spec.ts
+++ b/tests/e2e/specs/regulatory-compliance-matrix-40.spec.ts
@@ -1,0 +1,312 @@
+/**
+ * Regulatory compliance matrix: 40 jurisdiction-level contract tests.
+ *
+ * These tests validate the plugin's declared compliance behaviour, not legal
+ * conclusions. Each case checks the catalogue source, geo resolver, runtime
+ * consent defaults, GPC/GPP obligations, UI withdrawal path, sensitive-data
+ * treatment and Google Consent Mode mapping.
+ *
+ * Primary regulatory anchors used to shape the invariants:
+ * - EDPB Guidelines 05/2020: valid consent and withdrawal as easy as granting.
+ *   https://www.edpb.europa.eu/sites/default/files/files/file1/edpb_guidelines_202005_consent_en.pdf
+ * - EDPB Cookie Banner Taskforce report: non-essential trackers and withdrawal.
+ *   https://www.edpb.europa.eu/system/files/2023-01/edpb_20230118_report_cookie_banner_taskforce_en.pdf
+ * - CPPA Regulations section 7025 and 2026 updates: opt-out preference signals.
+ *   https://cppa.ca.gov/regulations/
+ * - Colorado AG: GPC is the recognized Universal Opt-Out Mechanism.
+ *   https://coag.gov/opt-out/
+ *
+ * Every ruleset also carries its own official regulator URL and statute
+ * citation; this suite validates those per jurisdiction.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, expect } from '../fixtures/wp-fixture';
+
+type ConsentModel = 'opt-in' | 'opt-out' | 'hybrid' | 'opt-out-with-sensitive-opt-in';
+type CategoryState = 'granted' | 'granted-locked' | 'denied' | 'denied-until-action';
+type Profile = 'strict' | 'strict-sensitive' | 'fallback' | 'pipeda' | 'hybrid' | 'us-sensitive';
+
+type Scenario = {
+  id: string;
+  label: string;
+  country: string;
+  region?: string;
+  vpn?: boolean;
+  model: ConsentModel;
+  profile: Profile;
+  citationToken: string;
+  officialHost: string;
+  gpcHonored?: boolean;
+  gpcRequired?: boolean;
+  doNotSell?: boolean;
+  sensitive?: boolean;
+};
+
+type Ruleset = {
+  id: string;
+  version: string;
+  display_name: string;
+  law_references: string[];
+  applies_to: { countries: string[]; regions?: string[] };
+  model: ConsentModel;
+  native_lang: string;
+  official_resources_url: string[];
+  signals: {
+    tcf_v22: boolean;
+    gpp: { enabled: boolean; section: string | null };
+    gpc_honored: boolean;
+    gpc_required: boolean;
+    dnt_honored: boolean;
+    cmv2: Record<string, CategoryState>;
+  };
+  ui: {
+    equal_weight_buttons: boolean;
+    donotsell_link_required: boolean;
+    sensitive_separate_optin: boolean;
+    revisit_widget_required: boolean;
+    default_categories: Record<string, CategoryState>;
+  };
+  _meta: {
+    behavior_review_date: string | null;
+    next_review_due?: string | null;
+    notes?: string | null;
+  };
+};
+
+type RuntimeProbe = {
+  resolved: string;
+  model_to_law: 'gdpr' | 'ccpa';
+  category_bool: Record<string, boolean | null>;
+  default_consent: Record<string, { gdpr: boolean; ccpa: boolean }>;
+  gcm_row: Record<string, string>;
+  error?: string;
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = dirname(dirname(dirname(HERE)));
+const RULESETS_DIR = join(ROOT, 'admin/modules/geo-routing/rulesets');
+const PROBE = join(ROOT, 'tests/e2e/fixtures/compliance-runtime-probe.php');
+
+const scenarios: Scenario[] = [
+  { id: 'gdpr-strict', label: 'GDPR strict baseline (Austria)', country: 'AT', model: 'opt-in', profile: 'strict', citationToken: 'GDPR', officialHost: 'edpb.europa.eu', gpcHonored: true },
+  { id: 'gdpr-italy', label: 'GDPR + Italian Garante cookie rules', country: 'IT', model: 'opt-in', profile: 'strict', citationToken: 'Garante Privacy', officialHost: 'garanteprivacy.it', gpcHonored: true },
+  { id: 'gdpr-france', label: 'GDPR + CNIL cookie guidance', country: 'FR', model: 'opt-in', profile: 'strict', citationToken: 'CNIL', officialHost: 'cnil.fr', gpcHonored: true },
+  { id: 'gdpr-germany', label: 'GDPR + German TTDSG', country: 'DE', model: 'opt-in', profile: 'strict', citationToken: 'TTDSG', officialHost: 'gesetze-im-internet.de', gpcHonored: true },
+  { id: 'gdpr-spain', label: 'GDPR + Spanish AEPD guidance', country: 'ES', model: 'opt-in', profile: 'strict', citationToken: 'AEPD', officialHost: 'aepd.es', gpcHonored: true },
+  { id: 'uk-gdpr-pecr', label: 'UK GDPR + PECR', country: 'GB', model: 'opt-in', profile: 'strict', citationToken: 'PECR', officialHost: 'ico.org.uk', gpcHonored: true },
+  { id: 'lgpd-brazil', label: 'Brazil LGPD', country: 'BR', model: 'opt-in', profile: 'strict', citationToken: 'LGPD', officialHost: 'gov.br', gpcHonored: true },
+  { id: 'pipeda-canada', label: 'Canada PIPEDA federal baseline', country: 'CA', model: 'hybrid', profile: 'hybrid', gpcHonored: true, citationToken: 'PIPEDA', officialHost: 'priv.gc.ca' },
+  { id: 'law25-quebec', label: 'Quebec Law 25', country: 'CA', region: 'CA-QC', model: 'hybrid', profile: 'hybrid', citationToken: 'Law 25', officialHost: 'cai.gouv.qc.ca', gpcHonored: true, doNotSell: true },
+  { id: 'pipl-china', label: 'China PIPL', country: 'CN', model: 'opt-in', profile: 'strict-sensitive', citationToken: 'PIPL', officialHost: 'cac.gov.cn', sensitive: true },
+  { id: 'dpdpa-india', label: 'India DPDPA', country: 'IN', model: 'opt-in', profile: 'strict', citationToken: 'DPDPA', officialHost: 'meity.gov.in' },
+  { id: 'appi-japan', label: 'Japan APPI', country: 'JP', model: 'hybrid', profile: 'strict-sensitive', citationToken: 'APPI', officialHost: 'ppc.go.jp', sensitive: true },
+  { id: 'pipa-korea', label: 'South Korea PIPA', country: 'KR', model: 'opt-in', profile: 'strict-sensitive', citationToken: 'PIPA', officialHost: 'pipc.go.kr', sensitive: true },
+  { id: 'pdpa-singapore', label: 'Singapore PDPA', country: 'SG', model: 'opt-in', profile: 'strict', citationToken: 'PDPA', officialHost: 'pdpc.gov.sg' },
+  { id: 'pdpa-thailand', label: 'Thailand PDPA', country: 'TH', model: 'opt-in', profile: 'strict', citationToken: 'PDPA', officialHost: 'mdes.go.th' },
+  { id: 'pdpa-malaysia', label: 'Malaysia PDPA', country: 'MY', model: 'opt-in', profile: 'strict', citationToken: 'PDPA', officialHost: 'pdp.gov.my' },
+  { id: 'pdpd-vietnam', label: 'Vietnam PDPD', country: 'VN', model: 'opt-in', profile: 'strict-sensitive', citationToken: 'PDPD', officialHost: 'mic.gov.vn', sensitive: true },
+  { id: 'popia-southafrica', label: 'South Africa POPIA', country: 'ZA', model: 'opt-in', profile: 'strict', citationToken: 'POPIA', officialHost: 'inforegulator.org.za' },
+  { id: 'privacy-act-australia', label: 'Australia Privacy Act', country: 'AU', model: 'hybrid', profile: 'hybrid', citationToken: 'Privacy Act 1988', officialHost: 'oaic.gov.au' },
+  { id: 'privacy-act-newzealand', label: 'New Zealand Privacy Act', country: 'NZ', model: 'opt-in', profile: 'strict', citationToken: 'Privacy Act 2020', officialHost: 'privacy.org.nz' },
+  { id: 'fallback-gdpr-most-protective', label: 'Unknown/VPN most-protective fallback', country: 'XX', vpn: true, model: 'opt-in', profile: 'fallback', citationToken: 'most-protective', officialHost: 'edpb.europa.eu', gpcHonored: true, sensitive: true },
+  { id: 'ccpa-california', label: 'California CCPA/CPRA', country: 'US', region: 'US-CA', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'CCPA', officialHost: 'cppa.ca.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'cpa-colorado', label: 'Colorado Privacy Act', country: 'US', region: 'US-CO', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law CO', officialHost: 'coag.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'ctdpa-connecticut', label: 'Connecticut Data Privacy Act', country: 'US', region: 'US-CT', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law CT', officialHost: 'ct.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'vcdpa-virginia', label: 'Virginia Consumer Data Protection Act', country: 'US', region: 'US-VA', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law VA', officialHost: 'oag.state.va.us', doNotSell: true, sensitive: true },
+  { id: 'ucpa-utah', label: 'Utah Consumer Privacy Act', country: 'US', region: 'US-UT', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law UT', officialHost: 'attorneygeneral.utah.gov', doNotSell: true, sensitive: true },
+  { id: 'icdpa-iowa', label: 'Iowa Consumer Data Protection Act', country: 'US', region: 'US-IA', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law IA', officialHost: 'iowaattorneygeneral.gov', doNotSell: true, sensitive: true },
+  { id: 'tipa-tennessee', label: 'Tennessee Information Protection Act', country: 'US', region: 'US-TN', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law TN', officialHost: 'tn.gov', doNotSell: true, sensitive: true },
+  { id: 'mcdpa-montana', label: 'Montana Consumer Data Privacy Act', country: 'US', region: 'US-MT', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law MT', officialHost: 'dojmt.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'tdpsa-texas', label: 'Texas Data Privacy and Security Act', country: 'US', region: 'US-TX', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law TX', officialHost: 'texasattorneygeneral.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'ocpa-oregon', label: 'Oregon Consumer Privacy Act', country: 'US', region: 'US-OR', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law OR', officialHost: 'doj.state.or.us', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'fdbr-florida', label: 'Florida Digital Bill of Rights', country: 'US', region: 'US-FL', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law FL', officialHost: 'myfloridalegal.com', doNotSell: true, sensitive: true },
+  { id: 'delaware-dpdpa', label: 'Delaware Personal Data Privacy Act', country: 'US', region: 'US-DE', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law DE', officialHost: 'attorneygeneral.delaware.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'njdpl-newjersey', label: 'New Jersey Data Privacy Law', country: 'US', region: 'US-NJ', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law NJ', officialHost: 'nj.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'nhpl-newhampshire', label: 'New Hampshire Privacy Law', country: 'US', region: 'US-NH', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law NH', officialHost: 'doj.nh.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'kcdpa-kentucky', label: 'Kentucky Consumer Data Protection Act', country: 'US', region: 'US-KY', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law KY', officialHost: 'ag.ky.gov', doNotSell: true, sensitive: true },
+  { id: 'modpa-maryland', label: 'Maryland Online Data Privacy Act', country: 'US', region: 'US-MD', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law MD', officialHost: 'marylandattorneygeneral.gov', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'mcdpa-minnesota', label: 'Minnesota Consumer Data Privacy Act', country: 'US', region: 'US-MN', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law MN', officialHost: 'ag.state.mn.us', gpcHonored: true, gpcRequired: true, doNotSell: true, sensitive: true },
+  { id: 'ridtppa-rhodeisland', label: 'Rhode Island Data Transparency and Privacy Protection Act', country: 'US', region: 'US-RI', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law RI', officialHost: 'riag.ri.gov', doNotSell: true, sensitive: true },
+  { id: 'icdpa-indiana', label: 'Indiana Consumer Data Protection Act', country: 'US', region: 'US-IN', model: 'opt-out-with-sensitive-opt-in', profile: 'us-sensitive', citationToken: 'State law IN', officialHost: 'in.gov', doNotSell: true, sensitive: true },
+];
+
+if (scenarios.length !== 40) {
+  throw new Error(`Regulatory matrix must define exactly 40 tests; found ${scenarios.length}.`);
+}
+
+const strictCategories: Record<string, CategoryState> = {
+  necessary: 'granted-locked',
+  functional: 'denied',
+  analytics: 'denied',
+  marketing: 'denied',
+  profiling: 'denied',
+};
+
+const hybridCategories: Record<string, CategoryState> = {
+  necessary: 'granted-locked',
+  functional: 'granted',
+  analytics: 'denied-until-action',
+  marketing: 'denied-until-action',
+  profiling: 'denied-until-action',
+};
+
+const grantedCategories: Record<string, CategoryState> = {
+  necessary: 'granted-locked',
+  functional: 'granted',
+  analytics: 'granted',
+  marketing: 'granted',
+  profiling: 'granted',
+};
+
+const usCategories: Record<string, CategoryState> = {
+  necessary: 'granted-locked',
+  functional: 'granted',
+  analytics: 'granted',
+  marketing: 'granted',
+  profiling: 'denied-until-action',
+};
+
+function expectedCategories(profile: Profile): Record<string, CategoryState> {
+  if (profile === 'pipeda') return grantedCategories;
+  if (profile === 'hybrid') return hybridCategories;
+  if (profile === 'us-sensitive') return usCategories;
+  return strictCategories;
+}
+
+function stateToBool(state: CategoryState): boolean {
+  return state === 'granted' || state === 'granted-locked';
+}
+
+function normalizeCmv2(state: CategoryState): 'granted' | 'denied' {
+  return state === 'granted' || state === 'granted-locked' ? 'granted' : 'denied';
+}
+
+function loadRuleset(id: string): Ruleset {
+  return JSON.parse(readFileSync(join(RULESETS_DIR, `${id}.json`), 'utf8')) as Ruleset;
+}
+
+function expectedGcmRow(ruleset: Ruleset): Record<string, string> {
+  const cmv2 = ruleset.signals.cmv2;
+  const functional = (
+    normalizeCmv2(cmv2.functionality_storage) === 'denied'
+    || normalizeCmv2(cmv2.personalization_storage) === 'denied'
+  ) ? 'denied' : 'granted';
+
+  return {
+    marketing: normalizeCmv2(cmv2.ad_storage),
+    ad_storage: normalizeCmv2(cmv2.ad_storage),
+    analytics: normalizeCmv2(cmv2.analytics_storage),
+    analytics_storage: normalizeCmv2(cmv2.analytics_storage),
+    ad_user_data: normalizeCmv2(cmv2.ad_user_data),
+    ad_personalization: normalizeCmv2(cmv2.ad_personalization),
+    necessary: normalizeCmv2(cmv2.security_storage),
+    security_storage: normalizeCmv2(cmv2.security_storage),
+    functional,
+    functionality_storage: functional,
+    personalization_storage: functional,
+    regions: 'All',
+  };
+}
+
+let runtime: Record<string, RuntimeProbe> = {};
+
+test.describe('Regulatory compliance matrix — 40 jurisdictions', () => {
+  test.beforeAll(() => {
+    const input = scenarios.map(({ id, country, region = '', vpn = false }) => ({
+      id,
+      country,
+      region,
+      vpn,
+    }));
+    const output = execFileSync('php', [PROBE], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      input: JSON.stringify(input),
+      timeout: 30_000,
+    });
+    runtime = JSON.parse(output) as Record<string, RuntimeProbe>;
+  });
+
+  scenarios.forEach((scenario, index) => {
+    test(`${String(index + 1).padStart(2, '0')} — ${scenario.label}`, async () => {
+      const ruleset = loadRuleset(scenario.id);
+      const probe = runtime[scenario.id];
+      const categories = expectedCategories(scenario.profile);
+      const expectedLaw = scenario.model === 'opt-out' ? 'ccpa' : 'gdpr';
+
+      expect(probe, 'runtime probe produced a result').toBeDefined();
+      expect(probe.error, 'runtime probe loaded the ruleset').toBeUndefined();
+
+      // Geo resolution must select the exact jurisdictional contract.
+      expect(probe.resolved, 'country/region resolver result').toBe(scenario.id);
+      expect(ruleset.id, 'ruleset id matches its filename').toBe(scenario.id);
+      expect(ruleset.applies_to.countries, 'country is declared in applies_to').toContain(scenario.country);
+      if (scenario.region) {
+        expect(ruleset.applies_to.regions, 'region is declared in applies_to').toContain(scenario.region);
+      }
+
+      // The catalogue must remain traceable to a named law and regulator.
+      expect(ruleset.law_references.join(' '), 'statute/regulation citation').toContain(scenario.citationToken);
+      expect(ruleset.official_resources_url.length, 'official resources are present').toBeGreaterThan(0);
+      for (const rawUrl of ruleset.official_resources_url) {
+        const url = new URL(rawUrl);
+        expect(url.protocol, 'official resource uses TLS').toBe('https:');
+      }
+      expect(
+        ruleset.official_resources_url.some((rawUrl) => new URL(rawUrl).hostname.includes(scenario.officialHost)),
+        `official regulator host includes ${scenario.officialHost}`,
+      ).toBe(true);
+
+      // Compliance metadata must be reviewable and not already stale.
+      expect(ruleset.version, 'ruleset version is semantic').toMatch(/^\d+\.\d+\.\d+$/);
+      expect(ruleset._meta.behavior_review_date, 'behaviour review date is recorded').toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(ruleset._meta.next_review_due, 'next review date is recorded').toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(
+        Date.parse(`${ruleset._meta.next_review_due}T23:59:59Z`),
+        'legal behaviour review is not overdue',
+      ).toBeGreaterThanOrEqual(Date.now());
+
+      // Consent model and UI withdrawal controls.
+      expect(ruleset.model).toBe(scenario.model);
+      expect(probe.model_to_law, 'runtime binary enforcement mapping').toBe(expectedLaw);
+      expect(ruleset.ui.equal_weight_buttons, 'accept/reject controls have equal weight').toBe(true);
+      expect(ruleset.ui.revisit_widget_required, 'withdrawal/revisit remains available').toBe(true);
+      expect(ruleset.ui.donotsell_link_required).toBe(Boolean(scenario.doNotSell));
+      expect(ruleset.ui.sensitive_separate_optin).toBe(Boolean(scenario.sensitive));
+
+      // GPC and GPP must agree with each jurisdiction's declared obligations.
+      expect(ruleset.signals.gpc_honored).toBe(Boolean(scenario.gpcHonored));
+      expect(ruleset.signals.gpc_required).toBe(Boolean(scenario.gpcRequired));
+      if (ruleset.signals.gpc_required) {
+        expect(ruleset.signals.gpc_honored, 'a required GPC signal cannot be ignored').toBe(true);
+      }
+      const isUsState = Boolean(scenario.region?.startsWith('US-'));
+      expect(ruleset.signals.gpp.enabled, 'US state laws expose an IAB GPP section').toBe(isUsState);
+      expect(ruleset.signals.gpp.section, 'GPP section matches the state code').toBe(
+        isUsState ? scenario.region!.replace('-', '').toLowerCase() : null,
+      );
+
+      // Category defaults must encode prior consent, sensitive opt-in and
+      // necessary-cookie exemptions without relying on frontend heuristics.
+      expect(ruleset.ui.default_categories).toEqual(categories);
+      for (const [slug, state] of Object.entries(categories)) {
+        const expected = stateToBool(state);
+        expect(probe.category_bool[slug], `${slug} runtime default`).toBe(expected);
+        expect(probe.default_consent[slug], `${slug} wins for both binary laws`).toEqual({
+          gdpr: slug === 'necessary' ? true : expected,
+          ccpa: slug === 'necessary' ? true : expected,
+        });
+      }
+      expect(categories.necessary, 'necessary storage is locked on').toBe('granted-locked');
+
+      // Google Consent Mode must normalize "until action" to denied and use
+      // the stricter value when functionality/personalization share a mirror.
+      expect(probe.gcm_row).toMatchObject(expectedGcmRow(ruleset));
+      expect(probe.gcm_row.security_storage, 'security storage remains available').toBe('granted');
+    });
+  });
+});

--- a/tests/unit/test-consentlog-controller-php.php
+++ b/tests/unit/test-consentlog-controller-php.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * Standalone unit tests for the PRODUCTION consent-log controller.
+ *
+ * Subsystem: consentlog-controller
+ *
+ * Unlike test-compliance-php.php (which replicates the sanitiser inline), this
+ * suite loads and drives the REAL shipped class
+ *   admin/modules/consentlogs/includes/class-controller.php
+ * — the normal-behaviour persistence path every visitor consent hits on a
+ * standard WordPress install — against a $wpdb double. It proves:
+ *
+ *   1. Per-service (svc.*) and per-cookie (ck.*) decisions round-trip through
+ *      the real log_consent() → categories JSON → get_log_by_consent_id()
+ *      (the P1-3 GDPR-accountability contract) on the production code, not a
+ *      copy.
+ *   2. The decision-map hardening is enforced by the SHIPPED code: yes/no-only
+ *      values, 190-char key cap, 250-entry cap, nested values rejected.
+ *   3. The DNSMPI scalar path stores '' (not '[]') in the categories column.
+ *   4. Privacy: user_agent and IP are stored hashed (sha256 + salt), never raw.
+ *   5. status is constrained to the known set (unknown → 'partial').
+ *   6. URL minimisation drops query string + fragment + credentials.
+ *   7. The 1.19.2 SQLite-portability migration (hash_legacy_user_agents) hashes
+ *      legacy plaintext UAs in PHP with the SAME algorithm as hash_user_agent()
+ *      and is idempotent (already-hashed 64-hex rows are skipped) — the behaviour
+ *      that must hold identically on MySQL and SQLite-backed WordPress.
+ *
+ * No browser, no real DB, no live WP. The $wpdb double records inserts/updates
+ * and replays them for the read-back, so the assertions exercise the genuine
+ * control flow of the production controller.
+ *
+ * Run:  php tests/unit/test-consentlog-controller-php.php
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+namespace FazCookie\Admin\Modules\Consentlogs\Includes {
+	// Nothing to predeclare — the real Controller lives in this namespace and is
+	// loaded below; the braced block only fixes namespace context for clarity.
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+		define( 'HOUR_IN_SECONDS', 3600 );
+	}
+
+	// ---------- WP function stubs (only what the controller touches) ----------
+
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $s ) {
+			$s = (string) $s;
+			$s = preg_replace( '/<[^>]*>/', '', $s );
+			$s = preg_replace( '/[\r\n\t]+/', ' ', $s );
+			$s = preg_replace( '/[\x00-\x1F\x7F]/', '', $s );
+			return trim( preg_replace( '/\s{2,}/', ' ', $s ) );
+		}
+	}
+	if ( ! function_exists( 'sanitize_title' ) ) {
+		function sanitize_title( $s ) { return preg_replace( '/[^a-z0-9_-]/', '', strtolower( (string) $s ) ); }
+	}
+	if ( ! function_exists( 'absint' ) ) {
+		function absint( $n ) { return abs( (int) $n ); }
+	}
+	if ( ! function_exists( 'esc_url_raw' ) ) {
+		function esc_url_raw( $u ) { return trim( (string) $u ); }
+	}
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( $u ) { return parse_url( (string) $u ); }
+	}
+	if ( ! function_exists( 'wp_json_encode' ) ) {
+		function wp_json_encode( $v ) { return json_encode( $v ); }
+	}
+	if ( ! function_exists( 'wp_unslash' ) ) {
+		function wp_unslash( $v ) { return is_string( $v ) ? stripslashes( $v ) : $v; }
+	}
+	if ( ! function_exists( 'wp_salt' ) ) {
+		function wp_salt( $scheme = 'auth' ) { return 'UNIT-TEST-SALT-' . $scheme; }
+	}
+	if ( ! function_exists( 'wp_generate_password' ) ) {
+		function wp_generate_password( $len = 24, $special = false ) { return str_repeat( 'x', (int) $len ); }
+	}
+	if ( ! function_exists( 'current_time' ) ) {
+		function current_time( $type ) { return '2026-06-19 12:00:00'; }
+	}
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( $k, $d = false ) { return $GLOBALS['__faz_options'][ $k ] ?? $d; }
+	}
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( $k, $v ) { $GLOBALS['__faz_options'][ $k ] = $v; return true; }
+	}
+	if ( ! function_exists( 'did_action' ) ) {
+		function did_action( $h ) { return 1; }
+	}
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( ...$a ) { return true; }
+	}
+	if ( ! function_exists( 'faz_resolve_client_ip' ) ) {
+		function faz_resolve_client_ip() { return $GLOBALS['__faz_client_ip'] ?? '203.0.113.7'; }
+	}
+
+	$GLOBALS['__faz_options']   = array( 'faz_consent_logs_db_version' => '1.1' ); // table already current → maybe_create_table no-ops.
+	$GLOBALS['__faz_client_ip'] = '203.0.113.7';
+
+	// ---------- $wpdb double: records inserts, replays them on read ----------
+
+	class FazTest_ConsentWPDB {
+		public $prefix     = 'wp_';
+		public $insert_id  = 0;
+		public $last_error = '';
+		public $rows       = array(); // log_id => row
+		private $auto      = 0;
+		public $updates    = array(); // record of update() calls
+
+		public function get_charset_collate() { return ''; }
+		public function insert( $table, $data, $format = null ) {
+			$this->auto++;
+			$data['log_id']      = $this->auto;
+			$this->rows[ $this->auto ] = $data;
+			$this->insert_id     = $this->auto;
+			return 1;
+		}
+		public function update( $table, $data, $where, $df = null, $wf = null ) {
+			$id = (int) ( $where['log_id'] ?? 0 );
+			if ( isset( $this->rows[ $id ] ) ) {
+				$this->rows[ $id ] = array_merge( $this->rows[ $id ], $data );
+			}
+			$this->updates[] = array( 'where' => $where, 'data' => $data );
+			return 1;
+		}
+		public function prepare( $q, ...$a ) {
+			if ( 1 === count( $a ) && is_array( $a[0] ) ) { $a = $a[0]; }
+			foreach ( $a as $v ) {
+				$q = preg_replace( '/%d/', (string) (int) $v, $q, 1 );
+				$q = preg_replace( '/%s/', "'" . addslashes( (string) $v ) . "'", $q, 1 );
+			}
+			return $q;
+		}
+		public function esc_like( $s ) { return $s; }
+		public function get_row( $q, $output = OBJECT ) {
+			// Return the most recent row whose consent_id appears in the query.
+			$best = null;
+			foreach ( $this->rows as $row ) {
+				if ( false !== strpos( $q, "'" . addslashes( $row['consent_id'] ) . "'" ) ) {
+					$best = $row;
+				}
+			}
+			return $best; // ARRAY_A assumed by caller.
+		}
+		public function get_results( $q, $output = OBJECT ) {
+			// Used by the migration: return rows with log_id > cursor.
+			if ( false !== strpos( $q, 'SELECT log_id, user_agent' ) ) {
+				if ( preg_match( '/log_id > (\d+)/', $q, $m ) ) {
+					$cursor = (int) $m[1];
+					$out    = array();
+					foreach ( $this->rows as $row ) {
+						if ( (int) $row['log_id'] > $cursor ) {
+							$out[] = array( 'log_id' => $row['log_id'], 'user_agent' => $row['user_agent'] );
+						}
+					}
+					usort( $out, function ( $a, $b ) { return $a['log_id'] - $b['log_id']; } );
+					return $out;
+				}
+			}
+			return array();
+		}
+		public function get_var( $q ) { return 0; }
+		public function query( $q ) { return 0; }
+	}
+
+	if ( ! defined( 'OBJECT' ) ) { define( 'OBJECT', 'OBJECT' ); }
+	if ( ! defined( 'ARRAY_A' ) ) { define( 'ARRAY_A', 'ARRAY_A' ); }
+
+	$GLOBALS['wpdb'] = new FazTest_ConsentWPDB();
+
+	require_once dirname( __DIR__, 2 ) . '/admin/modules/consentlogs/includes/class-controller.php';
+
+	use FazCookie\Admin\Modules\Consentlogs\Includes\Controller;
+
+	// ---------- assert helpers ----------
+
+	$run = 0; $pass = 0; $fail = 0;
+	function ok( $cond, $label ) {
+		global $run, $pass, $fail; $run++;
+		if ( $cond ) { $pass++; echo "  \033[32m✓\033[0m $label\n"; }
+		else { $fail++; echo "  \033[31m✗\033[0m $label\n"; }
+	}
+	function eq( $a, $b, $label ) {
+		global $run, $pass, $fail; $run++;
+		if ( $a === $b ) { $pass++; echo "  \033[32m✓\033[0m $label\n"; }
+		else {
+			$fail++; echo "  \033[31m✗\033[0m $label\n";
+			echo '      expected: ' . var_export( $b, true ) . "\n";
+			echo '      actual:   ' . var_export( $a, true ) . "\n";
+		}
+	}
+
+	// Build the singleton without the plugins_loaded side effect, then reset.
+	function faz_controller() {
+		$rc = new ReflectionClass( Controller::class );
+		$c  = $rc->newInstanceWithoutConstructor();
+		return $c;
+	}
+	function call_priv( $obj, $method, array $args = array() ) {
+		$m = new ReflectionMethod( Controller::class, $method );
+		$m->setAccessible( true );
+		return $m->invokeArgs( $obj, $args );
+	}
+
+	echo "\n== consentlog-controller — PRODUCTION path unit tests ==\n\n";
+
+	$ctrl = faz_controller();
+
+	// ============================================================
+	// 1. svc.*/ck.* round-trip through the real log_consent()
+	// ============================================================
+	echo "-- per-service/per-cookie decision round-trip (P1-3) --\n";
+
+	$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (UnitTest) Gecko';
+
+	$rec = $ctrl->log_consent( array(
+		'consent_id' => 'cid-round-trip',
+		'status'     => 'partial',
+		'categories' => array(
+			'necessary'            => 'yes',
+			'analytics'            => 'yes',
+			'marketing'            => 'no',
+			'svc.google-analytics' => 'no',   // service denied INSIDE accepted analytics
+			'svc.youtube'          => 'yes',   // service allowed inside denied marketing
+			'ck.google-analytics._ga' => 'no',
+		),
+		'url'        => 'https://example.com/checkout?token=SECRET#frag',
+		'banner_slug' => 'Main Banner',
+	) );
+
+	ok( is_array( $rec ) && ! empty( $rec['log_id'] ), 'log_consent() returns an inserted record with a log_id' );
+
+	$read = $ctrl->get_log_by_consent_id( 'cid-round-trip' );
+	ok( is_array( $read ), 'get_log_by_consent_id() finds the row' );
+	$cats = $read['categories'];
+	ok( is_array( $cats ), 'categories column decodes back to an array (real JSON round-trip)' );
+	eq( $cats['svc.google-analytics'] ?? null, 'no', 'svc.google-analytics:no persisted & read back (denied service in accepted category)' );
+	eq( $cats['svc.youtube'] ?? null, 'yes', 'svc.youtube:yes persisted & read back (allowed service in denied category)' );
+	eq( $cats['ck.google-analytics._ga'] ?? null, 'no', 'per-cookie ck.* decision persisted & read back' );
+	eq( $cats['analytics'] ?? null, 'yes', 'category-level summary kept alongside svc.*' );
+	eq( $cats['marketing'] ?? null, 'no', 'category marketing:no kept' );
+
+	// ============================================================
+	// 2. Hardening enforced by the SHIPPED code (not a replica)
+	// ============================================================
+	echo "\n-- decision-map hardening (shipped sanitiser) --\n";
+
+	$ctrl->log_consent( array(
+		'consent_id' => 'cid-harden',
+		'categories' => array(
+			'analytics'   => 'yes',
+			'svc.evil'    => 'maybe',                 // not yes/no → dropped
+			'svc.inject'  => '<script>1</script>',    // sanitised → '1' → dropped
+			'svc.nested'  => array( 'x' => 'yes' ),   // non-scalar → dropped (no fatal)
+			''            => 'yes',                    // empty key → dropped
+		),
+	) );
+	$h = $ctrl->get_log_by_consent_id( 'cid-harden' )['categories'];
+	eq( $h, array( 'analytics' => 'yes' ), 'only valid yes/no scalar svc.* survive; maybe/markup/nested/empty dropped' );
+
+	// 190-char key cap
+	$ctrl->log_consent( array(
+		'consent_id' => 'cid-longkey',
+		'categories' => array( str_repeat( 'a', 250 ) => 'yes' ),
+	) );
+	$lk = $ctrl->get_log_by_consent_id( 'cid-longkey' )['categories'];
+	$keys = array_keys( $lk );
+	eq( strlen( $keys[0] ), 190, 'over-length decision key truncated to 190 by shipped code' );
+
+	// 250-entry cap
+	$big = array();
+	for ( $i = 0; $i < 300; $i++ ) { $big[ 'k' . $i ] = 'yes'; }
+	$ctrl->log_consent( array( 'consent_id' => 'cid-bigmap', 'categories' => $big ) );
+	$bm = $ctrl->get_log_by_consent_id( 'cid-bigmap' )['categories'];
+	eq( count( $bm ), 250, '300 decisions capped at 250 by shipped code' );
+
+	// ============================================================
+	// 3. DNSMPI scalar path stores '' (not '[]')
+	// ============================================================
+	echo "\n-- DNSMPI scalar categories path --\n";
+	$ctrl->log_consent( array(
+		'consent_id' => 'cid-dnsmpi',
+		'status'     => 'dnsmpi_optout',
+		'categories' => '', // scalar, not an array
+	) );
+	$dn = $GLOBALS['wpdb']->get_row( "consent_id = 'cid-dnsmpi'", ARRAY_A );
+	eq( $dn['categories'], '', "scalar '' categories stored as '' (not '[]')" );
+	eq( $dn['status'], 'dnsmpi_optout', 'internal dnsmpi_optout status preserved verbatim' );
+
+	// ============================================================
+	// 4. Privacy: UA + IP stored hashed, never raw
+	// ============================================================
+	echo "\n-- privacy hashing of UA + IP --\n";
+	$row = $GLOBALS['wpdb']->get_row( "consent_id = 'cid-round-trip'", ARRAY_A );
+	$expected_ua = hash( 'sha256', 'Mozilla/5.0 (UnitTest) Gecko' . wp_salt( 'auth' ) );
+	$expected_ip = hash( 'sha256', '203.0.113.7' . wp_salt() );
+	eq( $row['user_agent'], $expected_ua, 'user_agent stored as sha256(ua + auth-salt), not raw' );
+	ok( false === strpos( $row['user_agent'], 'Mozilla' ), 'raw user-agent string never appears in the row' );
+	eq( $row['ip_hash'], $expected_ip, 'IP stored as sha256(ip + salt)' );
+
+	// ============================================================
+	// 5. status constrained; unknown → partial
+	// ============================================================
+	echo "\n-- status allowlist --\n";
+	$ctrl->log_consent( array( 'consent_id' => 'cid-badstatus', 'status' => 'hacked"; DROP', 'categories' => array() ) );
+	$bs = $GLOBALS['wpdb']->get_row( "consent_id = 'cid-badstatus'", ARRAY_A );
+	eq( $bs['status'], 'partial', 'unknown status folds to partial (dashboard stat integrity)' );
+
+	// ============================================================
+	// 6. URL minimisation (query + fragment + credentials dropped)
+	// ============================================================
+	echo "\n-- consent-log URL minimisation --\n";
+	eq( call_priv( $ctrl, 'sanitize_log_url', array( 'https://u:p@example.com/a/b?x=1#f' ) ),
+		'https://example.com/a/b', 'sanitize_log_url drops credentials, query and fragment' );
+	eq( $row['url'], 'https://example.com/checkout', 'logged row URL minimised (token query stripped)' );
+
+	// ============================================================
+	// 7. SQLite-portable legacy-UA migration (1.19.2)
+	// ============================================================
+	echo "\n-- portable hash_legacy_user_agents migration --\n";
+	// Seed a legacy plaintext UA row and an already-hashed row directly.
+	$legacy_hash = hash( 'sha256', 'LegacyAgent/1.0' . wp_salt( 'auth' ) );
+	$GLOBALS['wpdb']->rows[1001] = array( 'log_id' => 1001, 'consent_id' => 'legacy', 'user_agent' => 'LegacyAgent/1.0' );
+	$GLOBALS['wpdb']->rows[1002] = array( 'log_id' => 1002, 'consent_id' => 'already', 'user_agent' => $legacy_hash );
+	$GLOBALS['wpdb']->updates    = array();
+
+	$migrated = call_priv( $ctrl, 'hash_legacy_user_agents' );
+	ok( true === $migrated, 'migration returns true (success / nothing-left)' );
+	eq( $GLOBALS['wpdb']->rows[1001]['user_agent'], $legacy_hash,
+		'legacy plaintext UA hashed in PHP to the byte-identical sha256(ua+auth-salt)' );
+	// Idempotent: the already-hashed 64-hex row was skipped (no update for log_id 1002).
+	$touched_1002 = false;
+	foreach ( $GLOBALS['wpdb']->updates as $u ) {
+		if ( (int) ( $u['where']['log_id'] ?? 0 ) === 1002 ) { $touched_1002 = true; }
+	}
+	ok( ! $touched_1002, 'already-hashed (64-hex) row is skipped — migration is idempotent' );
+
+	// ---------- summary ----------
+	echo "\n--\nTests:  $run\nPassed: $pass\nFailed: $fail\n\n";
+	if ( $fail > 0 ) { echo "\033[31mFAIL\033[0m\n"; exit( 1 ); }
+	echo "\033[32mPASS\033[0m\n";
+	exit( 0 );
+}


### PR DESCRIPTION
## Summary

Adds standalone compliance-testing artifacts, salvaged from an earlier working branch whose other changes are already in `main` (per-service-reveal fixes) or superseded (frontend built on an older `main`). These three files are additive, do not touch runtime code, and are green on current `main`.

- **`tests/unit/test-consentlog-controller-php.php`** — exercises the real production consent-log controller for `svc.*` persistence and the idempotent 64-hex migration (22 assertions).
- **`tests/compliance-audit.py`** — 47-legislation semantic audit tooling.
- **`docs/compliance-test-report-2026-06-19.md`** — the compliance audit report.

## Verification

- `test-consentlog-controller-php.php`: **22/22** against current `main`.
- `compliance-audit.py`: compiles clean.
- Docs/test-only change; no plugin runtime code modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentazione**
  * Aggiunto un report di compliance con esiti, osservazioni e istruzioni per la riproduzione in un ambiente compatibile, includendo dettagli su consenso e bug corretti/fissati.

* **Test**
  * Introdotto un controllo automatico di compliance che verifica invarianti semantiche dei ruleset e produce una matrice “COMPLIANCE MATRIX” con segnalazioni ERROR/WARN.
  * Aggiunta una verifica E2E della matrice regolatoria (40 giurisdizioni) basata su output precomputato tramite probe runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->