### PR TITLE
Feature: Add placeholder blocking for Smash Balloon Instagram Feed and Elementor Video widget

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -2666,6 +2666,18 @@ class Frontend {
 			$html = strtr( $html, $noscript_stash );
 		}
 
+		// 7. Hide social/widget embed containers that depend on blocked scripts
+		// (Facebook/Instagram/Twitter/X, Smash Balloon Instagram Feed, Elementor
+		// video widgets). filter_content_blocking() already runs these same two
+		// detectors for the_content/widget_text/widget_block_content, but an
+		// embed placed OUTSIDE post content - a theme-builder header/footer, a
+		// global (non-widget-area) template part, or any markup a page builder
+		// renders directly into the page - never passes through those narrower
+		// filters and only ever reaches the page here, in the full-page buffer.
+		// Without this, such an embed is never detected at all.
+		$html = $this->process_social_embeds( $html, $blocked_categories );
+		$html = $this->process_elementor_video_widgets( $html, $blocked_categories );
+
 		return $html;
 	}
 
@@ -6085,6 +6097,11 @@ class Frontend {
 		// Hide social embed containers that depend on blocked scripts.
 		$content = $this->process_social_embeds( $content, $blocked_categories );
 
+		// Hide Elementor video widgets (they render an EMPTY .elementor-video
+		// wrapper server-side and build the real iframe client-side from
+		// data-settings, so the generic <iframe> blocker above never sees one).
+		$content = $this->process_elementor_video_widgets( $content, $blocked_categories );
+
 		return $content;
 	}
 
@@ -6259,7 +6276,153 @@ class Frontend {
 			);
 		}
 
+		// Smash Balloon Instagram Feed renders as <div id="sb_instagram" ...>
+		// (or "sb_instagram_<n>" when multiple feeds are on one page) rather
+		// than a class-based embed like the ones above, so it needs an
+		// id-anchored match instead of a class-anchored one. Same block/
+		// placeholder logic otherwise - mirrors the Known_Providers entry
+		// "smash-balloon-instagram" (distinct from the generic "instagram"
+		// oEmbed entry above, since it is blocked by its own script pattern).
+		$social_ids = array(
+			'sb_instagram' => array( 'service_id' => 'smash-balloon-instagram', 'label' => 'Instagram', 'category' => 'marketing' ),
+		);
+
+		foreach ( $social_ids as $id_prefix => $info ) {
+			if ( false === stripos( $content, $id_prefix ) ) {
+				continue;
+			}
+
+			$category     = $info['category'];
+			$should_block = in_array( $category, $blocked_categories, true );
+
+			// Per-service consent check: override category-level decision.
+			$service_consent = $this->get_service_consent();
+			if ( ! empty( $service_consent ) && ! empty( $info['service_id'] ) ) {
+				$svc_key = $info['service_id'];
+				if ( isset( $service_consent[ $svc_key ] ) ) {
+					if ( 'yes' === $service_consent[ $svc_key ] ) {
+						$should_block = false;
+					} elseif ( 'no' === $service_consent[ $svc_key ] ) {
+						$should_block = true;
+					}
+				}
+			}
+
+			if ( ! $should_block ) {
+				continue;
+			}
+
+			// Insert a placeholder BEFORE the widget container, and hide it.
+			$content = preg_replace_callback(
+				'#(<(?:div|blockquote|span)\b)([^>]*\bid\s*=\s*["\']' . preg_quote( $id_prefix, '#' ) . '[^"\']*["\'][^>]*)>#i',
+				function ( $m ) use ( $category, $info ) {
+					// Skip if already processed.
+					if ( false !== strpos( $m[2], 'data-faz-category' ) ) {
+						return $m[0];
+					}
+					$placeholder = Placeholder_Builder::build_social( $info['service_id'], $info['label'], $category );
+					// Placeholder before + hidden original element.
+					$blocked = $m[1] . $m[2] . ' data-faz-category="' . esc_attr( $category ) . '">';
+				return $placeholder . self::faz_add_hidden_class( $blocked );
+				},
+				$content
+			);
+		}
+
 		return $content;
