### PR TITLE
Guard admin pages against calling REST routes that do not exist

### DIFF
--- a/tests/e2e/specs/admin-rest-routes.spec.ts
+++ b/tests/e2e/specs/admin-rest-routes.spec.ts
@@ -95,7 +95,11 @@ async function visitAllTabs(page: Page, selector: string): Promise<void> {
     if (!(await tab.isVisible().catch(() => false))) {
       continue;
     }
-    await tab.click().catch(() => undefined);
+    // Deliberately not caught. A visible tab that cannot be clicked means this
+    // spec never exercises that tab's REST calls, and a guard that quietly
+    // skips the thing it is guarding is worse than no guard — it reports
+    // success for coverage it did not achieve.
+    await tab.click();
     // Let the tab's XHRs start and settle; networkidle would hang on pages
     // that keep a long-poll open, so a short settle window is enough here.
     await page.waitForTimeout(400);
@@ -165,11 +169,25 @@ test.describe('Admin pages call REST routes that exist (#198)', () => {
       'pipl-attestation',
     ];
 
-    const unscoped = seen.filter((url) =>
-      REGRESSION_PATHS.some(
-        (p) => url.includes(`/faz/v1/${p}`) || url.includes(`rest_route=/faz/v1/${p}`),
-      ),
-    );
+    // Compare against the decoded URL as well as the raw one. Without pretty
+    // permalinks WordPress addresses the API as `?rest_route=%2Ffaz%2Fv1%2F…`,
+    // and a raw-substring check would miss the regression entirely on exactly
+    // the sites most likely to hit it. The preflight enforces pretty permalinks
+    // here, so this is latent today — but a guard that only works under one
+    // permalink setting is not a guard.
+    const unscoped = seen.filter((url) => {
+      let decoded = url;
+      try {
+        decoded = decodeURIComponent(url);
+      } catch {
+        // Malformed escape sequence: fall back to the raw URL rather than
+        // dropping the request from the check.
+      }
+      return REGRESSION_PATHS.some(
+        (p) =>
+          decoded.includes(`/faz/v1/${p}`) || decoded.includes(`rest_route=/faz/v1/${p}`),
+      );
+    });
 
     expect(
       unscoped,

--- a/tests/e2e/specs/admin-rest-routes.spec.ts
+++ b/tests/e2e/specs/admin-rest-routes.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test } from '../fixtures/wp-fixture';
+import type { Page, Response, ConsoleMessage } from '@playwright/test';
+
+/**
+ * Guard against issue #198: an admin page calling REST paths that no route
+ * matches.
+ *
+ * The Geo-routing module registers its routes under `faz/v1/geo/…`, but its
+ * page script called `FAZ.get('status')`, and FAZ.get() only prepends
+ * `faz/v1/`. Every tab rendered "No route was found matching the URL and
+ * request method." Nothing failed at build time, no PHP error was logged, and
+ * the admin page looked fine until you opened a tab — so it reached a released
+ * version and a user had to report it.
+ *
+ * A static check on the JS would be fragile (paths are composed at runtime).
+ * This instead asserts the observable symptom: load each admin screen as an
+ * administrator and require that no faz/v1 request comes back 4xx/5xx and that
+ * the routing error never appears in the console.
+ *
+ * Scope note: only the two modules that namespace their routes (`geo`,
+ * `cookie-policy`) can exhibit this particular bug today, but the check is
+ * written against every admin page so a future module gets the guard for free.
+ */
+
+/** Every registered FAZ admin screen, including the ones outside the nav. */
+const ADMIN_PAGES = [
+  'faz-cookie-manager',
+  'faz-cookie-manager-banner',
+  'faz-cookie-manager-cookies',
+  'faz-cookie-manager-consent-logs',
+  'faz-cookie-manager-gcm',
+  'faz-cookie-manager-languages',
+  'faz-cookie-manager-gvl',
+  'faz-cookie-manager-geo-routing',
+  'faz-cookie-manager-cookie-policy',
+  'faz-cookie-manager-settings',
+  'faz-cookie-manager-import-export',
+  'faz-cookie-manager-system-status',
+];
+
+/** Tabs are rendered client-side, so a page's REST calls fire per tab. */
+const TABBED_PAGES: Record<string, string> = {
+  'faz-cookie-manager-geo-routing': 'button[data-tab], .faz-tab',
+  'faz-cookie-manager-cookie-policy': 'button[data-tab], .faz-tab',
+  'faz-cookie-manager-banner': 'button.faz-tab',
+  'faz-cookie-manager-settings': 'button[data-tab], .faz-tab',
+};
+
+const isFazRest = (url: string): boolean =>
+  url.includes('/faz/v1/') || url.includes('rest_route=%2Ffaz%2Fv1') || url.includes('rest_route=/faz/v1');
+
+/** Strip the origin so failures read as `faz/v1/status`, not a 200-char URL. */
+const shortUrl = (url: string): string => {
+  try {
+    const u = new URL(url);
+    return u.pathname + (u.search || '');
+  } catch {
+    return url;
+  }
+};
+
+interface Collected {
+  failures: string[];
+  routingErrors: string[];
+}
+
+function collect(page: Page): Collected {
+  const out: Collected = { failures: [], routingErrors: [] };
+
+  page.on('response', (response: Response) => {
+    const url = response.url();
+    if (!isFazRest(url) || response.status() < 400) {
+      return;
+    }
+    out.failures.push(`${response.status()} ${response.request().method()} ${shortUrl(url)}`);
+  });
+
+  page.on('console', (msg: ConsoleMessage) => {
+    const text = msg.text();
+    // The exact string WordPress returns for rest_no_route.
+    if (text.includes('No route was found matching the URL')) {
+      out.routingErrors.push(text);
+    }
+  });
+
+  return out;
+}
+
+/** Click through every tab so tab-scoped REST calls actually fire. */
+async function visitAllTabs(page: Page, selector: string): Promise<void> {
+  const tabs = page.locator(selector);
+  const count = await tabs.count();
+  for (let i = 0; i < count; i++) {
+    const tab = tabs.nth(i);
+    if (!(await tab.isVisible().catch(() => false))) {
+      continue;
+    }
+    await tab.click().catch(() => undefined);
+    // Let the tab's XHRs start and settle; networkidle would hang on pages
+    // that keep a long-poll open, so a short settle window is enough here.
+    await page.waitForTimeout(400);
+  }
+}
+
+test.describe('Admin pages call REST routes that exist (#198)', () => {
+  for (const slug of ADMIN_PAGES) {
+    test(`${slug}: no failed faz/v1 request`, async ({ page, wpBaseURL, loginAsAdmin }) => {
+      await loginAsAdmin(page);
+
+      const collected = collect(page);
+
+      await page.goto(`${wpBaseURL}/wp-admin/admin.php?page=${slug}`, {
+        waitUntil: 'domcontentloaded',
+      });
+      await expect(page.locator('#wpadminbar')).toBeVisible();
+
+      // Give the page's own boot requests time to complete.
+      await page.waitForTimeout(1200);
+
+      const tabSelector = TABBED_PAGES[slug];
+      if (tabSelector) {
+        await visitAllTabs(page, tabSelector);
+      }
+
+      expect(
+        collected.failures,
+        `${slug} issued FAZ REST requests that failed:\n  ${collected.failures.join('\n  ')}`,
+      ).toEqual([]);
+
+      expect(
+        collected.routingErrors,
+        `${slug} surfaced a rest_no_route error to the console:\n  ${collected.routingErrors.join('\n  ')}`,
+      ).toEqual([]);
+    });
+  }
+
+  test('geo-routing reaches its namespaced routes, not the bare ones', async ({
+    page,
+    wpBaseURL,
+    loginAsAdmin,
+  }) => {
+    await loginAsAdmin(page);
+
+    const seen: string[] = [];
+    page.on('request', (request) => {
+      const url = request.url();
+      if (isFazRest(url)) {
+        seen.push(shortUrl(url));
+      }
+    });
+
+    await page.goto(`${wpBaseURL}/wp-admin/admin.php?page=faz-cookie-manager-geo-routing`, {
+      waitUntil: 'domcontentloaded',
+    });
+    await page.waitForTimeout(1500);
+    await visitAllTabs(page, 'button[data-tab], .faz-tab');
+
+    // The six endpoints named in the issue must never be requested unscoped.
+    const REGRESSION_PATHS = [
+      'status',
+      'rulesets',
+      'overrides',
+      'ipinfo-settings',
+      'preview',
+      'pipl-attestation',
+    ];
+
+    const unscoped = seen.filter((url) =>
+      REGRESSION_PATHS.some(
+        (p) => url.includes(`/faz/v1/${p}`) || url.includes(`rest_route=/faz/v1/${p}`),
+      ),
+    );
+
+    expect(
+      unscoped,
+      `geo-routing requested unscoped paths (the #198 regression):\n  ${unscoped.join('\n  ')}`,
+    ).toEqual([]);
+
+    // And it must actually have talked to the module, so the assertion above
+    // is not passing merely because nothing was requested at all.
+    const scoped = seen.filter((url) => url.includes('geo/') || url.includes('geo%2F'));
+    expect(scoped.length, `geo-routing made no namespaced REST call; observed:\n  ${seen.join('\n  ')}`).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/specs/admin-rest-routes.spec.ts
+++ b/tests/e2e/specs/admin-rest-routes.spec.ts
@@ -87,9 +87,10 @@ function collect(page: Page): Collected {
 }
 
 /** Click through every tab so tab-scoped REST calls actually fire. */
-async function visitAllTabs(page: Page, selector: string): Promise<void> {
+async function visitAllTabs(page: Page, selector: string): Promise<number> {
   const tabs = page.locator(selector);
   const count = await tabs.count();
+  let visited = 0;
   for (let i = 0; i < count; i++) {
     const tab = tabs.nth(i);
     if (!(await tab.isVisible().catch(() => false))) {
@@ -100,10 +101,12 @@ async function visitAllTabs(page: Page, selector: string): Promise<void> {
     // skips the thing it is guarding is worse than no guard — it reports
     // success for coverage it did not achieve.
     await tab.click();
+    visited++;
     // Let the tab's XHRs start and settle; networkidle would hang on pages
     // that keep a long-poll open, so a short settle window is enough here.
     await page.waitForTimeout(400);
   }
+  return visited;
 }
 
 test.describe('Admin pages call REST routes that exist (#198)', () => {
@@ -123,7 +126,11 @@ test.describe('Admin pages call REST routes that exist (#198)', () => {
 
       const tabSelector = TABBED_PAGES[slug];
       if (tabSelector) {
-        await visitAllTabs(page, tabSelector);
+        const visited = await visitAllTabs(page, tabSelector);
+        expect(
+          visited,
+          `${slug} exposes no visible tab for selector "${tabSelector}"; REST coverage was not exercised`,
+        ).toBeGreaterThan(0);
       }
 
       expect(
@@ -157,7 +164,8 @@ test.describe('Admin pages call REST routes that exist (#198)', () => {
       waitUntil: 'domcontentloaded',
     });
     await page.waitForTimeout(1500);
-    await visitAllTabs(page, 'button[data-tab], .faz-tab');
+    const visited = await visitAllTabs(page, 'button[data-tab], .faz-tab');
+    expect(visited, 'geo-routing exposes no visible tab; the route guard exercised nothing').toBeGreaterThan(0);
 
     // The six endpoints named in the issue must never be requested unscoped.
     const REGRESSION_PATHS = [


### PR DESCRIPTION
This adds one Playwright spec. No plugin code changes.

## The bug it guards against

Issue #198 (now closed) reported that every tab on the Geo-routing screen showed "No route was found matching the URL and request method."

The cause was a prefix mismatch. The Geo module registers its routes under `faz/v1/geo/`, but the page script called `FAZ.get('status')` and friends, and `FAZ.get()` prepends only `faz/v1/` — so the module segment had to come from the caller and never did. The page has two transports, and only one of them was wrong: the raw-fetch fallback already used `rest_url('faz/v1/geo/')` correctly. Since `FAZ` is loaded in practice, the broken branch was the one that always ran, which is why the failure was total rather than intermittent.

Fixed in 85bbc5c and shipped in 1.25.0, by adding the module base once where the two transports diverge rather than at each of the dozen call sites.

## Why it needs a test

Nothing failed loudly, and that is the whole point. There was no build error, no PHP error in the log, and the admin page rendered fine until you actually opened a tab. The REST request 404s, the JS swallows it, and the screen shows an error string. That is how it reached a released version with a user reporting it rather than a test.

A static check on the JS would be fragile, because these paths are composed at runtime. So the spec asserts the observable symptom instead: it loads every FAZ admin screen as an administrator, clicks through each screen's tabs (tabs are rendered client-side, so a page's REST calls only fire once the tab is opened), and fails if any `faz/v1` request returns 4xx or 5xx, or if `rest_no_route` reaches the console.

## Scope

Only two modules namespace their routes today — `geo` and `cookie-policy` — so only those two can exhibit this exact bug, and both now go through a scoped helper. I cross-checked every REST path the admin JS calls against the 72 routes the site actually registers, and all of them resolve.

The spec is still written against every admin page rather than just those two, so a future module that namespaces its routes gets the guard for free instead of needing someone to remember to extend the test.

## Verification

I checked the spec in both directions, since a guard that has only ever been observed passing is not evidence of anything. It passes against current `main`. Reintroducing the bug fails it with:

```
404 GET /wp-json/faz/v1/status?_locale=user
```

which is the exact URL from the original report.

`npm run test:unit` is unaffected at 56 suites passing, and the PHP syntax sweep is clean. Per the repo convention I have not run the E2E suite here, since it drives the shared WordPress test site and parallel runs corrupt each other's fixtures — this spec should go through the normal separate E2E run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Test**
  * Aggiunti test end-to-end per verificare il corretto caricamento delle pagine amministrative, incluse le schede renderizzate lato client.
  * Introdotti controlli per rilevare risposte REST 4xx/5xx, endpoint non disponibili ed errori nella console durante la navigazione.
  * Aggiunta una verifica dedicata al geo-routing, con controllo dei percorsi namespaced e dell’effettiva esecuzione delle richieste previste.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->