### PR TITLE
Sync noOverrides JS fallback with the updated PHP copy (CodeRabbit)

### DIFF
--- a/admin/assets/js/pages/geo-routing.js
+++ b/admin/assets/js/pages/geo-routing.js
@@ -288,7 +288,7 @@
 				});
 				container.appendChild(el('table', { class: 'widefat striped' }, [thead, tbody]));
 			} else {
-				container.appendChild(el('p', { class: 'description', text: t('noOverrides', 'No per-country overrides configured. The plugin auto-detects rule-set from country and US state.') }));
+				container.appendChild(el('p', { class: 'description', text: t('noOverrides', 'No per-country overrides configured. Rule-sets are auto-resolved per country and US state for preview and reference only.') }));
 			}
 
 			// Add form


### PR DESCRIPTION
CodeRabbit follow-up to #181. The PHP `noOverrides` i18n string was updated to "Rule-sets are auto-resolved per country and US state for preview and reference only." but the English fallback in `geo-routing.js` `t('noOverrides', …)` was left on the old "auto-detects rule-set" wording. The PHP key wins at render (users already see the new copy), but the stale fallback is inconsistent and would surface if the key were ever removed. Aligned the fallback to match. JS lint clean; no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti**
  * Aggiornato il messaggio informativo nella sezione **Overridden** della pagina **Geo-routing** quando non sono presenti override per paese.
  * La descrizione ora chiarisce meglio che le rule-set vengono risolte automaticamente per paese e per stato USA, limitatamente alla **preview** e alla **reference**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->