### PR TITLE
Fix: add data-cfasync="false" to banner scripts to prevent Cloudflare Rocket Loader deferral

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -5242,6 +5242,14 @@ class Frontend {
 	}
 
 	public function filter_script_loader_tag( $tag, $handle, $src ) {
+		// Prevent Cloudflare Rocket Loader from deferring the consent banner and
+		// its companion scripts. These must execute synchronously so the DOM-hiding
+		// routine fires before the page is painted — deferral breaks Accept/Reject.
+		$own_handles = array( $this->plugin_name, 'faz-fw', $this->plugin_name . '-gcm', 'faz-fw-gcm', $this->plugin_name . '-tcf-cmp', 'faz-fw-tcf-cmp' );
+		if ( in_array( $handle, $own_handles, true ) && false === strpos( $tag, 'data-cfasync' ) ) {
+			$tag = str_replace( '<script ', '<script data-cfasync="false" ', $tag );
+		}
+
 		if ( is_admin() ) {
 			return $tag;
 		}


### PR DESCRIPTION
# Fix: add data-cfasync="false" to banner scripts to prevent Cloudflare Rocket Loader deferral

## Description

Cloudflare Rocket Loader rewrites `<script src="...">` tags to load them asynchronously. Because the consent banner must execute synchronously (the DOM-hiding routine that fires on Accept/Reject depends on running before the page renders), Rocket Loader's deferral breaks the banner interaction entirely.

The `data-cfasync="false"` attribute is the official Cloudflare opt-out signal: any script carrying it is excluded from Rocket Loader processing and executes at its original position in document order.

## Solution

The attribute is injected via the existing `script_loader_tag` filter in `Frontend::filter_script_loader_tag()`, applied exclusively to the plugin's own script handles (`faz-cookie-manager`, `faz-fw`, and their `-gcm` / `-tcf-cmp` companions). A `strpos` guard prevents double-injection if the attribute is already present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Migliorata la compatibilità con Cloudflare Rocket Loader per gli script del plugin.
  * Garantita l’esecuzione tempestiva degli script necessari, evitando ritardi nel caricamento e nella visualizzazione corretta dei banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->