### PR TITLE
Document intentional suppress_filters on the DSAR cleanup query

### DIFF
--- a/includes/class-activator.php
+++ b/includes/class-activator.php
@@ -309,6 +309,7 @@ class Activator {
 				'posts_per_page'   => 200,
 				'fields'           => 'ids',
 				'no_found_rows'    => true,
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters_suppress_filters -- intentional: this DSAR retention cleanup must find and delete EVERY expired faz_dsar record regardless of third-party query filters (e.g. multilingual language scoping), so filters are suppressed on this internal housekeeping query. Not a wp.org plugin_repo error (WordPressVIPMinimum only).
 				'suppress_filters' => true,
 				'date_query'       => array(
 					array(


### PR DESCRIPTION
## Summary

A broad Plugin Check run (WordPressVIPMinimum ruleset, beyond the wp.org `plugin_repo` gate) flags one ERROR: `WordPressVIPMinimum.Performance.WPQueryParams.SuppressFilters` at the DSAR retention-cleanup query in `class-activator.php`.

`suppress_filters => true` there is intentional: this internal housekeeping query must find and delete every expired `faz_dsar` record regardless of third-party query filters (e.g. a multilingual plugin scoping queries by language), so flipping it to `false` could leave expired records behind — a correctness regression, not a fix. Documented with a callsite `phpcs:ignore` + rationale instead.

## Notes

- Not a wp.org blocker: `suppress_filters` is a WordPressVIPMinimum sniff and is NOT in the `plugin_repo` Plugin Check category that wp.org review uses (verified). This only keeps a broader/VIP lint run clean.
- No behaviour change.
