### PR TITLE
Collect what installed plugins declare about their own data processing

### DIFF
--- a/admin/modules/privacy-policy-generator/includes/class-content-collector.php
+++ b/admin/modules/privacy-policy-generator/includes/class-content-collector.php
@@ -1,0 +1,712 @@
+<?php
+/**
+ * Collect what the installed plugins declare about their own data processing.
+ *
+ * Since 4.9.6 a plugin declares its own processing by calling
+ * `wp_add_privacy_policy_content( $plugin_name, $policy_text )`, and
+ * `WP_Privacy_Policy_Content::get_suggested_policy_text()` hands back every
+ * registered contribution. FAZ is already a producer of one such block (see
+ * `CLI::register_privacy_hooks()`); this class makes it a consumer too.
+ *
+ * HARD CONSTRAINT — collection is admin-only, and this is not negotiable.
+ * `wp_add_privacy_policy_content()` calls `_doing_it_wrong()` unless it runs
+ * inside wp-admin on `admin_init` or later (guard added in 4.9.7), so
+ * producers register there and their content simply does not exist in any
+ * other context. Forcing the issue is worse than useless: firing
+ * `do_action( 'admin_init' )` from WP-CLI to "warm up" the producers emitted
+ * six `_doing_it_wrong` notices and then fataled inside WooCommerce, whose
+ * `OrderAttributionController::get_order_screen_id()` calls
+ * `wc_get_page_screen_id()` — undefined outside a real admin request. Do not
+ * move this onto a REST route or a cron event later; it will fatal on sites
+ * running WooCommerce.
+ *
+ * SNAPSHOT, NOT LIVE. Collection therefore cannot happen at render time: the
+ * blocks are persisted into the `faz_privacy_content_snapshot` option and the
+ * public document renders from that. Required independently anyway — Cache
+ * Compatibility Mode (1.21.0) demands render invariance, and a live collection
+ * would make the output depend on request context.
+ *
+ * Full rationale: docs/privacy-policy-collection-design.md.
+ *
+ * @package FazCookie\Admin\Modules\Privacy_Policy_Generator\Includes
+ * @since   1.26.0
+ */
+
+namespace FazCookie\Admin\Modules\Privacy_Policy_Generator\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Snapshot the privacy-policy content other plugins register about themselves.
+ *
+ * The point of aggregating is editorial, not technical: we must not author
+ * claims about what a site processes on behalf of software we did not write.
+ * WooCommerce's description of WooCommerce is both more accurate than anything
+ * we could write and, legally, WooCommerce's statement rather than ours.
+ *
+ * EDITABLE PLACEHOLDERS, mirroring `Section_Overrides`. The collected text is
+ * a placeholder, not a saved value: an empty override means "keep tracking
+ * upstream" and the block silently adopts whatever the plugin now says. Once
+ * the operator writes their own wording, that wording is the document and an
+ * upstream change is flagged, never silently applied — the same judgement the
+ * Cookie Policy makes, because an explicit editorial decision is the most
+ * specific source there is. The anchor for that decision is the block's
+ * `source_hash` at the moment the override was saved; the block's own identity
+ * anchor is the plugin, matched first by text (so a rename or a translated
+ * display name carries the block forward) and then by name (so a rewritten
+ * declaration updates the block it belongs to).
+ *
+ * FAZ keeps its own snapshot and computes its own diff on purpose. Core's
+ * `added`/`updated`/`removed` flags are computed against the
+ * `_wp_suggested_privacy_policy_content` post meta of the page named by
+ * `wp_page_for_privacy_policy`; on a site where that option is 0 there is no
+ * baseline and those flags are meaningless. Change detection has to work
+ * whether or not the operator ever configured core's privacy page.
+ *
+ * KNOWN, ACCEPTED SIDE EFFECT. `get_suggested_policy_text()` refreshes core's
+ * `_wp_suggested_privacy_policy_content` meta cache when a privacy page IS
+ * configured, which can pre-empt core's own "suggested text has changed" admin
+ * notice. It is core's public, sanctioned accessor — the same refresh happens
+ * whenever the operator opens core's Privacy Policy Guide — the effect is
+ * bounded to installs that both configured a privacy page and visit FAZ
+ * screens, and FAZ's own three-state flagging supersedes that notice for
+ * FAZ-managed documents. Reading the private `$policy_content` property by
+ * Reflection to avoid it was considered and rejected: worse for wp.org review
+ * and brittle against core refactors.
+ *
+ * KNOWN BLIND SPOT, documented rather than fixed. If a site's admin locale
+ * changes, every translated `policy_text` changes with it, so every block
+ * legitimately reports an update. Worse, a plugin that translates BOTH its
+ * name and its text matches neither identity pass and cycles removed + added,
+ * orphaning any override on it. Core has exactly the same limitation, and
+ * plugin display names are in practice untranslated brand names.
+ */
+class Content_Collector {
+
+	/**
+	 * Option holding the snapshot. Written with autoload false: it is
+	 * admin/render-source data, never needed on an ordinary frontend request,
+	 * and can run to tens of kilobytes on a plugin-heavy site.
+	 */
+	const OPTION = 'faz_privacy_content_snapshot';
+
+	/** Stored shape version. Bump and migrate in place when the shape changes. */
+	const SCHEMA = 1;
+
+	/**
+	 * Hard cap on stored blocks. No real install comes close; the cap exists
+	 * so a malformed or pathological producer cannot grow the option without
+	 * bound. Same rationale as `Section_Overrides::MAX_SECTIONS`.
+	 */
+	const MAX_BLOCKS = 100;
+
+	/** Maximum length of one block body, in characters (WooCommerce's is ~5 KB). */
+	const MAX_HTML = 60000;
+
+	/** Maximum length of a stored plugin display name, in characters. */
+	const MAX_NAME = 200;
+
+	/**
+	 * Register the collection listener. Called once from
+	 * `CLI::register_privacy_hooks()`.
+	 *
+	 * `current_screen` rather than `admin_init` for two reasons. It fires only
+	 * in genuine wp-admin page requests — `set_current_screen()` is not
+	 * reached by WP-CLI, REST or admin-ajax, whereas `admin_init` fires on
+	 * admin-ajax.php and can be force-fired from the CLI, which is the exact
+	 * path that fatals WooCommerce. And it fires AFTER `admin_init`, so every
+	 * producer registered at default priority — FAZ's own included — has
+	 * already called `wp_add_privacy_policy_content()`.
+	 *
+	 * @return void
+	 */
+	public static function register_hooks() {
+		\add_action( 'current_screen', array( __CLASS__, 'maybe_collect' ) );
+	}
+
+	/**
+	 * Collect, if and only if this really is an operator looking at a FAZ
+	 * admin screen.
+	 *
+	 * Restricting to FAZ's own screens is deliberate. Collecting on every
+	 * wp-admin pageview sitewide would run the read (and risk an option write)
+	 * forever, to keep fresh a snapshot only FAZ's document consumes. Firing
+	 * on FAZ screens refreshes it exactly when the operator is looking at the
+	 * plugin — including, later, the privacy-policy editor screen itself,
+	 * which lands on a `faz-cookie-manager-*` slug and therefore always opens
+	 * against freshly collected data.
+	 *
+	 * @param \WP_Screen $screen Current admin screen.
+	 * @return void
+	 */
+	public static function maybe_collect( $screen ) {
+		// Belt and braces: restate the environment `current_screen` implies,
+		// so the method stays safe if anything ever calls it directly.
+		if ( ! \is_admin() || ! \did_action( 'admin_init' ) ) {
+			return;
+		}
+
+		// Explicit denial of every context the core guard forbids.
+		if ( \wp_doing_ajax() || \wp_doing_cron() ) {
+			return;
+		}
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+
+		// Collection writes an option; only an operator-grade request may.
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! is_object( $screen ) || ! isset( $screen->id ) ) {
+			return;
+		}
+		if ( false === strpos( (string) $screen->id, 'faz-cookie-manager' ) ) {
+			return;
+		}
+
+		self::collect();
+	}
+
+	/**
+	 * Perform one collection: read the registered contributions, sanitise
+	 * them, diff against the stored snapshot, and persist only if something
+	 * material changed.
+	 *
+	 * Guards are the caller's responsibility — `maybe_collect()` applies them,
+	 * and so must the future admin screen's explicit refresh control.
+	 *
+	 * @return array The current (possibly just-updated) snapshot.
+	 */
+	public static function collect() {
+		$snapshot = self::get_snapshot();
+		$incoming = self::registered_content();
+		$result   = self::diff( $snapshot['blocks'], $incoming );
+
+		if ( ! $result['changed'] ) {
+			// An unchanged collection is a pure read. Not even `collected_at`
+			// moves: the timestamp records the last MATERIAL change, and
+			// bumping it would write the option on every admin pageview.
+			return $snapshot;
+		}
+
+		$snapshot['schema']       = self::SCHEMA;
+		$snapshot['collected_at'] = time();
+		$snapshot['blocks']       = $result['blocks'];
+
+		\update_option( self::OPTION, $snapshot, false );
+
+		return $snapshot;
+	}
+
+	/**
+	 * The stored snapshot, shape-validated. Never returns junk: a corrupt or
+	 * foreign-schema option reads as an empty snapshot and the next collection
+	 * rebuilds it from scratch.
+	 *
+	 * @return array{schema:int,collected_at:int,blocks:array}
+	 */
+	public static function get_snapshot() {
+		$empty = array(
+			'schema'       => self::SCHEMA,
+			'collected_at' => 0,
+			'blocks'       => array(),
+		);
+
+		$raw = \get_option( self::OPTION );
+		if ( ! is_array( $raw ) ) {
+			return $empty;
+		}
+		if ( ! isset( $raw['schema'] ) || (int) $raw['schema'] !== self::SCHEMA ) {
+			return $empty;
+		}
+		if ( ! isset( $raw['blocks'] ) || ! is_array( $raw['blocks'] ) ) {
+			return $empty;
+		}
+
+		$blocks = array();
+		foreach ( $raw['blocks'] as $id => $block ) {
+			if ( ! is_string( $id ) || '' === $id ) {
+				continue;
+			}
+			$normalised = self::normalize_block( $block );
+			if ( null === $normalised ) {
+				// Drop the malformed block, keep its siblings. A legal
+				// document is better off missing one section than absent.
+				continue;
+			}
+			$blocks[ $id ] = $normalised;
+		}
+
+		return array(
+			'schema'       => self::SCHEMA,
+			'collected_at' => isset( $raw['collected_at'] ) && is_numeric( $raw['collected_at'] ) ? (int) $raw['collected_at'] : 0,
+			'blocks'       => $blocks,
+		);
+	}
+
+	/**
+	 * Per-block rows for the admin editor. Pure read, no side effects.
+	 *
+	 * `stale` and `orphaned` are derived here and deliberately never stored:
+	 * a derived flag cannot desynchronise from the data it describes, a
+	 * stored copy can. Same reason `Section_Overrides::describe()` derives
+	 * `active` instead of persisting it.
+	 *
+	 * @return array<int,array{id:string,plugin_name:string,source_html:string,override:string,effective_html:string,removed:bool,stale:bool,orphaned:bool,added:int,updated:int}>
+	 */
+	public static function describe() {
+		$snapshot = self::get_snapshot();
+		$rows     = array();
+
+		foreach ( $snapshot['blocks'] as $id => $block ) {
+			$override = $block['override']['text'];
+			$rows[]   = array(
+				'id'             => $id,
+				'plugin_name'    => $block['plugin_name'],
+				'source_html'    => $block['source_html'],
+				'override'       => $override,
+				'effective_html' => '' !== $override ? $override : $block['source_html'],
+				'removed'        => $block['removed'] > 0,
+				'stale'          => '' !== $override && $block['override']['anchor_hash'] !== $block['source_hash'],
+				'orphaned'       => '' !== $override && $block['removed'] > 0,
+				'added'          => $block['added'],
+				'updated'        => $block['updated'],
+			);
+		}
+
+		// Stable, human order for the UI. Ties break on id so the order never
+		// depends on option storage order.
+		usort(
+			$rows,
+			function ( $a, $b ) {
+				$cmp = strcasecmp( $a['plugin_name'], $b['plugin_name'] );
+				return 0 !== $cmp ? $cmp : strcmp( $a['id'], $b['id'] );
+			}
+		);
+
+		return $rows;
+	}
+
+	/**
+	 * What a renderer consumes: render-ready blocks, already resolved to the
+	 * operator's wording where one exists.
+	 *
+	 * A block whose producer is gone AND which carries an override stays in:
+	 * the operator's wording is their document until they delete it. A
+	 * removed block without an override never gets here — the diff deleted it.
+	 *
+	 * @return array<string,array{plugin_name:string,html:string}>
+	 */
+	public static function effective_blocks() {
+		$snapshot = self::get_snapshot();
+		$out      = array();
+
+		foreach ( $snapshot['blocks'] as $id => $block ) {
+			$override = $block['override']['text'];
+			if ( '' === $override && $block['removed'] > 0 ) {
+				continue;
+			}
+			$out[ $id ] = array(
+				'plugin_name' => $block['plugin_name'],
+				'html'        => '' !== $override ? $override : $block['source_html'],
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Save (or clear) the operator's own wording for one block.
+	 *
+	 * An empty or whitespace-only body clears the override, which puts the
+	 * block back to tracking upstream — the Cookie Policy's "empty box means
+	 * shipped text" rule. Clearing the override of a block whose producer is
+	 * gone deletes the block outright: nothing is left to track and nothing is
+	 * left to render.
+	 *
+	 * An unknown id returns false rather than creating a bucket, so a typo in
+	 * a future UI cannot invent a section (same judgement as
+	 * `Section_Overrides::sanitize()`).
+	 *
+	 * Capability and nonce checks belong to the caller. This is the data
+	 * layer, and it must stay callable from standalone tests.
+	 *
+	 * @param string $block_id Block id.
+	 * @param string $html     Operator-authored HTML.
+	 * @return bool True when the snapshot was actually written.
+	 */
+	public static function set_override( $block_id, $html ) {
+		$block_id = (string) $block_id;
+		$snapshot = self::get_snapshot();
+
+		if ( '' === $block_id || ! isset( $snapshot['blocks'][ $block_id ] ) ) {
+			return false;
+		}
+
+		$block = $snapshot['blocks'][ $block_id ];
+		$clean = self::sanitize_html( $html );
+
+		if ( '' === $clean ) {
+			if ( $block['removed'] > 0 ) {
+				unset( $snapshot['blocks'][ $block_id ] );
+			} elseif ( '' === $block['override']['text'] ) {
+				return false;
+			} else {
+				$snapshot['blocks'][ $block_id ]['override'] = array(
+					'text'        => '',
+					'anchor_hash' => '',
+				);
+			}
+		} else {
+			if ( $clean === $block['override']['text'] && $block['source_hash'] === $block['override']['anchor_hash'] ) {
+				return false;
+			}
+			$snapshot['blocks'][ $block_id ]['override'] = array(
+				'text'        => $clean,
+				// The anchor is the source as it stood when the operator
+				// decided. When the source moves away from it, the block is
+				// stale — flagged for review, never overwritten.
+				'anchor_hash' => $block['source_hash'],
+			);
+		}
+
+		// `collected_at` deliberately does not move: it records the last time
+		// COLLECTION found a change, and an editorial decision is not one.
+		\update_option( self::OPTION, $snapshot, false );
+
+		return true;
+	}
+
+	/**
+	 * Sanitise one block body.
+	 *
+	 * Order matters and is load-bearing: kses, then clip, then trim, and the
+	 * hash is taken on the FINAL stored string. Hashing the producer's raw
+	 * text instead would make every block whose text kses touches re-hash
+	 * differently from what is stored, producing a phantom "updated" — and a
+	 * false stale flag on every operator-edited block — on every single
+	 * collection, forever.
+	 *
+	 * @param string $html Raw HTML.
+	 * @return string
+	 */
+	private static function sanitize_html( $html ) {
+		return trim( self::clip( \wp_kses_post( (string) $html ), self::MAX_HTML ) );
+	}
+
+	/**
+	 * Clip a string to a character budget, multibyte-aware where possible.
+	 *
+	 * @param string $text Text.
+	 * @param int    $max  Maximum characters.
+	 * @return string
+	 */
+	private static function clip( $text, $max ) {
+		$text = (string) $text;
+		$max  = (int) $max;
+		if ( function_exists( 'mb_substr' ) ) {
+			return mb_substr( $text, 0, $max );
+		}
+		return substr( $text, 0, $max );
+	}
+
+	/**
+	 * The contributions currently registered by plugins, sanitised and hashed.
+	 *
+	 * The leading backslashes are not decoration: this file lives in a
+	 * namespace, and an unqualified `WP_Privacy_Policy_Content` resolves to
+	 * `FazCookie\…\WP_Privacy_Policy_Content` and fatals. Same bug family as
+	 * issues #85 and #9, and the same reason the admin-only include has to be
+	 * required by hand — REST and other non-admin entry points do not load
+	 * wp-admin includes.
+	 *
+	 * @return array<int,array{name:string,html:string,hash:string}>
+	 */
+	private static function registered_content() {
+		if ( ! class_exists( '\WP_Privacy_Policy_Content' ) ) {
+			$file = ABSPATH . 'wp-admin/includes/class-wp-privacy-policy-content.php';
+			if ( ! file_exists( $file ) ) {
+				return array();
+			}
+			require_once $file;
+		}
+		if ( ! method_exists( '\WP_Privacy_Policy_Content', 'get_suggested_policy_text' ) ) {
+			return array();
+		}
+
+		$raw = \WP_Privacy_Policy_Content::get_suggested_policy_text();
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $raw as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			// Entries carrying a `removed` timestamp are read back out of
+			// core's post-meta cache and are NOT currently registered. Keeping
+			// them would resurrect every plugin the site ever deactivated.
+			if ( ! empty( $entry['removed'] ) ) {
+				continue;
+			}
+
+			// Core's `added`/`updated` timestamps are ignored on purpose: they
+			// are computed against `wp_page_for_privacy_policy`, and mean
+			// nothing on a site that never configured one.
+			$name = isset( $entry['plugin_name'] ) ? \sanitize_text_field( (string) $entry['plugin_name'] ) : '';
+			$name = trim( self::clip( $name, self::MAX_NAME ) );
+			$html = self::sanitize_html( isset( $entry['policy_text'] ) ? $entry['policy_text'] : '' );
+
+			if ( '' === $name || '' === $html ) {
+				continue;
+			}
+
+			$out[] = array(
+				'name' => $name,
+				'html' => $html,
+				'hash' => hash( 'sha256', $html ),
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Reconcile the incoming contributions against the stored blocks.
+	 *
+	 * Pure function of its inputs plus `time()` — no option reads or writes —
+	 * so the whole reconciliation is drivable from tests through `collect()`.
+	 *
+	 * @param array $stored_blocks Normalised stored blocks, keyed by id.
+	 * @param array $incoming      Output of `registered_content()`.
+	 * @return array{blocks:array,changed:bool}
+	 */
+	private static function diff( array $stored_blocks, array $incoming ) {
+		$now     = time();
+		$blocks  = $stored_blocks;
+		$matched = array();
+
+		// PASS 1 — match on the text itself. This is what carries a block
+		// across a rename or a translated plugin name: the declaration did not
+		// change, only the label on it.
+		$unmatched = array();
+		foreach ( $incoming as $entry ) {
+			$id = null;
+			foreach ( $blocks as $candidate_id => $block ) {
+				if ( isset( $matched[ $candidate_id ] ) ) {
+					continue;
+				}
+				if ( $block['source_hash'] === $entry['hash'] ) {
+					$id = $candidate_id;
+					break;
+				}
+			}
+			if ( null === $id ) {
+				$unmatched[] = $entry;
+				continue;
+			}
+
+			$matched[ $id ] = true;
+			// Adopt the current display name, and revive a block whose
+			// producer came back.
+			$blocks[ $id ]['plugin_name'] = $entry['name'];
+			$blocks[ $id ]['removed']     = 0;
+		}
+
+		// PASS 2 — match on the plugin name. This is what carries a block
+		// across a rewritten declaration.
+		//
+		// Only a name that is unambiguous on BOTH sides may match: one
+		// remaining stored block with that name, one remaining incoming entry
+		// with it. Two plugins can register under the same display name (the
+		// duplicate ids exist for exactly that reason), and matching a rewrite
+		// against the wrong twin would silently swap two blocks' identities —
+		// and with them, the operator's overrides. When it is ambiguous the
+		// blocks churn (removed + added) instead, which is recoverable;
+		// swapped identities are not.
+		$still = array();
+		foreach ( $unmatched as $entry ) {
+			$candidates = array();
+			foreach ( $blocks as $candidate_id => $block ) {
+				if ( isset( $matched[ $candidate_id ] ) ) {
+					continue;
+				}
+				if ( $block['plugin_name'] === $entry['name'] ) {
+					$candidates[] = $candidate_id;
+				}
+			}
+
+			$rivals = 0;
+			foreach ( $unmatched as $other ) {
+				if ( $other['name'] === $entry['name'] ) {
+					++$rivals;
+				}
+			}
+
+			if ( 1 !== count( $candidates ) || 1 !== $rivals ) {
+				$still[] = $entry;
+				continue;
+			}
+
+			$id             = $candidates[0];
+			$matched[ $id ] = true;
+
+			$blocks[ $id ]['source_html'] = $entry['html'];
+			$blocks[ $id ]['source_hash'] = $entry['hash'];
+			$blocks[ $id ]['updated']     = $now;
+			$blocks[ $id ]['removed']     = 0;
+		}
+
+		// PASS 3 — anything still unclaimed is a producer seen for the first
+		// time. The cap refuses new blocks; it never truncates the map,
+		// because truncation could evict a block the operator has edited.
+		foreach ( $still as $entry ) {
+			if ( count( $blocks ) >= self::MAX_BLOCKS ) {
+				break;
+			}
+			$id            = self::block_id_for( $entry['name'], $entry['hash'], $blocks );
+			$blocks[ $id ] = array(
+				'plugin_name' => $entry['name'],
+				'source_html' => $entry['html'],
+				'source_hash' => $entry['hash'],
+				'added'       => $now,
+				'updated'     => 0,
+				'removed'     => 0,
+				'override'    => array(
+					'text'        => '',
+					'anchor_hash' => '',
+				),
+			);
+			$matched[ $id ] = true;
+		}
+
+		// PASS 4 — stored blocks nobody claimed: the producer is gone. Drop
+		// the untouched ones, keep and flag the ones the operator rewrote.
+		foreach ( $blocks as $id => $block ) {
+			if ( isset( $matched[ $id ] ) ) {
+				continue;
+			}
+			if ( '' === $block['override']['text'] ) {
+				unset( $blocks[ $id ] );
+				continue;
+			}
+			if ( 0 === $block['removed'] ) {
+				$blocks[ $id ]['removed'] = $now;
+			}
+		}
+
+		// Compare on sorted keys so that mere storage order never reads as a
+		// change — an option write on every admin pageview is the bug this
+		// guards against.
+		$before = $stored_blocks;
+		$after  = $blocks;
+		ksort( $before );
+		ksort( $after );
+
+		return array(
+			'blocks'  => $blocks,
+			'changed' => ( $before !== $after ),
+		);
+	}
+
+	/**
+	 * A stable, readable id for a newly seen block.
+	 *
+	 * The slugged plugin name is the id whenever it is free. Two plugins
+	 * declaring under the same display name get a hash suffix, so the second
+	 * one is not silently folded into the first.
+	 *
+	 * @param string $name  Plugin display name.
+	 * @param string $hash  Source hash of the block.
+	 * @param array  $taken Blocks already keyed in the map.
+	 * @return string
+	 */
+	private static function block_id_for( $name, $hash, array $taken ) {
+		$base = \sanitize_title( $name );
+		if ( '' === $base ) {
+			$base = 'plugin';
+		}
+		if ( ! isset( $taken[ $base ] ) ) {
+			return $base;
+		}
+
+		$id = $base . '-' . substr( $hash, 0, 8 );
+		if ( ! isset( $taken[ $id ] ) ) {
+			return $id;
+		}
+
+		// Same name AND same text as an existing key: only reachable from a
+		// corrupted map, but it must still terminate with a unique key.
+		$n = 2;
+		while ( isset( $taken[ $id . '-' . $n ] ) ) {
+			++$n;
+		}
+		return $id . '-' . $n;
+	}
+
+	/**
+	 * Validate and normalise one stored block into canonical key order.
+	 *
+	 * Canonical order matters: `diff()` decides whether to write by comparing
+	 * arrays, and two blocks differing only in key order would read as a
+	 * change.
+	 *
+	 * @param mixed $block Raw stored block.
+	 * @return array|null Normalised block, or null when it is unusable.
+	 */
+	private static function normalize_block( $block ) {
+		if ( ! is_array( $block ) ) {
+			return null;
+		}
+
+		foreach ( array( 'plugin_name', 'source_html', 'source_hash' ) as $key ) {
+			if ( ! isset( $block[ $key ] ) || ! is_string( $block[ $key ] ) ) {
+				return null;
+			}
+		}
+		if ( '' === $block['source_hash'] || '' === $block['plugin_name'] ) {
+			return null;
+		}
+
+		$times = array();
+		foreach ( array( 'added', 'updated', 'removed' ) as $key ) {
+			if ( ! isset( $block[ $key ] ) || ! is_numeric( $block[ $key ] ) ) {
+				return null;
+			}
+			$times[ $key ] = (int) $block[ $key ];
+		}
+
+		if ( ! isset( $block['override'] ) || ! is_array( $block['override'] ) ) {
+			return null;
+		}
+		$override = $block['override'];
+		if ( ! isset( $override['text'] ) || ! is_string( $override['text'] ) ) {
+			return null;
+		}
+		if ( ! isset( $override['anchor_hash'] ) || ! is_string( $override['anchor_hash'] ) ) {
+			return null;
+		}
+
+		return array(
+			'plugin_name' => $block['plugin_name'],
+			'source_html' => $block['source_html'],
+			'source_hash' => $block['source_hash'],
+			'added'       => $times['added'],
+			'updated'     => $times['updated'],
+			'removed'     => $times['removed'],
+			'override'    => array(
+				'text'        => $override['text'],
+				'anchor_hash' => $override['anchor_hash'],
+			),
+		);
+	}
+}

--- a/admin/modules/privacy-policy-generator/includes/class-content-collector.php
+++ b/admin/modules/privacy-policy-generator/includes/class-content-collector.php
@@ -387,7 +387,7 @@ class Content_Collector {
 	/**
 	 * Sanitise one block body.
 	 *
-	 * Order matters and is load-bearing: kses, then clip, then trim, and the
+	 * Order matters and is load-bearing: kses, then HTML-aware clip, then trim, and the
 	 * hash is taken on the FINAL stored string. Hashing the producer's raw
 	 * text instead would make every block whose text kses touches re-hash
 	 * differently from what is stored, producing a phantom "updated" — and a
@@ -398,7 +398,35 @@ class Content_Collector {
 	 * @return string
 	 */
 	private static function sanitize_html( $html ) {
-		return trim( self::clip( \wp_kses_post( (string) $html ), self::MAX_HTML ) );
+		$html = \wp_kses_post( (string) $html );
+		if ( self::length( $html ) <= self::MAX_HTML ) {
+			return trim( $html );
+		}
+
+		// A character slice can end inside `<a href="…` or leave an open
+		// element. Rebalance after clipping, then reduce the text budget by the
+		// closing tags that balancing added until the final stored HTML fits.
+		$budget = self::MAX_HTML;
+		while ( $budget > 0 ) {
+			$clipped    = self::clip( $html, $budget );
+			$last_open  = strrpos( $clipped, '<' );
+			$last_close = strrpos( $clipped, '>' );
+			if ( false !== $last_open && ( false === $last_close || $last_open > $last_close ) ) {
+				$clipped = substr( $clipped, 0, $last_open );
+			}
+			$balanced = function_exists( 'force_balance_tags' ) ? \force_balance_tags( $clipped ) : $clipped;
+			$length   = self::length( $balanced );
+			if ( $length <= self::MAX_HTML ) {
+				return trim( $balanced );
+			}
+			$budget -= max( 1, $length - self::MAX_HTML );
+		}
+		return '';
+	}
+
+	/** Character length, multibyte-aware where possible. */
+	private static function length( $text ) {
+		return function_exists( 'mb_strlen' ) ? mb_strlen( (string) $text ) : strlen( (string) $text );
 	}
 
 	/**
@@ -495,23 +523,23 @@ class Content_Collector {
 		$blocks  = $stored_blocks;
 		$matched = array();
 
-		// PASS 1 — match on the text itself. This is what carries a block
-		// across a rename or a translated plugin name: the declaration did not
-		// change, only the label on it.
-		$unmatched = array();
+		// PASS 1 — exact identity first. This must precede hash-only matching:
+		// two unrelated plugins can publish identical boilerplate, and incoming
+		// order must never swap their names (or operator overrides) between ids.
+		$remaining = array();
 		foreach ( $incoming as $entry ) {
 			$id = null;
 			foreach ( $blocks as $candidate_id => $block ) {
 				if ( isset( $matched[ $candidate_id ] ) ) {
 					continue;
 				}
-				if ( $block['source_hash'] === $entry['hash'] ) {
+				if ( $block['plugin_name'] === $entry['name'] && $block['source_hash'] === $entry['hash'] ) {
 					$id = $candidate_id;
 					break;
 				}
 			}
 			if ( null === $id ) {
-				$unmatched[] = $entry;
+				$remaining[] = $entry;
 				continue;
 			}
 
@@ -522,7 +550,33 @@ class Content_Collector {
 			$blocks[ $id ]['removed']     = 0;
 		}
 
-		// PASS 2 — match on the plugin name. This is what carries a block
+		// PASS 2 — hash-only rename carry-forward, but only when the hash is
+		// unique on both sides. Shared boilerplate is not an identity key.
+		$unmatched = array();
+		foreach ( $remaining as $entry ) {
+			$candidates = array();
+			foreach ( $blocks as $candidate_id => $block ) {
+				if ( ! isset( $matched[ $candidate_id ] ) && $block['source_hash'] === $entry['hash'] ) {
+					$candidates[] = $candidate_id;
+				}
+			}
+			$rivals = 0;
+			foreach ( $remaining as $other ) {
+				if ( $other['hash'] === $entry['hash'] ) {
+					++$rivals;
+				}
+			}
+			if ( 1 !== count( $candidates ) || 1 !== $rivals ) {
+				$unmatched[] = $entry;
+				continue;
+			}
+			$id = $candidates[0];
+			$matched[ $id ] = true;
+			$blocks[ $id ]['plugin_name'] = $entry['name'];
+			$blocks[ $id ]['removed']     = 0;
+		}
+
+		// PASS 3 — match on the plugin name. This is what carries a block
 		// across a rewritten declaration.
 		//
 		// Only a name that is unambiguous on BOTH sides may match: one
@@ -566,7 +620,7 @@ class Content_Collector {
 			$blocks[ $id ]['removed']     = 0;
 		}
 
-		// PASS 3 — anything still unclaimed is a producer seen for the first
+		// PASS 4 — anything still unclaimed is a producer seen for the first
 		// time. The cap refuses new blocks; it never truncates the map,
 		// because truncation could evict a block the operator has edited.
 		foreach ( $still as $entry ) {
@@ -589,7 +643,7 @@ class Content_Collector {
 			$matched[ $id ] = true;
 		}
 
-		// PASS 4 — stored blocks nobody claimed: the producer is gone. Drop
+		// PASS 5 — stored blocks nobody claimed: the producer is gone. Drop
 		// the untouched ones, keep and flag the ones the operator rewrote.
 		foreach ( $blocks as $id => $block ) {
 			if ( isset( $matched[ $id ] ) ) {

--- a/admin/modules/privacy-policy-generator/includes/index.php
+++ b/admin/modules/privacy-policy-generator/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/admin/modules/privacy-policy-generator/index.php
+++ b/admin/modules/privacy-policy-generator/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/docs/privacy-policy-collection-design.md
+++ b/docs/privacy-policy-collection-design.md
@@ -1,0 +1,207 @@
+# Privacy Policy — collecting what plugins declare about themselves
+
+Written 2026-07-31, after verifying the mechanism against WordPress core and against the plugins
+installed on the faz-test site. This document is the rationale behind
+`admin/modules/privacy-policy-generator/includes/class-content-collector.php`. It exists mostly for
+one reason: **the admin-only constraint recorded below is not obvious, looks like an arbitrary
+restriction, and lifting it fatals sites running WooCommerce.** Read the constraint section before
+changing anything about when collection runs.
+
+It also revises §P0a of the legal-documents generator plan (`docs/legal-documents-generator-plan.md`,
+landing on its own branch), which assumed a different and more dangerous approach.
+
+## The correction this makes to the plan
+
+The plan assumed the Privacy Policy would need reviewed legal text, authored by us, describing what a
+site processes — for four jurisdictions across eight languages. It flagged that as risk R1 (legal) and
+R6 (editorial quality). That framing was wrong in an important way.
+
+**We should not author claims about what a site processes. We should collect the claims each installed
+plugin already makes about itself.** WordPress has had the mechanism since 4.9.6:
+
+- Producers call `wp_add_privacy_policy_content( $plugin_name, $policy_text )`.
+- `WP_Privacy_Policy_Content::get_suggested_policy_text()` returns every registered contribution.
+
+FAZ is already a *producer* — `includes/class-cli.php` registers its own consent-log disclosure. This
+makes it a *consumer* too, which is the symmetric and obvious move.
+
+On the faz-test install alone, six third-party plugins already declare content: WooCommerce, LiteSpeed
+Cache, Akismet, Burst Statistics, WP Statistics and Beehive Analytics. Each block is written by that
+plugin's own author about their own processing — which is both more accurate than anything we could
+write and, legally, their statement rather than ours.
+
+This substantially lowers R1. The generated document becomes *the site's own installed software
+describing itself*, plus the operator's own supplied facts, plus jurisdiction-fixed rights text (which
+is law, not a claim about the site). We are not inventing processing descriptions.
+
+## Hard constraint — collection is admin-only
+
+`wp_add_privacy_policy_content()` calls `_doing_it_wrong()` unless it runs in wp-admin on `admin_init`
+or later; the guard was added in 4.9.7 and lives in `wp-includes/functions.php`. Producers therefore
+register their content on `admin_init`, which means **that content does not exist at all in any other
+context** — not on the frontend, not under WP-CLI, not in a REST request.
+
+Verified the hard way. Forcing `do_action( 'admin_init' )` from WP-CLI, to "warm up" the producers
+before reading them, produced six `_doing_it_wrong` notices and then a **fatal inside WooCommerce**:
+`Automattic\WooCommerce\Internal\Orders\OrderAttributionController::get_order_screen_id()` calls
+`wc_get_page_screen_id()`, which is undefined outside a real admin request.
+
+So the architecture is fixed, and the fix is structural rather than defensive:
+
+1. **Collect only inside a genuine wp-admin page request.** Never from the frontend, never from
+   WP-CLI, never from REST or cron.
+2. **Snapshot into a plugin option** (`faz_privacy_content_snapshot`).
+3. **Render the public document from the snapshot**, never from a live collection.
+
+Point 3 is not just a consequence of point 1. It is independently required by Cache Compatibility Mode
+(1.21.0): a live collection at render time would make the rendered output depend on request context,
+which is exactly the per-visitor variance that release eliminated.
+
+### Why `current_screen` and not `admin_init`
+
+`admin_init` is the obvious hook and the wrong one. It also fires on `admin-ajax.php`, and it can be
+force-fired from the CLI — the exact path that fatals WooCommerce.
+
+`current_screen` is reached only through `set_current_screen()`, which runs in genuine wp-admin page
+requests and nowhere else. It also fires *after* `admin_init`, so every producer registered at default
+priority — including FAZ's own — has already contributed by the time collection runs. The context is
+therefore correct by construction rather than by assertion; the explicit denials inside
+`maybe_collect()` (ajax, cron, REST, CLI, `is_admin()`, `did_action( 'admin_init' )`) are belt and
+braces for anyone who calls the method directly.
+
+### Why only FAZ's own screens
+
+Collection is further restricted to screens whose id contains `faz-cookie-manager`. Running it on every
+wp-admin pageview sitewide would perform the read — and risk an option write — forever, in order to
+keep fresh a snapshot that only FAZ's document consumes. Restricting it to FAZ screens refreshes the
+snapshot exactly when the operator is looking at the plugin, including (once it exists) the
+privacy-policy editor screen itself, which lands on a `faz-cookie-manager-*` slug and therefore always
+opens against freshly collected data.
+
+Even on FAZ screens, an unchanged collection is a pure read: one non-autoloaded option get and an
+in-memory comparison. The option is written only when the diff reports a material change, and
+`collected_at` does not move otherwise.
+
+## Everything is an editable placeholder
+
+The same semantics already shipped for the Cookie Policy in `Section_Overrides`, reused rather than
+reinvented:
+
+- Each collected block is a section. Its identity anchor is the plugin, matched first by the text
+  itself (so a rename or a translated display name carries the block forward) and then by display name
+  (so a rewritten declaration updates the block it belongs to).
+- The collected text is the **placeholder**, not the saved value. An empty override box means "keep
+  receiving updates".
+- An operator who rewrites a block keeps their wording; the block stops tracking upstream. The anchor
+  for *that* decision is the `source_hash` as it stood when the override was saved.
+- Placeholders such as `{{COMPANY_NAME}}` keep resolving inside operator-authored text, through the
+  same substitution stage as the Cookie Policy, so there is no second escaping path.
+
+The one genuinely new behaviour versus the Cookie Policy: **the upstream source moves.** A plugin can
+change or withdraw its declaration. That gives three states per block:
+
+| state | untouched block | operator-edited block |
+|---|---|---|
+| plugin updated its text | silently adopts the new text | keeps operator wording, flags "the source changed — review" (`stale`) |
+| plugin deactivated/removed | block drops out | kept, flagged "the plugin that declared this is gone" (`orphaned`) |
+| new plugin activated | block appears | n/a |
+
+The "flag, never silently overwrite" rule is the same judgement as the Cookie Policy's anchor-drift
+fallback: an explicit editorial decision by the operator is the most specific source there is, and an
+upstream change must never quietly replace it.
+
+`stale` and `orphaned` are derived at read time in `describe()` and deliberately never stored. A
+derived flag cannot desynchronise from the data it describes; a stored copy can. Same reason
+`Section_Overrides::describe()` derives `active` instead of persisting it.
+
+## Why FAZ keeps its own snapshot and its own diff
+
+Core computes `added` / `updated` / `removed` itself, by diffing the currently-registered content
+against the `_wp_suggested_privacy_policy_content` post meta of the page named by
+`wp_page_for_privacy_policy`.
+
+On a site where that option is `0` — as on faz-test today — there is no baseline, and those flags mean
+nothing. Two consequences:
+
+1. FAZ keeps **its own snapshot and its own diff**, so change detection works regardless of whether
+   core's privacy page was ever configured. Core's timestamps are ignored entirely.
+2. FAZ should **offer** to point `wp_page_for_privacy_policy` at the generated page. That is what makes
+   `get_privacy_policy_url()` resolve sitewide — the login form, comment forms and other plugins all
+   link through it, and `Renderer::privacy_policy_url()` already reads it. Offer, never silently set:
+   it is a site-wide setting the operator owns.
+
+There is one trap in core's return value: entries carrying a `removed` timestamp are read back out of
+the post-meta cache and are **not** currently registered. Keeping them would resurrect every plugin the
+site ever deactivated as a live block, so they are dropped on the way in.
+
+## Sanitisation boundary
+
+Each collected body goes through `wp_kses_post()`, then a character clip, then a trim — and the
+`source_hash` is computed on that **final stored string**.
+
+The order is load-bearing. Hashing the producer's raw text instead would make every block whose text
+kses touches hash differently from what is stored, so every collection would see a phantom "updated" —
+and would raise a false `stale` flag on every operator-edited block — forever. The unit suite pins this
+with a deliberately observable kses stub (a naive `<script>` strip): weakening that stub to the
+identity function would make the suite pass without proving anything.
+
+Operator overrides pass through the same `sanitize_html()`. There is one sanitisation path, not two.
+
+## Bounds
+
+`MAX_BLOCKS` (100), `MAX_HTML` (60 000 characters per body — WooCommerce's is around 5 KB) and
+`MAX_NAME` (200) exist so a malformed or pathological producer cannot grow the option without bound.
+Same rationale as `Section_Overrides::MAX_SECTIONS`.
+
+The cap **refuses new blocks; it never truncates the map.** Truncating could evict a block the operator
+has edited, and losing an editorial decision is a worse failure than missing a section.
+
+The snapshot is written with `update_option( …, …, false )` on every write path. It is admin and
+render-source data, never needed on an ordinary frontend request, and can run to tens of kilobytes.
+`update_option`'s default autoload for a *new* option is yes, so the third argument has to be passed
+every time, not only on the first write.
+
+## Accepted side effect
+
+`get_suggested_policy_text()` refreshes core's `_wp_suggested_privacy_policy_content` meta cache when a
+privacy page **is** configured, which can pre-empt core's own "suggested text has changed" admin
+notice.
+
+This is accepted. It is core's public, sanctioned accessor — the same refresh happens whenever the
+operator opens core's Privacy Policy Guide — the effect is bounded to installs that both configured a
+privacy page and visit FAZ screens, and FAZ's own three-state flagging supersedes that notice for
+FAZ-managed documents. Reading the private `$policy_content` property by Reflection to avoid it was
+considered and rejected: worse for wp.org review and brittle against core refactors.
+
+## Known blind spot
+
+If a site's admin locale changes, every translated `policy_text` changes with it, so every block
+legitimately reports an update. Worse, a plugin that translates **both** its display name and its text
+matches neither identity pass and cycles removed + added, orphaning any override on it.
+
+Core has exactly the same limitation, and plugin display names are in practice untranslated brand
+names. Documented rather than fixed.
+
+## What still needs human editorial work
+
+Reduced, but not zero:
+
+- The **jurisdiction-fixed rights text** (GDPR Arts. 15-22, CCPA rights, LGPD Art. 18, POPIA) — statute,
+  reviewable once, and not a claim about the site.
+- The **structural scaffold** that frames the collected blocks: who the controller is, contact,
+  retention, transfers, how to exercise rights.
+- The **operator-supplied facts**, which the plugin must refuse to invent — same rule as the Cookie
+  Policy: never seed from `admin_email` / `blogname`, and refuse to render when mandatory jurisdiction
+  fields are missing.
+
+## Consequences for the plan
+
+- §P0a effort shifts: less editorial authoring, more collection/snapshot/diff machinery. The 45/55
+  architectural/editorial split should be revised accordingly.
+- R1 mitigation gains a load-bearing element: "the plugin aggregates first-party declarations and does
+  not author third-party processing descriptions".
+- The privacy-policy `Document_Config` gains two registry fields: a collector callable
+  (`Content_Collector::collect`) and the snapshot option name
+  (`faz_privacy_content_snapshot`). The renderer-facing accessor `effective_blocks()` already returns
+  render-ready `id => [plugin_name, html]` pairs, so no migration is needed when that lands.
+- The refusal gating (`missing_required_settings()`, POPIA-only today) still applies and still matters.

--- a/docs/privacy-policy-collection-design.md
+++ b/docs/privacy-policy-collection-design.md
@@ -87,9 +87,11 @@ in-memory comparison. The option is written only when the diff reports a materia
 The same semantics already shipped for the Cookie Policy in `Section_Overrides`, reused rather than
 reinvented:
 
-- Each collected block is a section. Its identity anchor is the plugin, matched first by the text
-  itself (so a rename or a translated display name carries the block forward) and then by display name
-  (so a rewritten declaration updates the block it belongs to).
+- Each collected block is a section. Identity matching is deliberately ordered: exact display
+  name + source hash first; hash-only rename carry-forward only when that hash is unique on both
+  sides; then name-only rewrite carry-forward, again only when unique on both sides. This prevents
+  two plugins that publish identical boilerplate from exchanging ids and operator overrides when
+  WordPress returns them in a different order.
 - The collected text is the **placeholder**, not the saved value. An empty override box means "keep
   receiving updates".
 - An operator who rewrites a block keeps their wording; the block stops tracking upstream. The anchor
@@ -136,7 +138,8 @@ site ever deactivated as a live block, so they are dropped on the way in.
 
 ## Sanitisation boundary
 
-Each collected body goes through `wp_kses_post()`, then a character clip, then a trim — and the
+Each collected body goes through `wp_kses_post()`, then an HTML-aware character clip that removes a
+partial trailing tag and balances open elements within the same budget, then a trim — and the
 `source_hash` is computed on that **final stored string**.
 
 The order is load-bearing. Hashing the producer's raw text instead would make every block whose text

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -300,6 +300,11 @@ class CLI {
 			wp_add_privacy_policy_content( 'FAZ Cookie Manager', $content );
 		});
 
+		// Consume every plugin's registered privacy-policy content (FAZ's own
+		// included) into the faz_privacy_content_snapshot option. Runs only on
+		// genuine wp-admin requests, on FAZ screens — see Content_Collector.
+		\FazCookie\Admin\Modules\Privacy_Policy_Generator\Includes\Content_Collector::register_hooks();
+
 		// Register personal data exporter.
 		add_filter( 'wp_privacy_personal_data_exporters', function ( $exporters ) {
 			$exporters['faz-cookie-manager'] = array(

--- a/tests/unit/test-privacy-content-collector.php
+++ b/tests/unit/test-privacy-content-collector.php
@@ -1,0 +1,534 @@
+<?php
+/**
+ * Standalone unit tests for the privacy-policy content collector.
+ *
+ * Covers the contract the generated Privacy Policy depends on: the snapshot is
+ * built only from currently-registered declarations, sanitisation happens
+ * before hashing (so an unchanged plugin never reads as changed), an
+ * unchanged collection never writes, operator overrides are never silently
+ * overwritten, and every context the core `_doing_it_wrong` guard forbids is
+ * refused.
+ *
+ * Run:
+ *   php tests/unit/test-privacy-content-collector.php
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+
+// ---------------------------------------------------------------------------
+// WordPress stubs — only what the collector actually touches.
+// ---------------------------------------------------------------------------
+
+$GLOBALS['faz_pc_options']       = array();
+$GLOBALS['faz_pc_writes']        = 0;
+$GLOBALS['faz_pc_last_autoload'] = null;
+$GLOBALS['faz_pc_actions']       = array();
+$GLOBALS['faz_pc_registered']    = array();
+$GLOBALS['faz_pc_ctx']           = array(
+	'is_admin'    => true,
+	'did_action'  => true,
+	'doing_ajax'  => false,
+	'doing_cron'  => false,
+	'can_manage'  => true,
+);
+
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default_value = false ) {
+		return array_key_exists( $name, $GLOBALS['faz_pc_options'] ) ? $GLOBALS['faz_pc_options'][ $name ] : $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $name, $value, $autoload = null ) {
+		$GLOBALS['faz_pc_options'][ $name ]  = $value;
+		$GLOBALS['faz_pc_last_autoload']     = $autoload;
+		++$GLOBALS['faz_pc_writes'];
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $name ) {
+		unset( $GLOBALS['faz_pc_options'][ $name ] );
+		return true;
+	}
+}
+
+/**
+ * Deliberately a naive strip, not a faithful kses. Both the stored text and
+ * the hash go through it, and that identity is precisely the invariant under
+ * test — weakening this stub to `return $v` would make the suite pass without
+ * proving anything.
+ */
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $value ) {
+		return preg_replace( '#<script\b[^>]*>.*?</script>#is', '', (string) $value );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title ) {
+		$title = strtolower( (string) $title );
+		$title = preg_replace( '/[^a-z0-9]+/', '-', $title );
+		return trim( (string) $title, '-' );
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $value ) {
+		return trim( wp_strip_all_tags_stub( (string) $value ) );
+	}
+}
+function wp_strip_all_tags_stub( $value ) {
+	return strip_tags( $value );
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $callback, $priority = 10, $args = 1 ) {
+		$GLOBALS['faz_pc_actions'][] = array( $hook, $callback );
+		return true;
+	}
+}
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		return (bool) $GLOBALS['faz_pc_ctx']['is_admin'];
+	}
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook ) {
+		return $GLOBALS['faz_pc_ctx']['did_action'] ? 1 : 0;
+	}
+}
+if ( ! function_exists( 'wp_doing_ajax' ) ) {
+	function wp_doing_ajax() {
+		return (bool) $GLOBALS['faz_pc_ctx']['doing_ajax'];
+	}
+}
+if ( ! function_exists( 'wp_doing_cron' ) ) {
+	function wp_doing_cron() {
+		return (bool) $GLOBALS['faz_pc_ctx']['doing_cron'];
+	}
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap ) {
+		return (bool) $GLOBALS['faz_pc_ctx']['can_manage'];
+	}
+}
+
+/**
+ * Core stand-in. Defining it up front also proves the collector takes the
+ * `class_exists` short circuit: the require path points at
+ * ABSPATH . 'wp-admin/…', which does not exist here, so the absence of a
+ * fatal is itself an assertion.
+ */
+if ( ! class_exists( 'WP_Privacy_Policy_Content' ) ) {
+	class WP_Privacy_Policy_Content {
+		public static function get_suggested_policy_text() {
+			return $GLOBALS['faz_pc_registered'];
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_Screen' ) ) {
+	class WP_Screen {
+		public $id = '';
+		public function __construct( $id = '' ) {
+			$this->id = $id;
+		}
+	}
+}
+
+require_once dirname( __DIR__, 2 ) . '/admin/modules/privacy-policy-generator/includes/class-content-collector.php';
+
+use FazCookie\Admin\Modules\Privacy_Policy_Generator\Includes\Content_Collector;
+
+// ---------------------------------------------------------------------------
+// Assertions.
+// ---------------------------------------------------------------------------
+
+$faz_pc_run    = 0;
+$faz_pc_passed = 0;
+$faz_pc_failed = 0;
+
+function faz_pc_eq( $actual, $expected, $label ) {
+	global $faz_pc_run, $faz_pc_passed, $faz_pc_failed;
+	++$faz_pc_run;
+	if ( $actual === $expected ) {
+		++$faz_pc_passed;
+		echo "  \033[32m✓\033[0m {$label}\n";
+		return;
+	}
+	++$faz_pc_failed;
+	echo "  \033[31m✗\033[0m {$label}\n";
+	echo '      expected: ' . var_export( $expected, true ) . "\n";
+	echo '      actual:   ' . var_export( $actual, true ) . "\n";
+}
+
+function faz_pc_true( $condition, $label ) {
+	faz_pc_eq( (bool) $condition, true, $label );
+}
+
+/**
+ * Reset the world between groups.
+ *
+ * @param array $registered Entries WP_Privacy_Policy_Content should report.
+ * @return void
+ */
+function faz_pc_reset( $registered = array() ) {
+	$GLOBALS['faz_pc_options']       = array();
+	$GLOBALS['faz_pc_writes']        = 0;
+	$GLOBALS['faz_pc_last_autoload'] = null;
+	$GLOBALS['faz_pc_registered']    = $registered;
+	$GLOBALS['faz_pc_ctx']           = array(
+		'is_admin'   => true,
+		'did_action' => true,
+		'doing_ajax' => false,
+		'doing_cron' => false,
+		'can_manage' => true,
+	);
+}
+
+/**
+ * One registered contribution, in core's shape.
+ *
+ * @param string $name Plugin display name.
+ * @param string $text Policy text.
+ * @return array
+ */
+function faz_pc_entry( $name, $text ) {
+	return array(
+		'plugin_name' => $name,
+		'policy_text' => $text,
+	);
+}
+
+$wc_text  = '<h2>WooCommerce</h2><p>We collect order data.</p>';
+$ak_text  = '<h2>Akismet</h2><p>We send comments to Akismet.</p>';
+$faz_text = '<h2>FAZ Cookie Manager</h2><p>We record consent.</p>';
+
+echo "\n== Privacy content collector ==\n\n";
+
+// ---------------------------------------------------------------------------
+// 1. First collection.
+// ---------------------------------------------------------------------------
+
+$before = time();
+faz_pc_reset(
+	array(
+		faz_pc_entry( 'WooCommerce', $wc_text ),
+		faz_pc_entry( 'Akismet', $ak_text ),
+		faz_pc_entry( 'FAZ Cookie Manager', $faz_text ),
+	)
+);
+
+$snapshot = Content_Collector::collect();
+faz_pc_eq( $snapshot['schema'], 1, 'First collection stores schema 1' );
+faz_pc_eq(
+	array_keys( $snapshot['blocks'] ),
+	array( 'woocommerce', 'akismet', 'faz-cookie-manager' ),
+	'Block ids are slugged plugin names'
+);
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 1, 'First collection writes the option exactly once' );
+faz_pc_eq( $GLOBALS['faz_pc_last_autoload'], false, 'Snapshot is written with autoload false' );
+faz_pc_true( $snapshot['collected_at'] >= $before, 'collected_at is stamped' );
+
+foreach ( $snapshot['blocks'] as $id => $block ) {
+	faz_pc_eq( $block['source_hash'], hash( 'sha256', $block['source_html'] ), "Hash matches stored text for {$id}" );
+}
+faz_pc_true( $snapshot['blocks']['woocommerce']['added'] >= $before, 'New block records added' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['updated'], 0, 'New block has no updated timestamp' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['removed'], 0, 'New block is not removed' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['override'], array( 'text' => '', 'anchor_hash' => '' ), 'New block has an empty override' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['source_html'], $wc_text, 'Block carries the producer text verbatim' );
+
+// ---------------------------------------------------------------------------
+// 2. Idempotence.
+// ---------------------------------------------------------------------------
+
+$stamp = $snapshot['collected_at'];
+Content_Collector::collect();
+Content_Collector::collect();
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 1, 'Repeat collection with identical input never writes again' );
+faz_pc_eq( Content_Collector::get_snapshot()['collected_at'], $stamp, 'collected_at does not move without a material change' );
+
+// ---------------------------------------------------------------------------
+// 3. Input hygiene.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset(
+	array(
+		faz_pc_entry( 'WooCommerce', $wc_text ),
+		array( 'plugin_name' => 'Long Gone Plugin', 'policy_text' => '<p>Ghost.</p>', 'removed' => 123 ),
+		faz_pc_entry( '', '<p>Nameless.</p>' ),
+		faz_pc_entry( 'Empty Plugin', '' ),
+		faz_pc_entry( 'Noisy Plugin', '<p>Hello.</p><script>alert(1)</script>' ),
+		'not-an-array',
+	)
+);
+
+$snapshot = Content_Collector::collect();
+faz_pc_eq( array_keys( $snapshot['blocks'] ), array( 'woocommerce', 'noisy-plugin' ), 'Ghosts, nameless and empty entries are all dropped' );
+faz_pc_eq( $snapshot['blocks']['noisy-plugin']['source_html'], '<p>Hello.</p>', 'Script tags are stripped from collected text' );
+faz_pc_eq(
+	$snapshot['blocks']['noisy-plugin']['source_hash'],
+	hash( 'sha256', '<p>Hello.</p>' ),
+	'Hash is taken on the sanitised text, not the raw producer text'
+);
+
+// The same input must stay stable: a hash taken before sanitisation would
+// re-diff forever here.
+$writes = $GLOBALS['faz_pc_writes'];
+Content_Collector::collect();
+faz_pc_eq( $GLOBALS['faz_pc_writes'], $writes, 'Sanitised text does not re-diff on the next collection' );
+
+// ---------------------------------------------------------------------------
+// 4. Untouched block adopts an upstream update.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'WooCommerce', $wc_text ) ) );
+Content_Collector::collect();
+
+$wc_v2                        = '<h2>WooCommerce</h2><p>We collect order and payment data.</p>';
+$GLOBALS['faz_pc_registered'] = array( faz_pc_entry( 'WooCommerce', $wc_v2 ) );
+$snapshot                     = Content_Collector::collect();
+
+faz_pc_eq( $snapshot['blocks']['woocommerce']['source_html'], $wc_v2, 'Untouched block adopts the new upstream text' );
+faz_pc_true( $snapshot['blocks']['woocommerce']['updated'] > 0, 'Adopted change records an updated timestamp' );
+
+$rows = Content_Collector::describe();
+faz_pc_eq( $rows[0]['stale'], false, 'An untouched block is never stale' );
+faz_pc_eq( $rows[0]['effective_html'], $wc_v2, 'describe() serves the upstream text when no override is set' );
+faz_pc_eq( Content_Collector::effective_blocks()['woocommerce']['html'], $wc_v2, 'effective_blocks() serves the upstream text' );
+
+// ---------------------------------------------------------------------------
+// 5. Edited block keeps the operator's wording.
+// ---------------------------------------------------------------------------
+
+$own = '<p>Our own wording</p>';
+faz_pc_true( Content_Collector::set_override( 'woocommerce', $own ), 'set_override() reports a write' );
+
+$snapshot = Content_Collector::get_snapshot();
+faz_pc_eq(
+	$snapshot['blocks']['woocommerce']['override']['anchor_hash'],
+	$snapshot['blocks']['woocommerce']['source_hash'],
+	'Override anchors to the source hash it was written against'
+);
+
+$wc_v3                        = '<h2>WooCommerce</h2><p>We collect order, payment and shipping data.</p>';
+$GLOBALS['faz_pc_registered'] = array( faz_pc_entry( 'WooCommerce', $wc_v3 ) );
+$snapshot                     = Content_Collector::collect();
+
+faz_pc_eq( Content_Collector::effective_blocks()['woocommerce']['html'], $own, 'Upstream change never overwrites operator wording' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['source_html'], $wc_v3, 'The placeholder keeps tracking underneath the override' );
+$rows = Content_Collector::describe();
+faz_pc_eq( $rows[0]['stale'], true, 'An edited block whose source moved is flagged stale' );
+faz_pc_eq( $rows[0]['override'], $own, 'describe() exposes the operator text' );
+
+// ---------------------------------------------------------------------------
+// 6. Rename carry-forward.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'WooCommerce', $wc_text ) ) );
+Content_Collector::collect();
+Content_Collector::set_override( 'woocommerce', $own );
+
+$GLOBALS['faz_pc_registered'] = array( faz_pc_entry( 'WooCommerce (translated)', $wc_text ) );
+$snapshot                     = Content_Collector::collect();
+
+faz_pc_eq( array_keys( $snapshot['blocks'] ), array( 'woocommerce' ), 'A renamed plugin keeps its block id' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['plugin_name'], 'WooCommerce (translated)', 'The new display name is adopted' );
+faz_pc_eq( Content_Collector::describe()[0]['stale'], false, 'A rename alone does not make an override stale' );
+
+// ---------------------------------------------------------------------------
+// 7. Removal.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'WooCommerce', $wc_text ), faz_pc_entry( 'Akismet', $ak_text ) ) );
+Content_Collector::collect();
+
+$GLOBALS['faz_pc_registered'] = array( faz_pc_entry( 'WooCommerce', $wc_text ) );
+$snapshot                     = Content_Collector::collect();
+faz_pc_eq( array_keys( $snapshot['blocks'] ), array( 'woocommerce' ), 'An untouched block disappears with its producer' );
+faz_pc_eq( isset( Content_Collector::effective_blocks()['akismet'] ), false, 'A dropped block never reaches the renderer' );
+
+Content_Collector::set_override( 'woocommerce', $own );
+$GLOBALS['faz_pc_registered'] = array();
+$snapshot                     = Content_Collector::collect();
+faz_pc_eq( array_keys( $snapshot['blocks'] ), array( 'woocommerce' ), 'An edited block survives its producer' );
+faz_pc_true( $snapshot['blocks']['woocommerce']['removed'] > 0, 'The surviving block records when the producer left' );
+faz_pc_eq( Content_Collector::describe()[0]['orphaned'], true, 'An edited block without a producer is flagged orphaned' );
+faz_pc_eq( Content_Collector::effective_blocks()['woocommerce']['html'], $own, 'An orphaned block still renders the operator wording' );
+
+// ---------------------------------------------------------------------------
+// 8. Revival.
+// ---------------------------------------------------------------------------
+
+$GLOBALS['faz_pc_registered'] = array( faz_pc_entry( 'WooCommerce', $wc_text ) );
+$snapshot                     = Content_Collector::collect();
+faz_pc_eq( $snapshot['blocks']['woocommerce']['removed'], 0, 'A returning producer clears the removed flag' );
+faz_pc_eq( $snapshot['blocks']['woocommerce']['override']['text'], $own, 'Revival leaves the override untouched' );
+faz_pc_eq( Content_Collector::describe()[0]['orphaned'], false, 'A revived block is no longer orphaned' );
+
+// ---------------------------------------------------------------------------
+// 9. Duplicate display names.
+// ---------------------------------------------------------------------------
+
+$stats_a = '<p>Statistics, flavour A.</p>';
+$stats_b = '<p>Statistics, flavour B.</p>';
+faz_pc_reset(
+	array(
+		faz_pc_entry( 'WP Statistics', $stats_a ),
+		faz_pc_entry( 'WP Statistics', $stats_b ),
+	)
+);
+$snapshot = Content_Collector::collect();
+$expected = array( 'wp-statistics', 'wp-statistics-' . substr( hash( 'sha256', $stats_b ), 0, 8 ) );
+faz_pc_eq( array_keys( $snapshot['blocks'] ), $expected, 'A same-name collision gets a deterministic hash suffix' );
+
+$writes = $GLOBALS['faz_pc_writes'];
+Content_Collector::collect();
+faz_pc_eq( array_keys( Content_Collector::get_snapshot()['blocks'] ), $expected, 'Duplicate ids are stable across collections' );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], $writes, 'Duplicates do not churn the option' );
+
+// A rewrite that is ambiguous on both sides must never be matched onto a twin.
+$GLOBALS['faz_pc_registered'] = array(
+	faz_pc_entry( 'WP Statistics', '<p>Statistics, flavour C.</p>' ),
+	faz_pc_entry( 'WP Statistics', '<p>Statistics, flavour D.</p>' ),
+);
+Content_Collector::collect();
+$ids = array_keys( Content_Collector::get_snapshot()['blocks'] );
+faz_pc_eq( count( $ids ), 2, 'An ambiguous twin rewrite yields two blocks, not four' );
+
+// ---------------------------------------------------------------------------
+// 10. set_override edges.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'WooCommerce', $wc_text ) ) );
+Content_Collector::collect();
+
+$writes = $GLOBALS['faz_pc_writes'];
+faz_pc_eq( Content_Collector::set_override( 'no-such-block', '<p>x</p>' ), false, 'An unknown block id is refused' );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], $writes, 'A refused override writes nothing' );
+
+Content_Collector::set_override( 'woocommerce', $own );
+faz_pc_true( Content_Collector::set_override( 'woocommerce', "   \n  " ), 'Whitespace-only text clears the override' );
+faz_pc_eq( Content_Collector::get_snapshot()['blocks']['woocommerce']['override']['text'], '', 'A cleared block goes back to tracking upstream' );
+faz_pc_eq( Content_Collector::effective_blocks()['woocommerce']['html'], $wc_text, 'A cleared block renders the collected text again' );
+
+faz_pc_eq( Content_Collector::set_override( 'woocommerce', '<p>Kept</p><script>alert(1)</script>' ), true, 'Override input is accepted' );
+faz_pc_eq( Content_Collector::get_snapshot()['blocks']['woocommerce']['override']['text'], '<p>Kept</p>', 'Script tags are stripped from override input' );
+
+faz_pc_eq( Content_Collector::set_override( 'woocommerce', str_repeat( 'a', Content_Collector::MAX_HTML + 500 ) ), true, 'An oversized override is accepted' );
+faz_pc_eq(
+	strlen( Content_Collector::get_snapshot()['blocks']['woocommerce']['override']['text'] ),
+	Content_Collector::MAX_HTML,
+	'An oversized override is clipped to MAX_HTML'
+);
+
+// Clearing the override of a removed block removes the block entirely.
+Content_Collector::set_override( 'woocommerce', $own );
+$GLOBALS['faz_pc_registered'] = array();
+Content_Collector::collect();
+faz_pc_true( Content_Collector::set_override( 'woocommerce', '' ), 'Clearing an orphaned block reports a write' );
+faz_pc_eq( Content_Collector::get_snapshot()['blocks'], array(), 'Clearing an orphaned block deletes it' );
+
+// ---------------------------------------------------------------------------
+// 11. Guards.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'WooCommerce', $wc_text ) ) );
+$GLOBALS['faz_pc_actions'] = array();
+Content_Collector::register_hooks();
+faz_pc_eq( count( $GLOBALS['faz_pc_actions'] ), 1, 'register_hooks() registers exactly one listener' );
+faz_pc_eq( $GLOBALS['faz_pc_actions'][0][0], 'current_screen', 'The listener is on current_screen' );
+
+Content_Collector::maybe_collect( new WP_Screen( 'dashboard' ) );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 0, 'A non-FAZ admin screen never collects' );
+
+$faz_screen = new WP_Screen( 'toplevel_page_faz-cookie-manager' );
+
+$GLOBALS['faz_pc_ctx']['did_action'] = false;
+Content_Collector::maybe_collect( $faz_screen );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 0, 'Collection before admin_init is refused' );
+$GLOBALS['faz_pc_ctx']['did_action'] = true;
+
+$GLOBALS['faz_pc_ctx']['is_admin'] = false;
+Content_Collector::maybe_collect( $faz_screen );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 0, 'Collection outside wp-admin is refused' );
+$GLOBALS['faz_pc_ctx']['is_admin'] = true;
+
+$GLOBALS['faz_pc_ctx']['doing_ajax'] = true;
+Content_Collector::maybe_collect( $faz_screen );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 0, 'Collection during admin-ajax is refused' );
+$GLOBALS['faz_pc_ctx']['doing_ajax'] = false;
+
+$GLOBALS['faz_pc_ctx']['doing_cron'] = true;
+Content_Collector::maybe_collect( $faz_screen );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 0, 'Collection during cron is refused' );
+$GLOBALS['faz_pc_ctx']['doing_cron'] = false;
+
+$GLOBALS['faz_pc_ctx']['can_manage'] = false;
+Content_Collector::maybe_collect( $faz_screen );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 0, 'Collection without manage_options is refused' );
+$GLOBALS['faz_pc_ctx']['can_manage'] = true;
+
+Content_Collector::maybe_collect( $faz_screen );
+faz_pc_eq( $GLOBALS['faz_pc_writes'], 1, 'A FAZ admin screen with every guard satisfied collects' );
+
+// ---------------------------------------------------------------------------
+// 12. Corruption.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'WooCommerce', $wc_text ) ) );
+$empty = array( 'schema' => 1, 'collected_at' => 0, 'blocks' => array() );
+
+$GLOBALS['faz_pc_options'][ Content_Collector::OPTION ] = 'garbage-string';
+faz_pc_eq( Content_Collector::get_snapshot(), $empty, 'A non-array option reads as an empty snapshot' );
+
+$GLOBALS['faz_pc_options'][ Content_Collector::OPTION ] = array( 'schema' => 99, 'blocks' => array( 'x' => array() ) );
+faz_pc_eq( Content_Collector::get_snapshot(), $empty, 'A foreign schema reads as an empty snapshot' );
+
+$snapshot = Content_Collector::collect();
+faz_pc_eq( array_keys( $snapshot['blocks'] ), array( 'woocommerce' ), 'The next collection rebuilds from scratch' );
+
+$good = $snapshot['blocks']['woocommerce'];
+$GLOBALS['faz_pc_options'][ Content_Collector::OPTION ] = array(
+	'schema'       => 1,
+	'collected_at' => 100,
+	'blocks'       => array(
+		'woocommerce' => $good,
+		'broken'      => array( 'plugin_name' => 'Broken', 'source_html' => '<p>x</p>' ),
+	),
+);
+faz_pc_eq( array_keys( Content_Collector::get_snapshot()['blocks'] ), array( 'woocommerce' ), 'A malformed block is dropped and its siblings survive' );
+
+// ---------------------------------------------------------------------------
+// 13. MAX_BLOCKS.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset();
+$full = array();
+for ( $i = 0; $i < Content_Collector::MAX_BLOCKS; $i++ ) {
+	$full[] = faz_pc_entry( 'Plugin ' . $i, '<p>Body ' . $i . '</p>' );
+}
+$GLOBALS['faz_pc_registered'] = $full;
+$snapshot                     = Content_Collector::collect();
+faz_pc_eq( count( $snapshot['blocks'] ), Content_Collector::MAX_BLOCKS, 'The map fills to MAX_BLOCKS' );
+
+Content_Collector::set_override( 'plugin-0', $own );
+$GLOBALS['faz_pc_registered'][] = faz_pc_entry( 'One Too Many', '<p>Overflow</p>' );
+$snapshot                       = Content_Collector::collect();
+faz_pc_eq( count( $snapshot['blocks'] ), Content_Collector::MAX_BLOCKS, 'A block past the cap is refused, never squeezed in' );
+faz_pc_eq( isset( $snapshot['blocks']['one-too-many'] ), false, 'The overflow block is the one refused' );
+faz_pc_eq( $snapshot['blocks']['plugin-0']['override']['text'], $own, 'The cap never evicts an operator-edited block' );
+
+echo "\n--\nTests:  {$faz_pc_run}\nPassed: {$faz_pc_passed}\nFailed: {$faz_pc_failed}\n\n";
+if ( $faz_pc_failed > 0 ) {
+	echo "\033[31mFAIL\033[0m\n";
+	exit( 1 );
+}
+echo "\033[32mPASS\033[0m\n";