+	}
+
+	/**
+	 * Process Elementor "Video" widgets.
+	 *
+	 * Elementor's native Video widget renders an EMPTY `<div class="elementor-video">`
+	 * server-side and builds the real iframe entirely client-side, reading the
+	 * source URL from the `youtube_url` / `vimeo_url` / … key inside the
+	 * ancestor widget's `data-settings` JSON attribute - never from a `src`
+	 * attribute. The generic <iframe> blocker (process_iframe_tag) therefore
+	 * never sees anything to match, because there is no iframe in the initial
+	 * HTML at all. Detect the widget wrapper directly instead: parse its
+	 * data-settings JSON for the embed URL, resolve the provider the same way
+	 * the iframe blocker does, and gate the whole wrapper - mirroring
+	 * process_social_embeds() (placeholder before + faz-hidden original).
+	 *
+	 * @param string $content            HTML content.
+	 * @param array  $blocked_categories Blocked category slugs.
+	 * @return string Modified content.
+	 */
+	private function process_elementor_video_widgets( $content, $blocked_categories ) {
+		if ( false === stripos( $content, 'elementor-widget-video' ) ) {
+			return $content;
+		}
+
+		$result = preg_replace_callback(
+			'#<div\b(?=[^>]*\bclass\s*=\s*["\'][^"\']*\belementor-widget-video\b)(?=[^>]*\bdata-settings\s*=)([^>]*)>#i',
+			function ( $m ) use ( $blocked_categories ) {
+				$attrs = $m[1];
+
+				// Skip if already processed.
+				if ( false !== strpos( $attrs, 'data-faz-category' ) ) {
+					return '<div' . $attrs . '>';
+				}
+
+				$raw_settings = $this->extract_tag_attr( $attrs, 'data-settings' );
+				if ( '' === $raw_settings ) {
+					return '<div' . $attrs . '>';
+				}
+
+				// data-settings is HTML-entity-encoded JSON (Elementor escapes it
+				// for the attribute) - decode entities before json_decode.
+				$settings = json_decode( html_entity_decode( $raw_settings, ENT_QUOTES ), true );
+				if ( ! is_array( $settings ) ) {
+					return '<div' . $attrs . '>';
+				}
+
+				// The Video widget stores the source URL under one of these keys
+				// depending on the selected "video_type".
+				$url = '';
+				foreach ( array( 'youtube_url', 'vimeo_url', 'dailymotion_url', 'external_url' ) as $key ) {
+					if ( ! empty( $settings[ $key ] ) ) {
+						$url = (string) $settings[ $key ];
+						break;
+					}
+				}
+				if ( '' === $url ) {
+					return '<div' . $attrs . '>';
+				}
+
+				$service_id = Placeholder_Builder::detect_service_from_url( $url );
+				if ( 'default' === $service_id ) {
+					return '<div' . $attrs . '>'; // Self-hosted / unrecognised source - nothing to gate.
+				}
+
+				$known    = Known_Providers::get_all();
+				$category = isset( $known[ $service_id ]['category'] ) ? $known[ $service_id ]['category'] : 'marketing';
+
+				$should_block = in_array( $category, $blocked_categories, true );
+
+				// Per-service consent check: override category-level decision.
+				$service_consent = $this->get_service_consent();
+				if ( isset( $service_consent[ $service_id ] ) ) {
+					if ( 'yes' === $service_consent[ $service_id ] ) {
+						$should_block = false;
+					} elseif ( 'no' === $service_consent[ $service_id ] ) {
+						$should_block = true;
+					}
+				}
+
+				if ( ! $should_block ) {
+					return '<div' . $attrs . '>';
+				}
+
+				$label       = Placeholder_Builder::get_service_name( $service_id );
+				$placeholder = Placeholder_Builder::build_social( $service_id, $label, $category );
+				$blocked     = '<div' . $attrs . ' data-faz-category="' . esc_attr( $category ) . '">';
+				return $placeholder . self::faz_add_hidden_class( $blocked );
+			},
+			$content
+		);
+
+		return null !== $result ? $result : $content;
 	}
 
 	/**

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -6313,7 +6313,7 @@ class Frontend {
 			}
 
 			// Insert a placeholder BEFORE the widget container, and hide it.
-			$content = preg_replace_callback(
+			$result = preg_replace_callback(
 				'#(<(?:div|blockquote|span)\b)([^>]*\bid\s*=\s*["\']' . preg_quote( $id_prefix, '#' ) . '[^"\']*["\'][^>]*)>#i',
 				function ( $m ) use ( $category, $info ) {
 					// Skip if already processed.
@@ -6323,10 +6323,21 @@ class Frontend {
 					$placeholder = Placeholder_Builder::build_social( $info['service_id'], $info['label'], $category );
 					// Placeholder before + hidden original element.
 					$blocked = $m[1] . $m[2] . ' data-faz-category="' . esc_attr( $category ) . '">';
-				return $placeholder . self::faz_add_hidden_class( $blocked );
+					return $placeholder . self::faz_add_hidden_class( $blocked );
 				},
 				$content
 			);
+			// A PCRE failure returns null. filter_content_blocking() is hooked
+			// to the_content / widget_text / widget_block_content, and a null
+			// return there does not pass the content through — it renders as an
+			// empty string, silently blanking the post body. Keep the unblocked
+			// HTML instead, matching the scripts/iframes passes in
+			// filter_content_blocking().
+			if ( null !== $result ) {
+				$content = $result;
+			} else {
+				error_log( '[FAZ Cookie Manager] PCRE error ' . preg_last_error() . ' in process_social_embeds (' . $id_prefix . ')' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			}
 		}
 
 		return $content;

--- a/frontend/includes/class-placeholder-builder.php
+++ b/frontend/includes/class-placeholder-builder.php
@@ -30,6 +30,10 @@ class Placeholder_Builder {
 		'google-maps' => '<path d="M12 2C8.1 2 5 5.1 5 9c0 5.2 7 13 7 13s7-7.8 7-13c0-3.9-3.1-7-7-7zm0 9.5c-1.4 0-2.5-1.1-2.5-2.5S10.6 6.5 12 6.5 14.5 7.6 14.5 9 13.4 11.5 12 11.5z" fill="#4285F4"/>',
 		'facebook'    => '<path d="M24 12c0-6.6-5.4-12-12-12S0 5.4 0 12c0 6 4.4 11 10.1 11.9v-8.4H7.1V12h3V9.4c0-3 1.8-4.7 4.5-4.7 1.3 0 2.7.2 2.7.2v3h-1.5c-1.5 0-2 .9-2 1.9V12h3.3l-.5 3.5h-2.8v8.4C19.6 23 24 18 24 12z" fill="#1877F2"/>',
 		'instagram'   => '<path d="M12 2.2c3.2 0 3.6 0 4.8.1 3.5.2 5.1 1.7 5.3 5.3.1 1.3.1 1.6.1 4.8 0 3.2 0 3.6-.1 4.8-.2 3.5-1.8 5.1-5.3 5.3-1.3.1-1.6.1-4.8.1-3.2 0-3.6 0-4.8-.1-3.5-.2-5.1-1.8-5.3-5.3-.1-1.3-.1-1.6-.1-4.8 0-3.2 0-3.6.1-4.8.2-3.5 1.8-5.1 5.3-5.3 1.3-.1 1.6-.1 4.8-.1zM12 0C8.7 0 8.3 0 7.1.1 2.7.3.3 2.7.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.2 4.4 2.6 6.8 7 7 1.2.1 1.6.1 4.9.1s3.7 0 4.9-.1c4.4-.2 6.8-2.6 7-7 .1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.2-4.4-2.6-6.8-7-7C16.7 0 16.3 0 12 0zm0 5.8a6.2 6.2 0 100 12.4 6.2 6.2 0 000-12.4zM12 16a4 4 0 110-8 4 4 0 010 8zm6.4-10.8a1.4 1.4 0 100 2.8 1.4 1.4 0 000-2.8z" fill="#E4405F"/>',
+		// Smash Balloon Instagram Feed is a third-party feed widget, not the
+		// native oEmbed - kept as its own service id (matches its Known_Providers
+		// entry) but visually branded the same as Instagram.
+		'smash-balloon-instagram' => '<path d="M12 2.2c3.2 0 3.6 0 4.8.1 3.5.2 5.1 1.7 5.3 5.3.1 1.3.1 1.6.1 4.8 0 3.2 0 3.6-.1 4.8-.2 3.5-1.8 5.1-5.3 5.3-1.3.1-1.6.1-4.8.1-3.2 0-3.6 0-4.8-.1-3.5-.2-5.1-1.8-5.3-5.3-.1-1.3-.1-1.6-.1-4.8 0-3.2 0-3.6.1-4.8.2-3.5 1.8-5.1 5.3-5.3 1.3-.1 1.6-.1 4.8-.1zM12 0C8.7 0 8.3 0 7.1.1 2.7.3.3 2.7.1 7.1 0 8.3 0 8.7 0 12s0 3.7.1 4.9c.2 4.4 2.6 6.8 7 7 1.2.1 1.6.1 4.9.1s3.7 0 4.9-.1c4.4-.2 6.8-2.6 7-7 .1-1.2.1-1.6.1-4.9s0-3.7-.1-4.9c-.2-4.4-2.6-6.8-7-7C16.7 0 16.3 0 12 0zm0 5.8a6.2 6.2 0 100 12.4 6.2 6.2 0 000-12.4zM12 16a4 4 0 110-8 4 4 0 010 8zm6.4-10.8a1.4 1.4 0 100 2.8 1.4 1.4 0 000-2.8z" fill="#E4405F"/>',
 		'twitter'     => '<path d="M18.2 2h3.6l-7.9 9 9.3 12.3h-7.3l-5.7-7.4-6.5 7.4H.1l8.4-9.6L0 2h7.5l5.1 6.8L18.2 2zm-1.3 19.1h2L7.3 4H5.1l11.8 17.1z" fill="#000"/>',
 		'spotify'     => '<path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.6 0 12 0zm5.5 17.3c-.2.3-.6.4-.9.2-2.6-1.6-5.8-1.9-9.6-1.1-.4.1-.7-.2-.8-.5-.1-.4.2-.7.5-.8 4.2-.9 7.8-.5 10.6 1.2.4.2.4.7.2 1zm1.5-3.3c-.3.4-.8.5-1.2.3-3-1.8-7.5-2.4-11-1.3-.4.1-.9-.1-1-.6-.1-.4.1-.9.6-1 4-.1.2 8.9.7 12.2 2.5.3.2.5.8.2 1.1zm.1-3.4C15.3 8.4 8.9 8.2 5.2 9.3c-.5.2-1-.2-1.2-.7-.2-.5.2-1 .7-1.2 4.3-1.3 11.4-1 15.9 1.5.5.3.6.9.4 1.3-.3.5-.9.6-1.3.4z" fill="#1DB954"/>',
 		'dailymotion' => '<path d="M12.1 2C6.5 2 2 6.5 2 12.1s4.5 10.1 10.1 10.1c2.4 0 4.7-.9 6.5-2.4v2h3.4V12.1C22 6.5 17.5 2 12.1 2zm0 16.1c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z" fill="#00B2FF"/>',
@@ -52,6 +56,7 @@ class Placeholder_Builder {
 		'google-maps' => '#4285f4',
 		'facebook'    => '#1877f2',
 		'instagram'   => '#e4405f',
+		'smash-balloon-instagram' => '#e4405f',
 		'twitter'     => '#1d1d1f',
 		'spotify'     => '#1db954',
 		'dailymotion' => '#00b2ff',
@@ -273,9 +278,22 @@ class Placeholder_Builder {
 
 		$button_text = esc_html__( 'Accept cookies', 'faz-cookie-manager' );
 
-		$html  = '<div class="faz-placeholder faz-placeholder--social faz-social-placeholder" data-faz-category="' . esc_attr( $category ) . '" data-faz-service="' . esc_attr( $service_id ) . '">';
+		// A video service (e.g. an Elementor Video widget resolved to YouTube)
+		// routed through this social-style builder still needs the 16:9
+		// aspect-ratio "video" card, not the compact 120px social-icon card -
+		// otherwise the page collapses to a tiny box where a full-size video
+		// used to be, causing a layout shift instead of preventing one.
+		$is_video_service = in_array( $service_id, self::$video_services, true );
+		$class             = 'faz-placeholder faz-social-placeholder'
+			. ( $is_video_service ? ' faz-placeholder--video' : ' faz-placeholder--social' );
+		$brand = isset( self::$service_colors[ $service_id ] ) ? self::$service_colors[ $service_id ] : self::$service_colors['default'];
+
+		$html  = '<div class="' . esc_attr( $class ) . '" data-faz-category="' . esc_attr( $category ) . '" data-faz-service="' . esc_attr( $service_id ) . '" style="--faz-svc-color:' . esc_attr( $brand ) . '">';
 		$html .= '<div class="faz-placeholder-overlay">';
 		$html .= '<svg class="faz-placeholder-icon" viewBox="0 0 24 24" width="32" height="32" xmlns="http://www.w3.org/2000/svg">' . $icon_svg . '</svg>';
+		if ( $is_video_service ) {
+			$html .= '<span class="faz-placeholder-svcname">' . esc_html( $service_name ) . '</span>';
+		}
 		$html .= '<p class="faz-placeholder-msg">' . $message . '</p>';
 		$html .= '<button type="button" class="faz-placeholder-btn" data-faz-accept="' . esc_attr( $category ) . '" data-faz-accept-service="' . esc_attr( $service_id ) . '">' . $button_text . '</button>';
 		$html .= '</div>';


### PR DESCRIPTION
# Feature: Add placeholder blocking for Smash Balloon Instagram Feed and Elementor Video widget

## Description

Two third-party embed types were rendering unblocked before consent, bypassing the existing Google Maps-style placeholder mechanism entirely.

## Problem

### 1. Smash Balloon Instagram Feed

[Smash Balloon](https://wordpress.org/plugins/instagram-feed/) renders as `<div id="sb_instagram" class="sbi ...">`. The existing social embed detector (`process_social_embeds()`) only matched embeds by class (`fb-page`, `instagram-media`, `twitter-tweet`, …) and was only ever invoked from `filter_content_blocking()`, hooked to `the_content` / `widget_text` / `widget_block_content`.

A Smash Balloon widget placed via a page builder outside the main post content (header, footer, theme-builder template) never passed through those filters and was never scanned at all - regardless of id/class matching.

### 2. Elementor Video Widget

Elementor's native Video widget renders an empty `<div class="elementor-video"></div>` server-side. The real embed URL only exists inside `data-settings="{&quot;youtube_url&quot;:...}"` JSON on the ancestor widget wrapper - there is no `<iframe src="...">` in the initial HTML.

The plugin's generic iframe blocker (`process_iframe_tag()`) matches on a `src` attribute, so it never had anything to catch for this widget type.

## Root Cause

1. `process_social_embeds()` was id-blind (class-only) and wired to a narrower set of content filters than the full-page output buffer, so any social/feed widget rendered outside post content was invisible to it.
2. No detector existed for page builders that defer real embed construction to client-side JS reading a JSON attribute instead of emitting a `src`-bearing element server-side.

## Solution

### `process_social_embeds()` - id match + broader hook

- Extended with an id-anchored match for `sb_instagram`, reusing the same block/placeholder/per-service-consent logic as the existing class-anchored loop.
- Added a matching Instagram-branded icon/color entry (`smash-balloon-instagram`) in `Placeholder_Builder`.
- Wired into `process_output_buffer()` (the full-page buffer), not just `filter_content_blocking()`, so social/feed embeds are caught regardless of where on the page they render.

### `process_elementor_video_widgets()` - new detector

- Detects `.elementor-widget-video` wrappers.
- Decodes their `data-settings` JSON and resolves the embed URL (`youtube_url` / `vimeo_url` / `dailymotion_url`) through the existing `Placeholder_Builder::detect_service_from_url()`.
- Gates the whole wrapper the same way as other blocked embeds.
- Wired into both `filter_content_blocking()` and `process_output_buffer()`.

### `Placeholder_Builder::build_social()` — video-aware card sizing

- Extended to render a 16:9 `faz-placeholder--video` card (brand color + service name) when the resolved service is a video platform, instead of the compact 120px social-icon card.
- Prevents a blocked video widget from collapsing to a tiny box and causing a layout shift.

---

## Files Changed

| File | Change |
|---|---|
| `process_social_embeds()` | Added id-based `sb_instagram` match; hooked into output buffer |
| `process_elementor_video_widgets()` | New function; hooked into both content filters and output buffer |
| `Placeholder_Builder` | Added `smash-balloon-instagram` entry; video-aware card sizing in `build_social()` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto il supporto per bloccare e sostituire con un segnaposto i widget video di Elementor quando gli script non sono autorizzati.
  * Aggiunto il supporto per i feed Instagram di Smash Balloon, inclusa la gestione del consenso dedicato.
  * Migliorata la visualizzazione dei segnaposto per i contenuti video, con layout e proporzioni corrette.

* **Correzioni**
  * La gestione dei contenuti bloccati ora si applica all’intera pagina, inclusi widget ed elementi incorporati al di fuori dei post.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->