### PR TITLE
Fix misleading geo-routing 'automatic per-country' copy + expose runtime off-state

### DIFF
--- a/admin/assets/js/pages/geo-routing.js
+++ b/admin/assets/js/pages/geo-routing.js
@@ -175,6 +175,10 @@
 			clear(container);
 			var tbody = el('tbody');
 			tbody.appendChild(el('tr', null, [
+				el('td', null, el('strong', { text: 'Automatic per-visitor application' })),
+				el('td', { text: (data.runtime && data.runtime.applied) ? '✅ active' : '⚪ off — default banner served to all visitors' })
+			]));
+			tbody.appendChild(el('tr', null, [
 				el('td', null, el('strong', { text: 'Catalog rulesets' })),
 				el('td', { text: String(data.catalog.rulesets_count) })
 			]));

--- a/admin/modules/geo-routing/api/class-geo-api.php
+++ b/admin/modules/geo-routing/api/class-geo-api.php
@@ -391,6 +391,13 @@ class Geo_Api {
 				'rulesets_count' => count( Ruleset_Loader::get_instance()->list_all() ),
 				'fallback_id'    => Ruleset_Loader::get_instance()->get_fallback_id(),
 			),
+			// Whether the resolved ruleset is actually applied to the live banner
+			// per visitor. Currently hard-off (1.18.2 hotfix) until the per-
+			// jurisdiction UI obligations (Do Not Sell link, GPC, sensitive
+			// separate opt-in) are wired; the catalogue is preview/reference only.
+			'runtime' => array(
+				'applied' => \FazCookie\Frontend\Includes\Geo_Runtime::is_enabled(),
+			),
 		);
 		return new WP_REST_Response( $status, 200 );
 	}

--- a/admin/views/geo-routing.php
+++ b/admin/views/geo-routing.php
@@ -25,7 +25,7 @@ $rest_url   = esc_url( rest_url( 'faz/v1/geo/' ) );
 
 	<h1><?php esc_html_e( 'Geo-routing', 'faz-cookie-manager' ); ?></h1>
 	<p class="faz-page-intro">
-		<?php esc_html_e( 'Inspect, override, and preview the built-in jurisdiction rule-sets per country and US state. Note: automatic per-visitor application to the live banner is currently off — the default banner is served to every visitor, and jurisdiction-specific banners (for example a CCPA/CPRA "Do Not Sell" banner) are configured manually. The rule-set catalogue below powers the previews and is the reference for that configuration.', 'faz-cookie-manager' ); ?>
+		<?php esc_html_e( 'Inspect, override, and preview the built-in jurisdiction rule-sets per country and US state. Automatic per-visitor application to the live banner is off (see Pipeline status) — configure jurisdiction-specific banners, such as a CCPA/CPRA "Do Not Sell" banner, manually on the Banner page.', 'faz-cookie-manager' ); ?>
 	</p>
 
 	<nav class="faz-geo-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Geo-routing sections', 'faz-cookie-manager' ); ?>">

--- a/admin/views/geo-routing.php
+++ b/admin/views/geo-routing.php
@@ -25,7 +25,7 @@ $rest_url   = esc_url( rest_url( 'faz/v1/geo/' ) );
 
 	<h1><?php esc_html_e( 'Geo-routing', 'faz-cookie-manager' ); ?></h1>
 	<p class="faz-page-intro">
-		<?php esc_html_e( 'Configure how the cookie banner adapts to each visitor\'s jurisdiction. The plugin selects the appropriate rule-set per country (and US state) automatically; the panels below let you inspect, override, or preview the routing decisions.', 'faz-cookie-manager' ); ?>
+		<?php esc_html_e( 'Inspect, override, and preview the built-in jurisdiction rule-sets per country and US state. Note: automatic per-visitor application to the live banner is currently off — the default banner is served to every visitor, and jurisdiction-specific banners (for example a CCPA/CPRA "Do Not Sell" banner) are configured manually. The rule-set catalogue below powers the previews and is the reference for that configuration.', 'faz-cookie-manager' ); ?>
 	</p>
 
 	<nav class="faz-geo-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Geo-routing sections', 'faz-cookie-manager' ); ?>">


### PR DESCRIPTION
## Summary

Follow-up from a full compliance audit (blocking vectors × legislation models). The audit found the pre-consent blocking floor **assured** for opt-in jurisdictions (dual-layer server + client; no HIGH/MEDIUM real gaps). This PR fixes the one item with a real accuracy consequence.

`Geo_Runtime::is_enabled()` is hard-`false` (1.18.2 hotfix): the 47 jurisdiction rule-sets are catalogue/preview only and are **not** auto-applied to the live banner until the per-jurisdiction UI obligations (CCPA Do-Not-Sell link, GPC handling, sensitive separate opt-in) are wired. But the Geo-routing admin intro claimed the plugin *"selects the appropriate rule-set per country (and US state) automatically"* — misleading while runtime application is off, and it could lull an operator into assuming per-jurisdiction UI is delivered automatically (the "operator trap": a second country-targeted banner with a mismatched opt-out `applicableLaw` on an opt-in country would then skip pre-consent blocking).

## Changes

- **`admin/views/geo-routing.php`** — rewrite the intro to state the catalogue is inspect/override/preview only, that the default banner is served to every visitor, and that jurisdiction-specific banners are configured manually.
- **`admin/modules/geo-routing/api/class-geo-api.php`** — add `runtime.applied` (= `Geo_Runtime::is_enabled()`) to `GET /geo/status` so the off-state is machine-visible.

No behaviour change to blocking. Verified: unit 36/36, css-font/img-tile/font-link + settings-and-blocking e2e green, PHP lint clean.

## Not fixed (deliberately)

The audit also flagged a LOW inline-`<script>`-in-AJAX-HTML gap (an inline tracker in AJAX-delivered HTML re-run by jQuery is seen by neither the server buffer nor the async MutationObserver). A client-side content gate was prototyped and **reverted**: it re-introduced the exact false-positive the plugin intentionally avoids — see `settings-and-blocking.spec` *"inline scripts containing tracker URLs in data are not false-positively blocked"* (URL patterns must match `src` attributes only, never inline content, or config scripts like Rank Math's `rankMath.links` break). The gap stays a documented best-effort limit, partially mitigated by the fetch/XHR/sendBeacon interceptors and the img-src gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nella diagnostica di Geo-routing è stata aggiunta una sezione dedicata allo stato runtime, con indicazione se l’applicazione automatica per-visitor è attiva.
  * Nella pagina “status” compare una nuova riga che riporta chiaramente lo stato “Automatic per-visitor application” (attiva/disattiva).

* **Documentation**
  * Aggiornato il testo introduttivo della pagina Geo-routing per descrivere l’attuale comportamento dei banner e chiarire che i banner specifici per giurisdizione vanno configurati manualmente nella pagina “Banner”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->