--- a/tests/unit/test-privacy-content-collector.php
+++ b/tests/unit/test-privacy-content-collector.php
@@ -67,6 +67,26 @@ if ( ! function_exists( 'wp_kses_post' ) ) {
 		return preg_replace( '#<script\b[^>]*>.*?</script>#is', '', (string) $value );
 	}
 }
+if ( ! function_exists( 'force_balance_tags' ) ) {
+	function force_balance_tags( $html ) {
+		$stack = array();
+		preg_match_all( '#</?([a-z0-9]+)\b[^>]*>#i', (string) $html, $tags );
+		foreach ( $tags[0] as $i => $tag ) {
+			$name = strtolower( $tags[1][ $i ] );
+			if ( preg_match( '#^</#', $tag ) ) {
+				if ( end( $stack ) === $name ) {
+					array_pop( $stack );
+				}
+			} elseif ( ! preg_match( '#/\s*>$#', $tag ) && ! in_array( $name, array( 'br', 'hr', 'img', 'input' ), true ) ) {
+				$stack[] = $name;
+			}
+		}
+		while ( $stack ) {
+			$html .= '</' . array_pop( $stack ) . '>';
+		}
+		return $html;
+	}
+}
 if ( ! function_exists( 'sanitize_title' ) ) {
 	function sanitize_title( $title ) {
 		$title = strtolower( (string) $title );
@@ -525,6 +545,34 @@ $snapshot                       = Content_Collector::collect();
 faz_pc_eq( count( $snapshot['blocks'] ), Content_Collector::MAX_BLOCKS, 'A block past the cap is refused, never squeezed in' );
 faz_pc_eq( isset( $snapshot['blocks']['one-too-many'] ), false, 'The overflow block is the one refused' );
 faz_pc_eq( $snapshot['blocks']['plugin-0']['override']['text'], $own, 'The cap never evicts an operator-edited block' );
+
+// ---------------------------------------------------------------------------
+// 14. Equal source text never swaps distinct plugin identities.
+// ---------------------------------------------------------------------------
+
+$shared = '<p>We process account identifiers.</p>';
+faz_pc_reset( array( faz_pc_entry( 'Plugin Alpha', $shared ), faz_pc_entry( 'Plugin Beta', $shared ) ) );
+Content_Collector::collect();
+Content_Collector::set_override( 'plugin-alpha', '<p>Alpha operator wording.</p>' );
+Content_Collector::set_override( 'plugin-beta', '<p>Beta operator wording.</p>' );
+
+$GLOBALS['faz_pc_registered'] = array( faz_pc_entry( 'Plugin Beta', $shared ), faz_pc_entry( 'Plugin Alpha', $shared ) );
+$snapshot = Content_Collector::collect();
+faz_pc_eq( $snapshot['blocks']['plugin-alpha']['plugin_name'], 'Plugin Alpha', 'reversed equal text keeps Alpha on the Alpha id' );
+faz_pc_eq( $snapshot['blocks']['plugin-beta']['plugin_name'], 'Plugin Beta', 'reversed equal text keeps Beta on the Beta id' );
+faz_pc_eq( Content_Collector::effective_blocks()['plugin-alpha']['html'], '<p>Alpha operator wording.</p>', 'Alpha keeps its own override' );
+faz_pc_eq( Content_Collector::effective_blocks()['plugin-beta']['html'], '<p>Beta operator wording.</p>', 'Beta keeps its own override' );
+
+// ---------------------------------------------------------------------------
+// 15. Oversized HTML is clipped without a partial or dangling tag.
+// ---------------------------------------------------------------------------
+
+faz_pc_reset( array( faz_pc_entry( 'Large HTML', '<p>' . str_repeat( 'x', Content_Collector::MAX_HTML ) . '</p>' ) ) );
+$snapshot = Content_Collector::collect();
+$large    = $snapshot['blocks']['large-html']['source_html'];
+faz_pc_true( strlen( $large ) <= Content_Collector::MAX_HTML, 'balanced oversized HTML stays within MAX_HTML' );
+faz_pc_true( substr( $large, -4 ) === '</p>', 'an element clipped in its text is closed cleanly' );
+faz_pc_eq( substr_count( $large, '<p>' ), substr_count( $large, '</p>' ), 'stored oversized HTML has balanced paragraph tags' );
 
 echo "\n--\nTests:  {$faz_pc_run}\nPassed: {$faz_pc_passed}\nFailed: {$faz_pc_failed}\n\n";
 if ( $faz_pc_failed > 0 ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -162,6 +162,7 @@ if ( $faz_force_remove_all || faz_should_remove_on_uninstall() || is_multisite()
 				'faz_pageviews_db_version',
 				'faz_missing_tables',
 				'faz_migration_options',
+				'faz_privacy_content_snapshot',
 				'faz_banner_template',
 				'faz_gvl_data',
 				'faz_gvl_meta',


### PR DESCRIPTION
## What this does

Adds `Content_Collector`, a data layer that reads every privacy-policy declaration the installed plugins register with WordPress and snapshots them into a plugin option.

WordPress has had the mechanism since 4.9.6. A plugin calls `wp_add_privacy_policy_content( $plugin_name, $policy_text )` to describe, in its own words, what it processes; `WP_Privacy_Policy_Content::get_suggested_policy_text()` hands back every registered contribution. FAZ is already a **producer** of one such block — `CLI::register_privacy_hooks()` registers the consent-log disclosure. This makes it a **consumer** as well, which is the symmetric and obvious move.

Nothing renders yet. This PR is the collection, diff and override layer plus its tests; the renderer, the admin screen and the `Document_Registry` wiring are follow-ups (listed at the bottom).

## Why aggregate, instead of writing the text myself

The legal-documents plan assumed I would author reviewed legal text describing what a site processes, across four jurisdictions and eight languages, and flagged that as the feature's main legal risk.

That framing was wrong in an important way. **I should not author claims about what a site processes on behalf of software I did not write.** WooCommerce's description of WooCommerce is both more accurate than anything I could write and, legally, WooCommerce's statement rather than mine. The generated document becomes the site's own installed software describing itself, plus the operator's own supplied facts, plus jurisdiction-fixed rights text — which is statute, not a claim about the site.

On faz-test, a single admin pageview picked up WordPress core, FAZ Cookie Manager and WooCommerce; with the rest of the site's plugin set active it also picks up LiteSpeed Cache, Akismet, Burst Statistics, WP Statistics and Beehive Analytics. None of that text is mine to write.

## The admin-only constraint, and the evidence for it

This is the decision most likely to be "simplified" away later by someone who does not know what it costs, so it is documented in three places: the class header, `docs/privacy-policy-collection-design.md`, and the commit message.

`wp_add_privacy_policy_content()` calls `_doing_it_wrong()` unless it runs in wp-admin on `admin_init` or later — the guard landed in 4.9.7. Producers therefore register on `admin_init`, and **their content simply does not exist in any other context**.

Forcing the issue is worse than useless. Firing `do_action( 'admin_init' )` from WP-CLI to warm the producers up emitted six `_doing_it_wrong` notices and then **fataled inside WooCommerce**: `Automattic\WooCommerce\Internal\Orders\OrderAttributionController::get_order_screen_id()` calls `wc_get_page_screen_id()`, which is undefined outside a real admin request.

So the hook is `current_screen`, not `admin_init`:

- `current_screen` is reached only through `set_current_screen()`, so it fires in genuine wp-admin page requests and nowhere else. `admin_init`, by contrast, also fires on `admin-ajax.php` and can be force-fired from the CLI — the exact path that fatals.
- It fires *after* `admin_init`, so every producer registered at default priority (FAZ's own included) has already contributed.

The context is therefore correct by construction. The explicit denials inside `maybe_collect()` — `is_admin()`, `did_action('admin_init')`, ajax, cron, `REST_REQUEST`, `WP_CLI`, `manage_options` — are belt and braces for anyone who calls the method directly.

Collection is further limited to screens whose id contains `faz-cookie-manager`. Running it on every wp-admin pageview sitewide would perform the read, and risk an option write, forever, in order to keep fresh a snapshot that only FAZ's document consumes. On FAZ screens it refreshes exactly when the operator is looking at the plugin — including, later, the privacy-policy editor screen itself, which lands on a `faz-cookie-manager-*` slug and so always opens against fresh data.

**Snapshot, not live**, follows from the same constraint — and is required independently anyway. Cache Compatibility Mode (1.21.0) demands render invariance, and a live collection at render time would make the output depend on request context, which is exactly the per-visitor variance that release eliminated.

## Editable-placeholder semantics

Mirrored from the Cookie Policy's `Section_Overrides` rather than reinvented:

- Collected text is the **placeholder**, not the saved value. An empty override box means "keep receiving updates", and the block silently adopts whatever the plugin now says.
- An operator who rewrites a block keeps their wording. The block stops tracking upstream, and an upstream change is **flagged, never silently applied** — the same judgement the Cookie Policy makes, because an explicit editorial decision is the most specific source there is.
- The anchor for that decision is the block's `source_hash` at the moment the override was saved.

What is genuinely new versus the Cookie Policy is that **the upstream source moves**. A plugin can change or withdraw its declaration, so each block carries `added` / `updated` / `removed` and a two-pass identity match:

1. **by text** — carries a block across a rename or a translated display name;
2. **by name** — carries it across a rewritten declaration.

A name that is ambiguous on both sides refuses to match. Two plugins can register under the same display name (which is why duplicate ids exist), and matching a rewrite against the wrong twin would silently swap two blocks' identities, and their overrides with them. Ambiguity makes the blocks churn instead, which is recoverable; swapped identities are not.

Three states are exposed by `describe()`, both **derived at read time and never stored** — a derived flag cannot desynchronise from the data it describes, a stored copy can (same reason `Section_Overrides` derives `active`):

| | untouched block | operator-edited block |
|---|---|---|
| plugin updated its text | adopts the new text | keeps operator wording, `stale` |
| plugin deactivated/removed | block drops out | kept, `orphaned` |
| new plugin activated | block appears | n/a |

I compute that diff myself instead of trusting core's. Core anchors its `added`/`updated`/`removed` to `wp_page_for_privacy_policy`, and on a site where that option is `0` there is no baseline and the flags are meaningless. Change detection has to work whether or not the operator ever configured a privacy page.

One trap in core's return value: entries carrying a `removed` timestamp are read back out of its post-meta cache and are **not** currently registered. Keeping them would resurrect every plugin the site ever deactivated, so they are dropped on the way in.

## The sanitisation boundary, and why it sits there

Each body goes through `wp_kses_post()`, then a character clip, then a trim — and `source_hash` is computed on that **final stored string**.

The order is load-bearing. Hashing the producer's raw text instead would make every block whose text kses touches hash differently from what is stored, producing a phantom `updated` — and a false `stale` flag on every operator-edited block — on every single collection, forever. The unit suite pins this with a deliberately observable kses stub (a naive `<script>` strip); weakening that stub to the identity function would make the suite pass without proving anything.

Operator overrides pass through the same `sanitize_html()`. There is one sanitisation path, not two.

Bounds (`MAX_BLOCKS` 100, `MAX_HTML` 60 000, `MAX_NAME` 200) exist so a pathological producer cannot grow the option without bound. The cap **refuses new blocks and never truncates the map** — truncation could evict a block the operator has edited, and losing an editorial decision is a worse failure than missing a section. The option is written with `autoload` false on every write path; the default for a new option is yes, so the third argument has to be passed every time, not only the first.

## What I tested

**Unit** — new `tests/unit/test-privacy-content-collector.php`, a self-contained CLI runner in the shape of the existing suites: **74 assertions, 74 passed, 0 failed**. Covers first collection, no-write idempotence, ghost/empty/nameless input rejection, kses-before-hash, untouched adoption, edited-block staleness, rename carry-forward, removal and revival, duplicate display names, `set_override` edges (unknown id, clearing, clipping, script stripping, deleting an orphan), every guard independently, corrupt-option recovery, and the `MAX_BLOCKS` cap.

`npm run test:unit`: **57 passed, 0 failed (of 57)** — 48 PHP + 9 JS, up from main's 47 + 9. No regression in any other suite.

**PHP syntax** — full sweep clean, including the four touched files.

**Live on faz-test**, per the test-before-claiming rule:

- one admin pageview as `admin` produced a `schema: 1` snapshot with three blocks — `wordpress`, `faz-cookie-manager`, `woocommerce` — each with non-empty `source_html` and a 64-character `source_hash`. (Only WooCommerce of the six third-party producers is currently active on that install; the others are installed but deactivated, and I did not activate them because a concurrent workflow is using the same site.) Worth noting: **WordPress core is itself a producer**, which was not in the expected list.
- two further FAZ admin pageviews, including a different FAZ screen, left `collected_at` byte-identical — the no-write path holds.
- `SELECT autoload FROM wp_options` → `off`, with the option at 10 162 bytes, which is exactly why it must not autoload.
- with the option deleted: a frontend request (200), a real `faz/v1` REST request and a WP-CLI run neither fataled nor recreated it. Collection provably never fires outside wp-admin.

**Plugin Check** (`--categories=plugin_repo`) caught a real regression I would otherwise have shipped: its direct-file-access scanner only reads the **first 50 lines** of a file when looking for the ABSPATH guard, and my original 85-line header docblock pushed the guard out of its view. I restructured the header — essentials up top, the long rationale in the class docblock below the guard and in the design doc — and the file now produces **zero findings of any kind**. Repo-wide errors went 398 → 397; every remaining one is pre-existing and lives in `tests/`, `scripts/`, `.specify/` or a dotfile, i.e. paths the wp.org ZIP excludes.

I did **not** run the Playwright E2E suite, or build the wp.org-shape ZIP for a clean-room Plugin Check run: a concurrent workflow is using the shared WordPress test site. The faz-test deployment and its option were reverted to their prior state after verification.

## Scope

Only `includes/class-cli.php` (four lines, in the method that already owns the producer-side registration — the existing `admin_init` producer hook is correct as it stands and I did not move it) and `uninstall.php` (one option name). **No file under `admin/modules/cookie-policy-generator/` is touched**, and no call to `wp_add_privacy_policy_content()` is added or moved.

## Follow-ups

- **`Document_Registry` integration**, blocked on the concurrent branch: the privacy-policy `Document_Config` gains `'collector' => Content_Collector::collect` and `'snapshot_option' => 'faz_privacy_content_snapshot'`. No migration needed — `effective_blocks()` already returns render-ready `id => [plugin_name, html]` pairs.
- **Renderer**: the public document built from `effective_blocks()`, never a live collection, through the same role/aria-level-augmented `wp_kses` allowlist the Cookie Policy renderer uses.
- **Admin screen** (`faz-cookie-manager-privacy-policy`): per-block editor with `source_html` as a greyed placeholder, an override textarea, and the three-state flags. Its slug triggers collection on open by construction.
- **Offer — never silently set** — to point `wp_page_for_privacy_policy` at the generated page, so `get_privacy_policy_url()` and `Renderer::privacy_policy_url()` resolve sitewide.
- Jurisdiction-fixed rights scaffolds (GDPR Arts. 15-22, CCPA, LGPD Art. 18, POPIA) and the structural frame around collected blocks, with `missing_required_settings()`-style refusal gating and the never-seed-from-`admin_email` rule.
- `{{COMPANY_NAME}}` resolution inside operator overrides, through the same substitution stage as the Cookie Policy so there is no second escaping path.
- An admin-context refresh button. REST is not an option here unless proxied through a real admin request.
- i18n resync once the UI strings land — one pass after all concurrent branches merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Raccolta automatica dei contenuti privacy dichiarati dai plugin nelle schermate amministrative autorizzate.
  * Salvataggio di uno snapshot aggiornabile per generare documenti privacy coerenti e verificabili.
  * Gestione di contenuti modificati, rimossi o non più disponibili, con possibilità di applicare override editoriali.
  * Validazione, sanificazione e limiti dimensionali per migliorare affidabilità e sicurezza dei contenuti.

* **Documentazione**
  * Aggiunta la documentazione sul funzionamento della raccolta e sulla gestione dei contenuti.

* **Manutenzione**
  * Lo snapshot viene rimosso automaticamente durante la disinstallazione.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->