### PR TITLE
Admin watchdog notice when an ad blocker blocks cookie-policy.js / cookies.js

### DIFF
--- a/admin/assets/js/pages/cookie-policy.js
+++ b/admin/assets/js/pages/cookie-policy.js
@@ -10,6 +10,12 @@
 (function () {
 	'use strict';
 
+	// Signal that this file actually loaded and ran. The view renders an inline
+	// watchdog that shows a "your browser blocked this script" notice if this
+	// flag is still unset after a short delay — the case when an ad blocker /
+	// browser shield blocks cookie-policy.js by filename (it contains "cookie").
+	window.fazCpBooted = true;
+
 	var root = document.getElementById('faz-cookie-policy-app');
 	if (!root) { return; }
 

--- a/admin/assets/js/pages/cookies.js
+++ b/admin/assets/js/pages/cookies.js
@@ -4,6 +4,11 @@
 (function () {
 	'use strict';
 
+	// Signal that this file loaded and ran, for the view's blocked-script
+	// watchdog (cookies.js can be blocked by ad blockers / browser shields that
+	// match its "cookie" filename, leaving the page silently inert).
+	window.fazCookiesBooted = true;
+
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
 	function __(key, fallback) {
 		var parts = key.split('.');

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -930,6 +930,67 @@ class Admin {
 						filemtime( $page_js ),
 						true
 					);
+
+					// Blocked-script watchdog for the two pages whose page script
+					// filename contains "cookie" (cookie-policy.js, cookies.js) and
+					// is therefore liable to be blocked by ad blockers / browser
+					// privacy shields matching that name. The view ships a hidden
+					// "notice notice-error" element plus an aria-live <p> and a
+					// <template> carrying the message; this inline script reveals
+					// the notice (and announces it) only after the window 'load'
+					// lifecycle completes AND the boot flag is still unset — so a
+					// merely slow-but-not-blocked footer script never trips a false
+					// positive — and it re-hides the notice if the flag later turns
+					// true. Registered via wp_add_inline_script() (not an inline
+					// <script> in the view) to stay Plugin-Check clean, mirroring
+					// the languages.php pattern.
+					$faz_watchdog = array(
+						'cookie-policy' => array( 'flag' => 'fazCpBooted', 'notice' => 'faz-cp-script-blocked' ),
+						'cookies'       => array( 'flag' => 'fazCookiesBooted', 'notice' => 'faz-cookies-script-blocked' ),
+					);
+					if ( isset( $faz_watchdog[ $page['view'] ] ) ) {
+						$faz_wd  = $faz_watchdog[ $page['view'] ];
+						$faz_cfg = wp_json_encode(
+							array(
+								'flag'   => $faz_wd['flag'],
+								'notice' => $faz_wd['notice'],
+							)
+						);
+						$faz_wd_js = '( function () {' .
+							'var cfg = ' . $faz_cfg . ';' .
+							'var notice = document.getElementById( cfg.notice );' .
+							'if ( ! notice ) { return; }' .
+							'var msg = notice.querySelector( "[aria-live]" );' .
+							'var tpl = notice.querySelector( "template" );' .
+							'function booted() { return !! window[ cfg.flag ]; }' .
+							// Reveal: populate the aria-live region (content change drives
+							// the screen-reader announcement) and show the error notice.
+							'function reveal() {' .
+								'if ( booted() ) { return; }' .
+								'if ( msg && tpl && ! msg.textContent ) { msg.textContent = tpl.innerHTML; }' .
+								'notice.style.display = "";' .
+							'}' .
+							// Recovery: if the script later boots, clear the announcement
+							// and hide the notice again so it never persists falsely.
+							'function clear() {' .
+								'notice.style.display = "none";' .
+								'if ( msg ) { msg.textContent = ""; }' .
+							'}' .
+							// Decide once the page-load lifecycle has settled: by the time
+							// window "load" fires, every enqueued footer script has had its
+							// chance to run, so an unset flag now means genuinely blocked
+							// (not merely slow). Re-check shortly after as a last-resort
+							// fallback and to catch a late boot for recovery.
+							'function decide() { if ( booted() ) { clear(); } else { reveal(); } }' .
+							'function arm() {' .
+								'decide();' .
+								'window.setTimeout( decide, 1500 );' .
+							'}' .
+							'if ( document.readyState === "complete" ) { arm(); }' .
+							'else { window.addEventListener( "load", arm ); }' .
+						'}() );';
+						wp_add_inline_script( 'faz-page-' . $page['view'], $faz_wd_js, 'after' );
+					}
 				}
 
 				// Pass theme presets so banner.js can reset colours on theme switch.

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -967,7 +967,11 @@ class Admin {
 							// the screen-reader announcement) and show the error notice.
 							'function reveal() {' .
 								'if ( booted() ) { return; }' .
-								'if ( msg && tpl && ! msg.textContent ) { msg.textContent = tpl.innerHTML; }' .
+								// Read the parsed template content (a DocumentFragment lives in
+								// .content) as raw text — tpl.innerHTML would re-serialize
+								// entities and .textContent would double-escape any &, <, > in a
+								// localized string. tpl.textContent is empty for a <template>.
+								'if ( msg && tpl && ! msg.textContent ) { msg.textContent = tpl.content.textContent; }' .
 								'notice.style.display = "";' .
 							'}' .
 							// Recovery: if the script later boots, clear the announcement

--- a/admin/views/cookie-policy.php
+++ b/admin/views/cookie-policy.php
@@ -19,6 +19,28 @@ $rest_url   = esc_url( rest_url( 'faz/v1/cookie-policy/' ) );
      data-faz-rest-url="<?php echo esc_url( $rest_url ); ?>"
      data-faz-rest-nonce="<?php echo esc_attr( $rest_nonce ); ?>">
 
+	<?php /* Blocked-script watchdog: cookie-policy.js sets window.fazCpBooted the
+		instant it runs. When an ad blocker or browser privacy shield blocks that
+		file by name — its filename contains "cookie", which some filter lists
+		match — the script never runs, so Save and Preview silently do nothing and
+		the only symptom is "the button does not work". This server-rendered notice
+		(hidden by default) is revealed by a tiny inline script when the flag is
+		still unset shortly after load. Inline first-party script is not blocked the
+		way the external .js file is, so the message reliably reaches the user. */ ?>
+	<div id="faz-cp-script-blocked" class="notice notice-error inline" role="alert" style="display:none;">
+		<p><?php esc_html_e( 'The Cookie Policy editor did not load, so Save and Preview will not work on this page. A browser privacy shield or ad blocker is most likely blocking its script (the filename contains the word “cookie”, which some block lists match). Allow scripts for /wp-admin in this browser — or pause the shield for this page — then reload.', 'faz-cookie-manager' ); ?></p>
+	</div>
+	<script>
+	( function () {
+		window.setTimeout( function () {
+			if ( ! window.fazCpBooted ) {
+				var n = document.getElementById( 'faz-cp-script-blocked' );
+				if ( n ) { n.style.display = ''; }
+			}
+		}, 2500 );
+	}() );
+	</script>
+
 	<?php /* onsubmit="return false" is a no-JS / broken-JS safety net: the form is
 		saved entirely by cookie-policy.js (it preventDefault()s and POSTs via REST).
 		If that script never runs — a JS conflict from another plugin/theme, or a

--- a/admin/views/cookie-policy.php
+++ b/admin/views/cookie-policy.php
@@ -24,22 +24,15 @@ $rest_url   = esc_url( rest_url( 'faz/v1/cookie-policy/' ) );
 		file by name — its filename contains "cookie", which some filter lists
 		match — the script never runs, so Save and Preview silently do nothing and
 		the only symptom is "the button does not work". This server-rendered notice
-		(hidden by default) is revealed by a tiny inline script when the flag is
-		still unset shortly after load. Inline first-party script is not blocked the
-		way the external .js file is, so the message reliably reaches the user. */ ?>
-	<div id="faz-cp-script-blocked" class="notice notice-error inline" role="alert" style="display:none;">
-		<p><?php esc_html_e( 'The Cookie Policy editor did not load, so Save and Preview will not work on this page. A browser privacy shield or ad blocker is most likely blocking its script (the filename contains the word “cookie”, which some block lists match). Allow scripts for /wp-admin in this browser — or pause the shield for this page — then reload.', 'faz-cookie-manager' ); ?></p>
+		(hidden by default) is revealed by the watchdog inline script registered via
+		wp_add_inline_script() in class-admin.php (handle faz-page-cookie-policy) when
+		the page-load lifecycle completes and the boot flag is still unset. The
+		notice carries an aria-live region so the reveal is announced to screen
+		readers when the inner status text is populated. */ ?>
+	<div id="faz-cp-script-blocked" class="notice notice-error inline" style="display:none;">
+		<p id="faz-cp-script-blocked-msg" aria-live="assertive" aria-atomic="true"></p>
+		<template id="faz-cp-script-blocked-text"><?php esc_html_e( 'The Cookie Policy editor did not load, so Save and Preview will not work on this page. A browser privacy shield or ad blocker is most likely blocking its script (the filename contains the word “cookie”, which some block lists match). Allow scripts for /wp-admin in this browser — or pause the shield for this page — then reload.', 'faz-cookie-manager' ); ?></template>
 	</div>
-	<script>
-	( function () {
-		window.setTimeout( function () {
-			if ( ! window.fazCpBooted ) {
-				var n = document.getElementById( 'faz-cp-script-blocked' );
-				if ( n ) { n.style.display = ''; }
-			}
-		}, 2500 );
-	}() );
-	</script>
 
 	<?php /* onsubmit="return false" is a no-JS / broken-JS safety net: the form is
 		saved entirely by cookie-policy.js (it preventDefault()s and POSTs via REST).

--- a/admin/views/cookies.php
+++ b/admin/views/cookies.php
@@ -12,22 +12,15 @@ defined( 'ABSPATH' ) || exit;
 		instant it runs. An ad blocker or browser privacy shield can block that file
 		by name (it contains "cookie"), leaving this page silently inert (categories,
 		add-cookie and scan buttons do nothing). This server-rendered notice, hidden
-		by default and revealed by a tiny inline script if the flag stays unset, tells
-		the user why. Inline first-party script is not blocked the way the external
-		.js file is. */ ?>
-	<div id="faz-cookies-script-blocked" class="notice notice-error inline" role="alert" style="display:none;">
-		<p><?php esc_html_e( 'The Cookies page editor did not load, so its buttons will not work. A browser privacy shield or ad blocker is most likely blocking its script (the filename contains the word “cookie”, which some block lists match). Allow scripts for /wp-admin in this browser — or pause the shield for this page — then reload.', 'faz-cookie-manager' ); ?></p>
+		by default, is revealed by the watchdog inline script registered via
+		wp_add_inline_script() in class-admin.php (handle faz-page-cookies) when the
+		page-load lifecycle completes and the boot flag is still unset. The notice
+		carries an aria-live region so the reveal is announced to screen readers when
+		the inner status text is populated. */ ?>
+	<div id="faz-cookies-script-blocked" class="notice notice-error inline" style="display:none;">
+		<p id="faz-cookies-script-blocked-msg" aria-live="assertive" aria-atomic="true"></p>
+		<template id="faz-cookies-script-blocked-text"><?php esc_html_e( 'The Cookies page editor did not load, so its buttons will not work. A browser privacy shield or ad blocker is most likely blocking its script (the filename contains the word “cookie”, which some block lists match). Allow scripts for /wp-admin in this browser — or pause the shield for this page — then reload.', 'faz-cookie-manager' ); ?></template>
 	</div>
-	<script>
-	( function () {
-		window.setTimeout( function () {
-			if ( ! window.fazCookiesBooted ) {
-				var n = document.getElementById( 'faz-cookies-script-blocked' );
-				if ( n ) { n.style.display = ''; }
-			}
-		}, 2500 );
-	}() );
-	</script>
 
 	<!-- Cookie Categories Editor -->
 	<div class="faz-card" style="margin-bottom:16px;">

--- a/admin/views/cookies.php
+++ b/admin/views/cookies.php
@@ -8,6 +8,27 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 <div id="faz-cookies">
+	<?php /* Blocked-script watchdog: cookies.js sets window.fazCookiesBooted the
+		instant it runs. An ad blocker or browser privacy shield can block that file
+		by name (it contains "cookie"), leaving this page silently inert (categories,
+		add-cookie and scan buttons do nothing). This server-rendered notice, hidden
+		by default and revealed by a tiny inline script if the flag stays unset, tells
+		the user why. Inline first-party script is not blocked the way the external
+		.js file is. */ ?>
+	<div id="faz-cookies-script-blocked" class="notice notice-error inline" role="alert" style="display:none;">
+		<p><?php esc_html_e( 'The Cookies page editor did not load, so its buttons will not work. A browser privacy shield or ad blocker is most likely blocking its script (the filename contains the word “cookie”, which some block lists match). Allow scripts for /wp-admin in this browser — or pause the shield for this page — then reload.', 'faz-cookie-manager' ); ?></p>
+	</div>
+	<script>
+	( function () {
+		window.setTimeout( function () {
+			if ( ! window.fazCookiesBooted ) {
+				var n = document.getElementById( 'faz-cookies-script-blocked' );
+				if ( n ) { n.style.display = ''; }
+			}
+		}, 2500 );
+	}() );
+	</script>
+
 	<!-- Cookie Categories Editor -->
 	<div class="faz-card" style="margin-bottom:16px;">
 		<div class="faz-card-header">

--- a/tests/e2e/specs/admin-blocked-script-watchdog.spec.ts
+++ b/tests/e2e/specs/admin-blocked-script-watchdog.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '../fixtures/wp-fixture';
+import type { Page } from '@playwright/test';
+
+/**
+ * Blocked-script watchdog (support topic "Cookie Policy saving issue").
+ *
+ * The Cookie Policy and Cookies admin pages are driven by per-page scripts
+ * whose filenames contain "cookie" (cookie-policy.js / cookies.js). Some ad
+ * blockers and browser privacy shields (e.g. Brave Shield) match those names
+ * and block the file, leaving the page silently inert — Save/Preview and the
+ * buttons do nothing with no explanation. The page already refuses the native
+ * form submit (no blank-page data loss), but gave no feedback.
+ *
+ * Each view now renders a hidden, server-translated `notice notice-error` plus a
+ * tiny INLINE watchdog: the page script sets a `window.faz*Booted` flag the
+ * instant it runs; if the flag is still unset shortly after load (the script was
+ * blocked), the inline script reveals the notice. Inline first-party script is
+ * not blocked the way the external .js file is, so the message always reaches
+ * the user.
+ *
+ * These tests drive the real behaviour: abort the page script request to
+ * simulate the blocker (notice must appear), and load it normally (notice must
+ * stay hidden, flag set). Reusable + self-contained — no fixtures created, no
+ * settings mutated.
+ */
+
+const PAGES = [
+  {
+    name: 'Cookie Policy',
+    url: '/wp-admin/admin.php?page=faz-cookie-manager-cookie-policy',
+    script: '**/pages/cookie-policy.js*',
+    notice: '#faz-cp-script-blocked',
+    flag: 'fazCpBooted',
+  },
+  {
+    name: 'Cookies',
+    url: '/wp-admin/admin.php?page=faz-cookie-manager-cookies',
+    script: '**/pages/cookies.js*',
+    notice: '#faz-cookies-script-blocked',
+    flag: 'fazCookiesBooted',
+  },
+] as const;
+
+async function flagSet(page: Page, flag: string): Promise<boolean> {
+  return page.evaluate((f) => Boolean((window as unknown as Record<string, unknown>)[f]), flag);
+}
+
+test.describe('Admin blocked-script watchdog', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  for (const p of PAGES) {
+    test(`${p.name}: blocked page script reveals the actionable notice`, async ({ page, loginAsAdmin }) => {
+      await loginAsAdmin(page);
+      // Simulate an ad blocker / shield dropping the per-page script by name.
+      await page.route(p.script, (route) => route.abort());
+      await page.goto(p.url, { waitUntil: 'domcontentloaded' });
+      // The script never ran, so its boot flag stays unset…
+      expect(await flagSet(page, p.flag)).toBe(false);
+      // …and the inline watchdog reveals the notice (2.5s timeout + margin).
+      await expect(page.locator(p.notice)).toBeVisible({ timeout: 6000 });
+      await expect(page.locator(`${p.notice} p`)).toContainText(/did not load|will not work/i);
+    });
+
+    test(`${p.name}: when the script loads, the notice stays hidden`, async ({ page, loginAsAdmin }) => {
+      await loginAsAdmin(page);
+      await page.goto(p.url, { waitUntil: 'domcontentloaded' });
+      // The page script ran and set its boot flag.
+      await expect.poll(() => flagSet(page, p.flag), { timeout: 6000 }).toBe(true);
+      // Give the watchdog's 2.5s timer time to (wrongly) fire, then confirm the
+      // notice is still hidden — the flag suppresses it.
+      await page.waitForTimeout(3000);
+      await expect(page.locator(p.notice)).toBeHidden();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds an admin-side watchdog notice for when a visitor's ad blocker (or a privacy extension) blocks the plugin's own front-end assets — `cookie-policy.js` / `cookies.js`. When those scripts are blocked, the cookie policy table and the cookie-list widget silently fail to render; this surfaces a clear admin notice so the operator understands the cause instead of chasing a phantom "broken banner" bug.

## Notes

- Admin-only notice; no change to front-end consent/blocking behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunti avvisi automatici nelle pagine di amministrazione per segnalare quando uno script non si carica correttamente.
  * Gli avvisi includono un messaggio accessibile e si aggiornano in modo dinamico.

* **Bug Fixes**
  * Migliorato il rilevamento dei blocchi causati da ad blocker o protezioni privacy.
  * Se lo script viene caricato correttamente, l’avviso resta nascosto o si chiude automaticamente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->