### PR TITLE
i18n the new geo Pipeline-status strings (CodeRabbit follow-up)

### DIFF
--- a/admin/assets/js/pages/geo-routing.js
+++ b/admin/assets/js/pages/geo-routing.js
@@ -175,8 +175,8 @@
 			clear(container);
 			var tbody = el('tbody');
 			tbody.appendChild(el('tr', null, [
-				el('td', null, el('strong', { text: 'Runtime rule-set application' })),
-				el('td', { text: (data.runtime && data.runtime.applied) ? '✅ active' : '⚪ off — catalogue is preview/reference only' })
+				el('td', null, el('strong', { text: t('runtimeApplicationLabel', 'Runtime rule-set application') })),
+				el('td', { text: (data.runtime && data.runtime.applied) ? t('runtimeApplicationActive', '✅ active') : t('runtimeApplicationOff', '⚪ off — catalogue is preview/reference only') })
 			]));
 			tbody.appendChild(el('tr', null, [
 				el('td', null, el('strong', { text: 'Catalog rulesets' })),

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -740,6 +740,10 @@ class Admin {
 						'addOverride'                  => __( 'Add override', 'faz-cookie-manager' ),
 						'noOverrides'                  => __( 'No per-country overrides configured. The plugin auto-detects rule-set from country and US state.', 'faz-cookie-manager' ),
 						'confirmDelete'                => __( 'Remove this override?', 'faz-cookie-manager' ),
+						// Pipeline status panel.
+						'runtimeApplicationLabel'      => __( 'Runtime rule-set application', 'faz-cookie-manager' ),
+						'runtimeApplicationActive'     => __( '✅ active', 'faz-cookie-manager' ),
+						'runtimeApplicationOff'        => __( '⚪ off — catalogue is preview/reference only', 'faz-cookie-manager' ),
 						// Preview panel.
 						'resolvedRuleset'              => __( 'Resolved ruleset', 'faz-cookie-manager' ),
 						'fullRulesetJson'              => __( 'Full ruleset JSON', 'faz-cookie-manager' ),


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit finding on the Pipeline-status row added in #178/#179: the new "Runtime rule-set application" label and its two state texts were hardcoded English, while `geo-routing.js` already has a `t()` i18n helper (`fazConfig.i18n.geo`) used elsewhere in the file.

- Register the three strings in the geo i18n map (`admin/class-admin.php`) with `__()` so they are translatable and extracted to the `.pot`.
- Wrap the JS literals in `t('key', 'English fallback')`.

The other pre-existing Pipeline-status rows (Catalog rulesets, ipinfo opt-in, Schema migration, …) are still hardcoded; left as a separate cleanup to keep this change minimal and scoped to the strings this PR introduced.

JS + PHP lint clean; admin JS is not in the `build:min` pipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * La pagina Geo-routing ora mostra le etichette e gli stati del pannello di stato in più lingue, invece di testo fisso in inglese.
  * Le voci relative all’applicazione del rule-set in runtime sono state rese localizzabili anche per gli stati attivo e non attivo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->