### PR TITLE
Scope geo 'off' copy to rule-set application (per-country banner selection still works)

### DIFF
--- a/admin/assets/js/pages/geo-routing.js
+++ b/admin/assets/js/pages/geo-routing.js
@@ -175,8 +175,8 @@
 			clear(container);
 			var tbody = el('tbody');
 			tbody.appendChild(el('tr', null, [
-				el('td', null, el('strong', { text: 'Automatic per-visitor application' })),
-				el('td', { text: (data.runtime && data.runtime.applied) ? '✅ active' : '⚪ off — default banner served to all visitors' })
+				el('td', null, el('strong', { text: 'Runtime rule-set application' })),
+				el('td', { text: (data.runtime && data.runtime.applied) ? '✅ active' : '⚪ off — catalogue is preview/reference only' })
 			]));
 			tbody.appendChild(el('tr', null, [
 				el('td', null, el('strong', { text: 'Catalog rulesets' })),

--- a/admin/views/geo-routing.php
+++ b/admin/views/geo-routing.php
@@ -25,7 +25,7 @@ $rest_url   = esc_url( rest_url( 'faz/v1/geo/' ) );
 
 	<h1><?php esc_html_e( 'Geo-routing', 'faz-cookie-manager' ); ?></h1>
 	<p class="faz-page-intro">
-		<?php esc_html_e( 'Inspect, override, and preview the built-in jurisdiction rule-sets per country and US state. Automatic per-visitor application to the live banner is off (see Pipeline status) — configure jurisdiction-specific banners, such as a CCPA/CPRA "Do Not Sell" banner, manually on the Banner page.', 'faz-cookie-manager' ); ?>
+		<?php esc_html_e( 'Inspect, override, and preview the built-in jurisdiction rule-sets per country and US state. Automatic application of a rule-set to the live banner (consent model, GPC, Do Not Sell) is off — the catalogue is preview and reference only. Per-country banner selection still works: configure country-specific banners, such as a CCPA/CPRA "Do Not Sell" banner, on the Banner page.', 'faz-cookie-manager' ); ?>
 	</p>
 
 	<nav class="faz-geo-tabs" role="tablist" aria-label="<?php esc_attr_e( 'Geo-routing sections', 'faz-cookie-manager' ); ?>">


### PR DESCRIPTION
## Summary

Reviewer P3 follow-up to #178. The Geo-routing status row and intro copy implied that with runtime application off, "the default banner is served to all visitors". That is inaccurate.

Only the **rule-set** runtime application (the jurisdiction's consent model / GPC / Do-Not-Sell UI, gated by `Geo_Runtime::is_enabled()`, hard-off since the 1.18.2 hotfix) is disabled. **Per-country banner selection** via `Controller::get_active_banner_for_country()` (`frontend/class-frontend.php:763`) is unconditional and still active — a US-targeted banner still wins for US visitors (confirmed by the geo multi-banner E2E).

## Changes

- **Status row** (`geo-routing.js`): label → "Runtime rule-set application"; off value → "off — catalogue is preview/reference only".
- **Intro** (`geo-routing.php`): scope the off-state to rule-set application (consent model / GPC / Do Not Sell) and state explicitly that per-country banner selection still works and is configured on the Banner page.

No behaviour change. JS + PHP lint clean; admin JS is not in the `build:min` pipeline.
