### PR TITLE
refactor: introduce Document_Registry/Document_Config and extract Renderer::render_for() — zero behaviour change

### DIFF
--- a/admin/modules/cookie-policy-generator/includes/class-document-config.php
+++ b/admin/modules/cookie-policy-generator/includes/class-document-config.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Class Document_Config file — immutable description of one legal document type.
+ *
+ * Plan: docs/legal-documents-generator-plan.md §3.1
+ *
+ * The engine (Generator + Renderer + Template_Translations) is already generic;
+ * what differs between a Cookie Policy, a Privacy Policy and a Terms page is
+ * DATA — where the templates live, which option holds the settings, which
+ * jurisdictions apply — plus exactly one behavioural hook (which tokens get
+ * built). So the abstraction is a value object with typed accessors and a
+ * callable, not an interface hierarchy: there is no polymorphic behaviour to
+ * dispatch on, and a bare config array would give neither validation nor a
+ * single place to catch a typo'd key.
+ *
+ * The constructor validates eagerly and throws: a malformed registry entry is a
+ * programming error that must surface the moment the registry is built, not as
+ * a null-ish token halfway through a rendered legal document.
+ *
+ * @package FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes
+ * @since   1.25.1
+ */
+
+namespace FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * One legal document type, described as data.
+ *
+ * Immutable by construction: everything is assigned in the constructor and only
+ * ever read back through getters. PHP 7.4 floor — no readonly properties, no
+ * constructor promotion, no union types.
+ *
+ * @class    Document_Config
+ * @since    1.25.1
+ */
+class Document_Config {
+
+	/**
+	 * Registry key, e.g. 'cookie-policy'.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Shortcode tag that renders this document.
+	 *
+	 * @var string
+	 */
+	private $shortcode;
+
+	/**
+	 * wp_options key holding this document's settings.
+	 *
+	 * @var string
+	 */
+	private $option;
+
+	/**
+	 * Absolute path to the <jurisdiction>/<lang>.md tree (no trailing slash).
+	 *
+	 * @var string
+	 */
+	private $templates_dir;
+
+	/**
+	 * Jurisdictions this document ships. The FIRST entry is the fallback used
+	 * when neither the shortcode attribute nor the saved setting names a valid
+	 * one — reordering the array changes the default legal regime.
+	 *
+	 * @var string[]
+	 */
+	private $jurisdictions;
+
+	/**
+	 * Jurisdiction → native language map.
+	 *
+	 * @var array<string,string>
+	 */
+	private $native_lang;
+
+	/**
+	 * Tokens whose values are pre-rendered HTML and must bypass the markdown
+	 * pass (see Generator::HTML_TOKENS for the why).
+	 *
+	 * @var string[]
+	 */
+	private $html_tokens;
+
+	/**
+	 * Absolute path to the generated _x() catalogue for this document.
+	 *
+	 * @var string
+	 */
+	private $gettext_catalog;
+
+	/**
+	 * CSS class on the <article> wrapper.
+	 *
+	 * @var string
+	 */
+	private $wrapper_class;
+
+	/**
+	 * callable( array $settings, string $jurisdiction, string $lang ): array
+	 *
+	 * @var callable
+	 */
+	private $data_builder;
+
+	/**
+	 * callable( string $jurisdiction, array $settings ): string[]
+	 *
+	 * @var callable
+	 */
+	private $required_fields;
+
+	/**
+	 * Build and validate one document description.
+	 *
+	 * @param array $config Registry entry.
+	 * @throws \InvalidArgumentException When a field is missing or mistyped.
+	 */
+	public function __construct( array $config ) {
+		foreach ( array( 'slug', 'shortcode', 'option', 'templates_dir', 'gettext_catalog', 'wrapper_class' ) as $key ) {
+			if ( ! isset( $config[ $key ] ) || ! is_string( $config[ $key ] ) || '' === trim( $config[ $key ] ) ) {
+				throw new \InvalidArgumentException(
+					sprintf( 'Document_Config: "%s" must be a non-empty string.', $key )
+				);
+			}
+		}
+
+		if ( ! isset( $config['jurisdictions'] ) || ! is_array( $config['jurisdictions'] ) || array() === $config['jurisdictions'] ) {
+			throw new \InvalidArgumentException( 'Document_Config: "jurisdictions" must be a non-empty array.' );
+		}
+		foreach ( $config['jurisdictions'] as $jurisdiction ) {
+			if ( ! is_string( $jurisdiction ) || '' === $jurisdiction ) {
+				throw new \InvalidArgumentException( 'Document_Config: every "jurisdictions" entry must be a non-empty string.' );
+			}
+		}
+
+		if ( ! isset( $config['native_lang'] ) || ! is_array( $config['native_lang'] ) ) {
+			throw new \InvalidArgumentException( 'Document_Config: "native_lang" must be an array.' );
+		}
+		foreach ( $config['native_lang'] as $lang ) {
+			if ( ! is_string( $lang ) || '' === $lang ) {
+				throw new \InvalidArgumentException( 'Document_Config: every "native_lang" value must be a non-empty string.' );
+			}
+		}
+
+		if ( ! isset( $config['html_tokens'] ) || ! is_array( $config['html_tokens'] ) ) {
+			throw new \InvalidArgumentException( 'Document_Config: "html_tokens" must be an array.' );
+		}
+		foreach ( $config['html_tokens'] as $token ) {
+			if ( ! is_string( $token ) || '' === $token ) {
+				throw new \InvalidArgumentException( 'Document_Config: every "html_tokens" entry must be a non-empty string.' );
+			}
+		}
+
+		foreach ( array( 'data_builder', 'required_fields' ) as $key ) {
+			if ( ! isset( $config[ $key ] ) || ! is_callable( $config[ $key ] ) ) {
+				throw new \InvalidArgumentException(
+					sprintf( 'Document_Config: "%s" must be callable.', $key )
+				);
+			}
+		}
+
+		$this->slug          = (string) $config['slug'];
+		$this->shortcode     = (string) $config['shortcode'];
+		$this->option        = (string) $config['option'];
+		// Normalised here rather than trusted, so a registry entry written with
+		// a trailing slash cannot produce '…/templates//gdpr-strict/en.md'.
+		$this->templates_dir   = rtrim( (string) $config['templates_dir'], '/' );
+		$this->jurisdictions   = array_values( $config['jurisdictions'] );
+		$this->native_lang     = $config['native_lang'];
+		$this->html_tokens     = array_values( $config['html_tokens'] );
+		$this->gettext_catalog = (string) $config['gettext_catalog'];
+		$this->wrapper_class   = (string) $config['wrapper_class'];
+		$this->data_builder    = $config['data_builder'];
+		$this->required_fields = $config['required_fields'];
+	}
+
+	/**
+	 * Registry key.
+	 *
+	 * @return string
+	 */
+	public function slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * Shortcode tag rendering this document.
+	 *
+	 * @return string
+	 */
+	public function shortcode() {
+		return $this->shortcode;
+	}
+
+	/**
+	 * wp_options key holding this document's settings.
+	 *
+	 * @return string
+	 */
+	public function option() {
+		return $this->option;
+	}
+
+	/**
+	 * Absolute templates root, no trailing slash.
+	 *
+	 * @return string
+	 */
+	public function templates_dir() {
+		return $this->templates_dir;
+	}
+
+	/**
+	 * Supported jurisdictions; the first entry is the fallback regime.
+	 *
+	 * @return string[]
+	 */
+	public function jurisdictions() {
+		return $this->jurisdictions;
+	}
+
+	/**
+	 * Native language of a jurisdiction, 'en' when unmapped.
+	 *
+	 * @param string $jurisdiction Jurisdiction id.
+	 * @return string
+	 */
+	public function native_lang( $jurisdiction ) {
+		return isset( $this->native_lang[ $jurisdiction ] ) ? $this->native_lang[ $jurisdiction ] : 'en';
+	}
+
+	/**
+	 * Tokens protected from the markdown pass.
+	 *
+	 * @return string[]
+	 */
+	public function html_tokens() {
+		return $this->html_tokens;
+	}
+
+	/**
+	 * Absolute path to the generated gettext catalogue.
+	 *
+	 * @return string
+	 */
+	public function gettext_catalog() {
+		return $this->gettext_catalog;
+	}
+
+	/**
+	 * CSS class on the rendered <article> wrapper.
+	 *
+	 * @return string
+	 */
+	public function wrapper_class() {
+		return $this->wrapper_class;
+	}
+
+	/**
+	 * Build the substitution-data array for this document.
+	 *
+	 * @param array  $settings     Saved settings for this document.
+	 * @param string $jurisdiction Effective jurisdiction.
+	 * @param string $lang         Effective language.
+	 * @return array<string,mixed>
+	 */
+	public function build_data( array $settings, $jurisdiction, $lang ) {
+		return (array) call_user_func( $this->data_builder, $settings, $jurisdiction, $lang );
+	}
+
+	/**
+	 * Settings this document's jurisdiction cannot legally do without.
+	 *
+	 * @param string $jurisdiction Effective jurisdiction.
+	 * @param array  $settings     Saved settings for this document.
+	 * @return string[] Missing dot-paths.
+	 */
+	public function missing_required_settings( $jurisdiction, array $settings ) {
+		return (array) call_user_func( $this->required_fields, $jurisdiction, $settings );
+	}
+}

--- a/admin/modules/cookie-policy-generator/includes/class-document-config.php
+++ b/admin/modules/cookie-policy-generator/includes/class-document-config.php
@@ -113,7 +113,12 @@ class Document_Config {
 	private $data_builder;
 
 	/**
-	 * callable( string $jurisdiction, array $settings ): string[]
+	 * callable( string $jurisdiction, array $settings, Document_Config $doc ): string[]
+	 *
+	 * The document is passed as the third argument so a shared callback can tell
+	 * which document it is validating. A callback that only declares the first
+	 * two parameters keeps working — PHP ignores surplus arguments to userland
+	 * functions.
 	 *
 	 * @var callable
 	 */
@@ -150,6 +155,24 @@ class Document_Config {
 			if ( ! is_string( $lang ) || '' === $lang ) {
 				throw new \InvalidArgumentException( 'Document_Config: every "native_lang" value must be a non-empty string.' );
 			}
+		}
+		// The map must name every declared jurisdiction and nothing else. A
+		// missing key is the dangerous one: native_lang() would answer 'en' and
+		// the document would quietly fall back to English instead of the
+		// jurisdiction's real language — a wrong-language legal text that no
+		// error ever reports. An extra key is dead config and just as likely a
+		// typo, so both are refused here, where the registry is built.
+		$missing_langs = array_diff( $config['jurisdictions'], array_keys( $config['native_lang'] ) );
+		if ( array() !== $missing_langs ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Document_Config: "native_lang" has no entry for %s.', implode( ', ', $missing_langs ) )
+			);
+		}
+		$unknown_langs = array_diff( array_keys( $config['native_lang'] ), $config['jurisdictions'] );
+		if ( array() !== $unknown_langs ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Document_Config: "native_lang" names unknown jurisdiction(s) %s.', implode( ', ', $unknown_langs ) )
+			);
 		}
 
 		if ( ! isset( $config['html_tokens'] ) || ! is_array( $config['html_tokens'] ) ) {
@@ -281,11 +304,15 @@ class Document_Config {
 	/**
 	 * Settings this document's jurisdiction cannot legally do without.
 	 *
+	 * Passes $this to the callback so a callback shared between documents — as
+	 * Generator::missing_required_settings() is meant to be — can gate on the
+	 * document it was handed. Without it that gate never runs.
+	 *
 	 * @param string $jurisdiction Effective jurisdiction.
 	 * @param array  $settings     Saved settings for this document.
 	 * @return string[] Missing dot-paths.
 	 */
 	public function missing_required_settings( $jurisdiction, array $settings ) {
-		return (array) call_user_func( $this->required_fields, $jurisdiction, $settings );
+		return (array) call_user_func( $this->required_fields, $jurisdiction, $settings, $this );
 	}
 }

--- a/admin/modules/cookie-policy-generator/includes/class-document-registry.php
+++ b/admin/modules/cookie-policy-generator/includes/class-document-registry.php
@@ -23,6 +23,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// build() reads every coordinate off these four classes, and this file is
+// reachable without an autoloader (unit suites, CLI tools). Requiring them here
+// as well as in class-renderer.php makes either file a valid entry point; the
+// renderer cycle is safe because no class is referenced at file scope.
+require_once __DIR__ . '/class-document-config.php';
+require_once __DIR__ . '/class-generator.php';
+require_once __DIR__ . '/class-template-translations.php';
+require_once __DIR__ . '/class-renderer.php';
+
 /**
  * Static registry of Document_Config value objects.
  *
@@ -99,9 +108,10 @@ class Document_Registry {
 					'gettext_catalog' => Template_Translations::CATALOG_FILE,
 					'wrapper_class'   => 'faz-cookie-policy',
 					'data_builder'    => array( Renderer::class, 'build_data' ),
-					// Invoked with two arguments, so Generator's own trailing
-					// $doc parameter stays null and the existing POPIA-only
-					// gating runs verbatim — no recursion back into the registry.
+					// Receives this config as its third argument, so Generator's
+					// per-document gate sees 'cookie-policy' and falls through to
+					// the existing POPIA-only rules verbatim. It reads the slug
+					// off the object it was handed — no recursion back here.
 					'required_fields' => array( Generator::class, 'missing_required_settings' ),
 				)
 			),

--- a/admin/modules/cookie-policy-generator/includes/class-document-registry.php
+++ b/admin/modules/cookie-policy-generator/includes/class-document-registry.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Class Document_Registry file — the hardcoded catalogue of document types.
+ *
+ * Plan: docs/legal-documents-generator-plan.md §3.1
+ *
+ * Deliberately NOT filterable in v1: opening document registration to third
+ * parties before the Document_Config shape has settled would create a compat
+ * contract we cannot yet honour, for a use case nobody has asked for. A filter
+ * can be added later; it cannot be taken away.
+ *
+ * Only the cookie policy is registered here. That is the whole point of this
+ * step — the engine learns to take its coordinates from a config object while
+ * still rendering exactly the one document it renders today.
+ *
+ * @package FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes
+ * @since   1.25.1
+ */
+
+namespace FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Static registry of Document_Config value objects.
+ *
+ * @class    Document_Registry
+ * @since    1.25.1
+ */
+class Document_Registry {
+
+	/**
+	 * Built configs, slug-keyed. Null until the first access.
+	 *
+	 * @var array<string,Document_Config>|null
+	 */
+	private static $configs = null;
+
+	/**
+	 * One document config, or null when the slug is unknown.
+	 *
+	 * @param string $slug Document slug.
+	 * @return Document_Config|null
+	 */
+	public static function get( $slug ) {
+		$configs = self::build();
+		return isset( $configs[ (string) $slug ] ) ? $configs[ (string) $slug ] : null;
+	}
+
+	/**
+	 * Every registered document, slug-keyed.
+	 *
+	 * @return array<string,Document_Config>
+	 */
+	public static function all() {
+		return self::build();
+	}
+
+	/**
+	 * Registered document slugs.
+	 *
+	 * @return string[]
+	 */
+	public static function slugs() {
+		return array_keys( self::build() );
+	}
+
+	/**
+	 * Build the registry once, on first access.
+	 *
+	 * Lazy on purpose. Building at file-load time would require Generator,
+	 * Renderer and Template_Translations to already be loaded the instant this
+	 * file is included, which is a load-order trap for any context that pulls
+	 * the classes in by hand — the golden-render suite does exactly that, with
+	 * no autoloader and no plugin bootstrap.
+	 *
+	 * @return array<string,Document_Config>
+	 */
+	private static function build() {
+		if ( null !== self::$configs ) {
+			return self::$configs;
+		}
+
+		self::$configs = array(
+			'cookie-policy' => new Document_Config(
+				array(
+					'slug' => 'cookie-policy',
+					// Literal rather than Cookie_Policy_Generator::SHORTCODE: that
+					// class is the module bootstrap and is not loaded in the
+					// bootstrap-free unit-test context this registry must survive.
+					'shortcode'       => 'faz_cookie_policy_complete',
+					'option'          => Renderer::SETTINGS_OPTION,
+					'templates_dir'   => Generator::templates_dir(),
+					'jurisdictions'   => Generator::JURISDICTIONS,
+					'native_lang'     => Generator::NATIVE_LANG,
+					'html_tokens'     => Generator::HTML_TOKENS,
+					'gettext_catalog' => Template_Translations::CATALOG_FILE,
+					'wrapper_class'   => 'faz-cookie-policy',
+					'data_builder'    => array( Renderer::class, 'build_data' ),
+					// Invoked with two arguments, so Generator's own trailing
+					// $doc parameter stays null and the existing POPIA-only
+					// gating runs verbatim — no recursion back into the registry.
+					'required_fields' => array( Generator::class, 'missing_required_settings' ),
+				)
+			),
+		);
+
+		return self::$configs;
+	}
+}

--- a/admin/modules/cookie-policy-generator/includes/class-generator.php
+++ b/admin/modules/cookie-policy-generator/includes/class-generator.php
@@ -154,11 +154,22 @@ class Generator {
 	 * for recipient/safeguard detail, so those fields must not silently vanish
 	 * through Renderer::strip_empty_label_lines().
 	 *
-	 * @param string $jurisdiction Effective jurisdiction id.
-	 * @param array  $settings     Cookie Policy settings.
+	 * @param string               $jurisdiction Effective jurisdiction id.
+	 * @param array                $settings     Cookie Policy settings.
+	 * @param Document_Config|null $doc          Optional document being rendered.
+	 *                                           Null (or the cookie policy) keeps
+	 *                                           the behaviour below; any other
+	 *                                           document has no mandatory fields
+	 *                                           yet, because registry-driven
+	 *                                           gating is a later step of the plan
+	 *                                           and inventing rules here would
+	 *                                           change refusal output.
 	 * @return string[] Missing dot-paths.
 	 */
-	public static function missing_required_settings( $jurisdiction, array $settings ) {
+	public static function missing_required_settings( $jurisdiction, array $settings, ?Document_Config $doc = null ) {
+		if ( null !== $doc && 'cookie-policy' !== $doc->slug() ) {
+			return array();
+		}
 		if ( 'popia-southafrica' !== $jurisdiction ) {
 			return array();
 		}
@@ -203,26 +214,32 @@ class Generator {
 	 *   2. native lang of jurisdiction (if different)
 	 *   3. en (universal fallback)
 	 *
-	 * @param string $jurisdiction Ruleset id (gdpr-strict / ccpa-california / lgpd-brazil / popia-southafrica).
-	 * @param string $lang         BCP-47 language code. Languages without a
-	 *                             bundled file use the jurisdiction fallback.
+	 * @param string               $jurisdiction Ruleset id (gdpr-strict / ccpa-california / lgpd-brazil / popia-southafrica).
+	 * @param string               $lang         BCP-47 language code. Languages without
+	 *                                           a bundled file use the jurisdiction
+	 *                                           fallback.
+	 * @param Document_Config|null $doc          Optional document being rendered. Null
+	 *                                           resolves against the cookie-policy
+	 *                                           constants below, which remain the
+	 *                                           cookie policy's source of truth.
 	 * @return string|null Absolute path to .md file, or null if no template found.
 	 */
-	public static function resolve_template_path( $jurisdiction, $lang ) {
-		if ( ! in_array( $jurisdiction, self::JURISDICTIONS, true ) ) {
+	public static function resolve_template_path( $jurisdiction, $lang, ?Document_Config $doc = null ) {
+		$jurisdictions = null === $doc ? self::JURISDICTIONS : $doc->jurisdictions();
+		if ( ! in_array( $jurisdiction, $jurisdictions, true ) ) {
 			return null;
 		}
+		// Native fallback if different from requested.
+		$native = null === $doc ? ( self::NATIVE_LANG[ $jurisdiction ] ?? 'en' ) : $doc->native_lang( $jurisdiction );
 		// Defense-in-depth path-traversal hardening. A valid BCP-47 code is safe
 		// to compose into a candidate path; a language with no shipped file then
 		// follows the documented native/en fallback chain.
 		$lang = self::normalize_language_code( $lang );
 		if ( '' === $lang ) {
-			$lang = self::NATIVE_LANG[ $jurisdiction ] ?? 'en';
+			$lang = $native;
 		}
-		$dir = self::templates_dir() . '/' . $jurisdiction;
+		$dir = ( null === $doc ? self::templates_dir() : $doc->templates_dir() ) . '/' . $jurisdiction;
 		$candidates = array( $lang );
-		// Native fallback if different from requested.
-		$native = self::NATIVE_LANG[ $jurisdiction ] ?? 'en';
 		if ( $native !== $lang ) {
 			$candidates[] = $native;
 		}

--- a/admin/modules/cookie-policy-generator/includes/class-renderer.php
+++ b/admin/modules/cookie-policy-generator/includes/class-renderer.php
@@ -25,6 +25,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// The document registry is a hard dependency of render(), and the renderer is
+// routinely loaded by hand (unit suites, CLI tools) with no autoloader and no
+// plugin bootstrap. Pull both files in here so that loading this one file is
+// enough to render, exactly as it was before the registry existed.
+require_once __DIR__ . '/class-document-config.php';
+require_once __DIR__ . '/class-document-registry.php';
+
 /**
  * Cookie policy renderer.
  *
@@ -72,7 +79,26 @@ class Renderer {
 	 * @return string HTML (already wp_kses_post'd, safe to echo).
 	 */
 	public static function render( $atts = array() ) {
-		$settings = (array) get_option( self::SETTINGS_OPTION, array() );
+		return self::render_for( Document_Registry::get( 'cookie-policy' ), $atts );
+	}
+
+	/**
+	 * Render one registered document.
+	 *
+	 * This is render()'s pipeline, with every cookie-policy-specific coordinate
+	 * (settings option, template tree, gettext catalogue, mandatory fields,
+	 * token builder, wrapper class) read from the document config instead of
+	 * being hardcoded. For the cookie policy the two paths are byte-identical —
+	 * pinned by tests/unit/test-cookie-policy-golden-render.php.
+	 *
+	 * @param Document_Config      $doc  Document to render.
+	 * @param array<string,string> $atts Shortcode attributes:
+	 *                                   - 'lang' (optional)
+	 *                                   - 'jurisdiction' (optional)
+	 * @return string HTML (already kses'd, safe to echo).
+	 */
+	public static function render_for( Document_Config $doc, $atts = array() ) {
+		$settings = (array) get_option( $doc->option(), array() );
 
 		// Merge a minimal structural baseline so substitution doesn't trip on
 		// missing keys when the option is absent. See baseline_defaults() —
@@ -86,17 +112,17 @@ class Renderer {
 		$lang = self::resolve_lang( $atts, $settings );
 
 		// FR-03 step 2: resolve jurisdiction.
-		$jurisdiction = self::resolve_jurisdiction( $atts, $settings );
+		$jurisdiction = self::resolve_jurisdiction( $atts, $settings, $doc );
 		// Validate the jurisdiction that will actually be rendered. A shortcode
 		// override changes the legal regime, but it must never bypass that
 		// regime's mandatory fields (notably the POPIA operator and Information
 		// Officer details).
-		if ( Generator::missing_required_settings( $jurisdiction, $settings ) ) {
+		if ( $doc->missing_required_settings( $jurisdiction, $settings ) ) {
 			return self::incomplete_configuration_notice();
 		}
 
 		// FR-03 step 3: load scaffold.
-		$template_path = Generator::resolve_template_path( $jurisdiction, $lang );
+		$template_path = Generator::resolve_template_path( $jurisdiction, $lang, $doc );
 		if ( null === $template_path ) {
 			// NFR-03 graceful no-op + admin notice.
 			return self::no_template_notice( $jurisdiction, $lang );
@@ -113,7 +139,7 @@ class Renderer {
 		if ( '' === $scaffold ) {
 			return self::no_template_notice( $jurisdiction, $lang );
 		}
-		$scaffold = Template_Translations::apply( $jurisdiction, $lang, $scaffold );
+		$scaffold = Template_Translations::apply( $jurisdiction, $lang, $scaffold, $doc );
 
 		// Administrator-authored sections win over both the bundled template and
 		// any translation: an explicit editorial decision is the most specific
@@ -123,7 +149,7 @@ class Renderer {
 		$scaffold = Section_Overrides::apply( $jurisdiction, $lang, $scaffold, $settings );
 
 		// FR-03 step 5: build data.
-		$data = self::build_data( $settings, $jurisdiction, $lang );
+		$data = $doc->build_data( $settings, $jurisdiction, $lang );
 
 		// FR-03 step 6+7: substitute + convert.
 		//
@@ -137,7 +163,7 @@ class Renderer {
 		// sentinel back for the real HTML. Standalone-line sentinels get the
 		// surrounding `<p>` wrapper stripped so the injected block sits at the
 		// right nesting level.
-		$html_tokens   = array_intersect_key( $data, array_flip( Generator::HTML_TOKENS ) );
+		$html_tokens   = array_intersect_key( $data, array_flip( $doc->html_tokens() ) );
 		$data_for_md   = $data;
 		foreach ( array_keys( $html_tokens ) as $token_name ) {
 			$data_for_md[ $token_name ] = Generator::html_token_sentinel( $token_name );
@@ -212,7 +238,7 @@ class Renderer {
 		$policy_version = self::register_version_meta( $template_path, $data, $scaffold );
 
 		// Wrap in <article> per NFR-02-X accessibility.
-		$wrapper_open  = '<article class="faz-cookie-policy" lang="' . esc_attr( $lang )
+		$wrapper_open  = '<article class="' . esc_attr( $doc->wrapper_class() ) . '" lang="' . esc_attr( $lang )
 			. '" data-jurisdiction="' . esc_attr( $jurisdiction )
 			. '" data-faz-policy-version="' . esc_attr( $policy_version ) . '">';
 		$wrapper_close = '</article>';
@@ -304,31 +330,42 @@ class Renderer {
 	}
 
 	/**
-	 * Resolve effective jurisdiction. Explicit > admin default > gdpr-strict.
+	 * Resolve effective jurisdiction. Explicit > admin default > first supported.
 	 *
-	 * @param array $atts
-	 * @param array $settings
+	 * The final fallback is the document's FIRST declared jurisdiction — for the
+	 * cookie policy that is 'gdpr-strict', the same value this method returned
+	 * when it was hardcoded.
+	 *
+	 * @param array           $atts
+	 * @param array           $settings
+	 * @param Document_Config $doc Document being rendered.
 	 * @return string
 	 */
-	private static function resolve_jurisdiction( array $atts, array $settings ) {
-		if ( ! empty( $atts['jurisdiction'] ) && in_array( $atts['jurisdiction'], Generator::JURISDICTIONS, true ) ) {
+	private static function resolve_jurisdiction( array $atts, array $settings, Document_Config $doc ) {
+		$jurisdictions = $doc->jurisdictions();
+		if ( ! empty( $atts['jurisdiction'] ) && in_array( $atts['jurisdiction'], $jurisdictions, true ) ) {
 			return (string) $atts['jurisdiction'];
 		}
-		if ( ! empty( $settings['jurisdiction'] ) && in_array( $settings['jurisdiction'], Generator::JURISDICTIONS, true ) ) {
+		if ( ! empty( $settings['jurisdiction'] ) && in_array( $settings['jurisdiction'], $jurisdictions, true ) ) {
 			return (string) $settings['jurisdiction'];
 		}
-		return 'gdpr-strict';
+		return (string) $jurisdictions[0];
 	}
 
 	/**
 	 * Build the substitution-data array.
+	 *
+	 * Internal API: public only because Document_Registry registers it as the
+	 * cookie policy's `data_builder` callable, which PHP cannot invoke on a
+	 * private method from outside the class. Not part of the plugin's public
+	 * surface — call it through Document_Config::build_data().
 	 *
 	 * @param array  $settings    Admin form payload.
 	 * @param string $jurisdiction
 	 * @param string $lang
 	 * @return array<string,string>
 	 */
-	private static function build_data( array $settings, $jurisdiction, $lang ) {
+	public static function build_data( array $settings, $jurisdiction, $lang ) {
 		$company = (array) ( $settings['company'] ?? array() );
 		$dpo     = (array) ( $settings['dpo'] ?? array() );
 

--- a/admin/modules/cookie-policy-generator/includes/class-renderer.php
+++ b/admin/modules/cookie-policy-generator/includes/class-renderer.php
@@ -25,10 +25,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// The document registry is a hard dependency of render(), and the renderer is
-// routinely loaded by hand (unit suites, CLI tools) with no autoloader and no
-// plugin bootstrap. Pull both files in here so that loading this one file is
-// enough to render, exactly as it was before the registry existed.
+// The renderer is routinely loaded by hand (unit suites, CLI tools) with no
+// autoloader and no plugin bootstrap, so every class the render pipeline hard-
+// depends on is pulled in here: loading this one file has to be enough to
+// render. Document_Registry::build() reads its coordinates off Generator and
+// Template_Translations, so requiring only the two registry files would move
+// the old "Class not found" fatal from render() into the registry instead of
+// removing it.
+require_once __DIR__ . '/class-generator.php';
+require_once __DIR__ . '/class-template-translations.php';
+require_once __DIR__ . '/class-section-overrides.php';
 require_once __DIR__ . '/class-document-config.php';
 require_once __DIR__ . '/class-document-registry.php';
 
@@ -79,7 +85,15 @@ class Renderer {
 	 * @return string HTML (already wp_kses_post'd, safe to echo).
 	 */
 	public static function render( $atts = array() ) {
-		return self::render_for( Document_Registry::get( 'cookie-policy' ), $atts );
+		$doc = Document_Registry::get( 'cookie-policy' );
+		if ( ! $doc instanceof Document_Config ) {
+			// Unreachable while the registry is the hardcoded array it is today,
+			// but render() is a shortcode callback: a missing document must
+			// degrade to an empty string on a public page, never to a TypeError
+			// that takes the whole post down with it.
+			return '';
+		}
+		return self::render_for( $doc, $atts );
 	}
 
 	/**

--- a/admin/modules/cookie-policy-generator/includes/class-template-translations.php
+++ b/admin/modules/cookie-policy-generator/includes/class-template-translations.php
@@ -37,23 +37,28 @@ class Template_Translations {
 	 * cannot remove controller contacts, the cookie inventory, retention
 	 * information, or statutory-resource tokens.
 	 *
-	 * @param string $jurisdiction     Jurisdiction template key.
-	 * @param string $lang             Effective policy language.
-	 * @param string $bundled_scaffold Localized Markdown loaded from disk.
+	 * @param string               $jurisdiction     Jurisdiction template key.
+	 * @param string               $lang             Effective policy language.
+	 * @param string               $bundled_scaffold Localized Markdown from disk.
+	 * @param Document_Config|null $doc              Optional document being
+	 *                                               rendered. Null keeps the
+	 *                                               cookie-policy catalogue and
+	 *                                               template tree.
 	 * @return string Effective localized Markdown.
 	 */
-	public static function apply( $jurisdiction, $lang, $bundled_scaffold ) {
+	public static function apply( $jurisdiction, $lang, $bundled_scaffold, ?Document_Config $doc = null ) {
 		if ( ! is_string( $bundled_scaffold ) || '' === $bundled_scaffold ) {
 			return (string) $bundled_scaffold;
 		}
 		if ( ! self::locale_matches_policy_lang( $lang ) || ! function_exists( '_x' ) ) {
 			return $bundled_scaffold;
 		}
-		if ( ! is_readable( self::CATALOG_FILE ) ) {
+		$catalog_file = null === $doc ? self::CATALOG_FILE : $doc->gettext_catalog();
+		if ( ! is_readable( $catalog_file ) ) {
 			return $bundled_scaffold;
 		}
 
-		$source_path = Generator::resolve_template_path( $jurisdiction, 'en' );
+		$source_path = Generator::resolve_template_path( $jurisdiction, 'en', $doc );
 		if ( ! is_string( $source_path ) || ! is_readable( $source_path ) ) {
 			return $bundled_scaffold;
 		}
@@ -62,7 +67,7 @@ class Template_Translations {
 		$source_scaffold = (string) file_get_contents( $source_path );
 		$source_sections = self::split_sections( $source_scaffold );
 		$local_sections  = self::split_sections( $bundled_scaffold );
-		$catalogue       = self::catalogue_for_current_locale();
+		$catalogue       = self::catalogue_for_current_locale( $catalog_file );
 		$translated      = isset( $catalogue[ $jurisdiction ] ) && is_array( $catalogue[ $jurisdiction ] )
 			? $catalogue[ $jurisdiction ]
 			: array();
@@ -121,21 +126,25 @@ class Template_Translations {
 	 * Load the generated gettext catalogue for the active locale.
 	 *
 	 * A locale-keyed cache remains correct when WPML/Polylang or core
-	 * switch_to_locale() changes language during the same request.
+	 * switch_to_locale() changes language during the same request. The catalogue
+	 * path is part of the key as well: with one catalogue per document type, a
+	 * locale-only key would let the first document rendered on a request serve
+	 * its sections to every other document rendered after it.
 	 *
+	 * @param string $catalog_file Absolute path to the generated catalogue.
 	 * @return array<string,array<int,string>>
 	 */
-	private static function catalogue_for_current_locale() {
+	private static function catalogue_for_current_locale( $catalog_file ) {
 		static $catalogues = array();
-		$locale            = self::current_locale();
-		if ( isset( $catalogues[ $locale ] ) ) {
-			return $catalogues[ $locale ];
+		$key               = self::current_locale() . '|' . (string) $catalog_file;
+		if ( isset( $catalogues[ $key ] ) ) {
+			return $catalogues[ $key ];
 		}
 
-		$loaded = require self::CATALOG_FILE;
+		$loaded = require $catalog_file;
 
-		$catalogues[ $locale ] = is_array( $loaded ) ? $loaded : array();
-		return $catalogues[ $locale ];
+		$catalogues[ $key ] = is_array( $loaded ) ? $loaded : array();
+		return $catalogues[ $key ];
 	}
 
 	/**

--- a/admin/modules/cookie-policy-generator/includes/class-template-translations.php
+++ b/admin/modules/cookie-policy-generator/includes/class-template-translations.php
@@ -141,7 +141,22 @@ class Template_Translations {
 			return $catalogues[ $key ];
 		}
 
-		$loaded = require $catalog_file;
+		// This is a require of a path that now comes from a Document_Config, so
+		// it is confined to the plugin tree before it executes. Nothing outside
+		// the plugin can reach this path today — the registry is a hardcoded
+		// array — but a `require` whose argument is configuration is exactly the
+		// line that must not depend on the registry staying hardcoded. The bound
+		// is the plugin root rather than this directory: each document type gets
+		// its own module directory, and its catalogue ships beside it.
+		$catalog_real = realpath( (string) $catalog_file );
+		$plugin_root  = realpath( dirname( __DIR__, 4 ) );
+		if ( false === $catalog_real || false === $plugin_root
+			|| 0 !== strpos( $catalog_real, $plugin_root . DIRECTORY_SEPARATOR ) ) {
+			$catalogues[ $key ] = array();
+			return $catalogues[ $key ];
+		}
+
+		$loaded = require $catalog_real;
 
 		$catalogues[ $key ] = is_array( $loaded ) ? $loaded : array();
 		return $catalogues[ $key ];

--- a/docs/legal-documents-generator-plan.md
+++ b/docs/legal-documents-generator-plan.md
@@ -98,6 +98,9 @@ The registry is a hardcoded PHP array inside the class — **no** `apply_filters
 >
 > What must NOT happen is registering `array( Renderer::class, '<private method>' )` and calling it from elsewhere. `Closure::fromCallable()` inside `Renderer` would also work (it binds scope at creation), but it buys nothing over option 1 and hides the coupling. Whichever is chosen, §6 gains a test that actually executes each registered document's builder — a visibility fatal must surface in the suite, not in production.
 
+The shipped Cookie Policy registry slice chooses option 3: it registers the public
+`Renderer::build_data()` entry point, which composes the private inventory helpers internally.
+
 ### 3.2 How the four engine classes become document-aware
 
 Every existing public signature keeps working unchanged. The document dimension is added via new methods / optional trailing parameters that default to the cookie-policy config.
@@ -105,7 +108,7 @@ Every existing public signature keeps working unchanged. The document dimension 
 | Class | Change | BC guarantee |
 |---|---|---|
 | `Generator` | `resolve_template_path( $jurisdiction, $lang, ?Document_Config $doc = null )`; null → cookie-policy behaviour byte-identical (same dir, same `JURISDICTIONS`/`NATIVE_LANG` consts, which stay as the cookie-policy config's source of truth). `substitute()`, `markdown_to_html()`, `policy_version_hash()`, `normalize_language_code()` are already generic — **no change**. `missing_required_settings()` grows a `$doc` param; null keeps the current POPIA-only behaviour. | Existing constants unreferenced-from-outside stay; unit tests pass unmodified |
-| `Renderer` | Extract the pipeline body of `render()` into `render_for( Document_Config $doc, array $atts )`. `render( $atts )` resolves `Document_Registry::get( 'cookie-policy' )`, returns a safe empty string if the registry entry is unavailable, otherwise delegates to `render_for()`. Settings option and data builder read from `$doc`; later phases adopt the remaining config fields as they are implemented. `build_cookie_list_html()`, `collect_transfer_disclosures()`, `build_services_list()` stay private and can be composed by the public cookie-policy builder entry point. | `Renderer::render()` output byte-identical (golden-file test) and never type-errors on a missing registry entry |
+| `Renderer` | Extract the pipeline body of `render()` into `render_for( Document_Config $doc, array $atts )`. `render( $atts )` resolves the Cookie Policy config, guards a missing/invalid registry entry with a safe empty string, then delegates. In the shipped registry slice, settings option, template coordinates, catalogue, required-fields callback, public data builder and wrapper class read from `$doc`; `disclaimer_key` and `filter_tag` remain deferred with their config fields. The cookie-specific inventory helpers stay private behind `Renderer::build_data()`. | `Renderer::render()` output byte-identical (golden-file test); an invalid registry state never causes a public-page `TypeError` |
 | `Section_Overrides` | **No change.** It already receives `$settings`; each document's own option carries its own `section_overrides[jurisdiction][lang][index]` subtree. Existing cookie-policy overrides never move, never re-key. | Untouched file |
 | `Template_Translations` | `apply( $jurisdiction, $lang, $scaffold, ?Document_Config $doc = null )`; catalogue path + English source path come from `$doc`; null → current constants. `split_sections()` and the placeholder-parity guards are already generic. | Existing gettext tests pass unmodified |
 

--- a/docs/legal-documents-generator-plan.md
+++ b/docs/legal-documents-generator-plan.md
@@ -72,13 +72,21 @@ Document_Config (per document type):
     native_lang     map jurisdiction → lang
     html_tokens     string[]  — tokens protected from markdown_to_html()
     gettext_catalog absolute path to the generated _x() catalogue file
-    rest_base       'legal-documents/privacy-policy' | (cookie-policy keeps its own API)
     data_builder    callable( array $settings, string $jurisdiction, string $lang ) : array
-    required_fields callable( string $jurisdiction, array $settings ) : string[]  (missing dot-paths)
-    disclaimer_key  which default disclaimer text to use
+    required_fields callable( string $jurisdiction, array $settings, Document_Config $doc ) : string[]
+                    (missing dot-paths; $doc lets one shared callback tell the
+                     documents apart — a callback declaring only the first two
+                     parameters keeps working)
     wrapper_class   'faz-privacy-policy' etc. (cookie policy keeps 'faz-cookie-policy')
+
+    LATER STEPS — deliberately NOT in the shipped Document_Config yet, because a
+    validated field nothing reads is a contract with no implementation behind it:
+    rest_base       'legal-documents/privacy-policy' | (cookie-policy keeps its own API)
+    disclaimer_key  which default disclaimer text to use
     filter_tag      'faz_privacy_policy_data' etc. (cookie policy keeps 'faz_cookie_policy_data')
 ```
+
+`native_lang` must name **exactly** the declared `jurisdictions` — no missing key, no unknown key. The constructor refuses both: a missing entry would silently resolve to `en` and publish a legal text in the wrong language, with nothing anywhere reporting it.
 
 The registry is a hardcoded PHP array inside the class — **no** `apply_filters` on the registry itself in v1. Opening document registration to third parties before the shape is proven invites support burden and a compat contract we can't yet honour. Add a filter later if demand appears.
 
@@ -153,7 +161,13 @@ admin/modules/cookie-policy-generator/          ← directory name UNCHANGED (se
 - `[faz_privacy_policy_complete]` — NOT `[faz_privacy_policy]`: symmetric with `[faz_cookie_policy_complete]`, and it leaves the unsuffixed name free forever (the cookie side has a legacy unsuffixed shortcode; keeping the naming rule "engine documents end in `_complete`" is worth more than a shorter name). Verified: no `faz_privacy_policy*`, `faz_terms*`, `faz_disclaimer*` shortcode exists today.
 - `[faz_terms_conditions_complete]`, `[faz_disclaimer_complete]` (P1b).
 
-**REST** — new namespace path, one generic controller: `faz/v1/legal-documents/(?P<document>[a-z-]+)/settings|preview|scaffold` with the document slug validated against `Document_Registry::slugs()` minus `cookie-policy`. The existing `faz/v1/cookie-policy/*` routes are **frozen**: same class, same responses, byte-identical. The new controller reuses the old one's `check_admin_read`/`check_admin_write` pattern (`current_user_can( 'manage_options' )` + nonce), `trim_clip`/`trim_clip_multiline` helpers (moved to a shared trait or small `Api_Helpers` class), and the same sanitise-against-defaults strategy. `suggest-services`/`detected-services` stay cookie-policy-only (they are scanner-driven and cookie-specific).
+**REST** — new namespace path, one generic controller registering three separate routes rather than one alternation (an un-grouped `a|b|c` in a route regex matches things nobody intends, including an empty document slug):
+
+- `faz/v1/legal-documents/(?P<document>[a-z-]+)/settings`
+- `faz/v1/legal-documents/(?P<document>[a-z-]+)/preview`
+- `faz/v1/legal-documents/(?P<document>[a-z-]+)/scaffold`
+
+The document slug is validated against `Document_Registry::slugs()` minus `cookie-policy`. The existing `faz/v1/cookie-policy/*` routes are **frozen**: same class, same responses, byte-identical. The new controller reuses the old one's `check_admin_read`/`check_admin_write` pattern, `trim_clip`/`trim_clip_multiline` helpers (moved to a shared trait or small `Api_Helpers` class), and the same sanitise-against-defaults strategy. Every **write** route (`settings`, `acknowledge`, and any added later) checks `current_user_can( 'manage_options' )` **and** verifies the nonce through `faz_verify_nonce()` — both, not either; tests cover missing nonce, invalid nonce, and an authenticated user without the capability. `suggest-services`/`detected-services` stay cookie-policy-only (they are scanner-driven and cookie-specific).
 
 **Blocks** — one new block `faz/legal-document` with attributes `document` (enum from registry, default `privacy-policy`), `jurisdiction`, `lang`, `show_title`. Server-rendered via `Renderer::render_for()`. Registered in `includes/blocks/class-blocks.php` next to the existing three; the legacy `faz/cookie-policy` block is untouched. (`register_block_type` with array config is WP 5.0-safe — same call pattern already shipping.)
 
@@ -297,7 +311,7 @@ Admin-controlled, never automatic — by design *and* because an automatic link 
    §6 gains an E2E assertion: acknowledging a *material* change to Terms leaves `consent_revision` untouched and does not re-show the banner to a visitor holding a valid consent cookie.
 3. **Upgrade neutrality**: on first load after the 1.27.0 upgrade the ledger is empty → it is seeded silently with current hashes, so the feature's own arrival never generates a prompt.
 
-**Files:** `includes/class-version-ledger.php` (new, inside the module), notice rendering inside `legal-documents.php` + the cookie-policy view, one new REST route `faz/v1/legal-documents/acknowledge` (POST, admin, nonce), JS in `legal-documents.js`. No frontend files change at all — the consent-revision plumbing already exists end-to-end.
+**Files:** `includes/class-version-ledger.php` (new, inside the module), notice rendering inside `legal-documents.php` + the cookie-policy view, one new REST route `faz/v1/legal-documents/acknowledge` (POST; `manage_options` **and** `faz_verify_nonce()`, per §4), JS in `legal-documents.js`. No frontend files change at all — the consent-revision plumbing already exists end-to-end.
 
 **Acceptance:** editing a section override surfaces the notice; "minor" silences it without touching consent; "material" demonstrably re-shows the banner to a visitor with a prior consent cookie (E2E); plugin upgrade alone never prompts. **Done means:** the operator has a one-click, fully-informed path from "policy text changed" to "visitors re-consent", and no path where it happens without them.
 

--- a/tests/unit/test-legal-documents-registry.php
+++ b/tests/unit/test-legal-documents-registry.php
@@ -1,0 +1,584 @@
+<?php
+/**
+ * Unit tests for Document_Registry / Document_Config and the render_for()
+ * extraction.
+ *
+ * WHY THIS EXISTS
+ *
+ * The golden-render suite proves the cookie policy still renders byte-for-byte
+ * as it did. It cannot prove WHY: it only ever calls `Renderer::render()`, so a
+ * registry that silently returned the wrong config, or a `render_for()` that
+ * quietly ignored its `$doc` and kept reading the old constants, would still be
+ * green. This suite pins the seam itself — the registry contents, the config
+ * validation, and the equivalence of every "with $doc" / "without $doc" pair
+ * that the refactor introduced.
+ *
+ * Same harness as test-cookie-policy-golden-render.php: WordPress is stubbed
+ * deterministically and the classes under test are required directly, with no
+ * autoloader and no plugin bootstrap. That is not just convenience — it is the
+ * constraint that forces Document_Registry to build its configs lazily and to
+ * name the shortcode as a literal, and this suite is what would catch a
+ * regression on either point.
+ *
+ * Run:
+ *   php tests/unit/test-legal-documents-registry.php
+ *   bash scripts/run-unit-tests.sh
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ );
+}
+if ( ! defined( 'FAZ_VERSION' ) ) {
+	define( 'FAZ_VERSION', '1.25.1-test' );
+}
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 3600 );
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic environment.
+// ---------------------------------------------------------------------------
+$GLOBALS['faz_test_state'] = array(
+	'now'           => '2026-06-03 09:41:00',
+	'locale'        => 'en_US',
+	'home'          => 'https://example.test',
+	'options'       => array(),
+	'privacy_url'   => '',
+	'is_admin_user' => true,
+);
+$_SERVER['REQUEST_URI'] = '/cookie-policy/';
+
+// ---------------------------------------------------------------------------
+// WordPress stubs.
+// ---------------------------------------------------------------------------
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $v ) { return htmlspecialchars( (string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ); }
+}
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $v ) { return htmlspecialchars( (string) $v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ); }
+}
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $u ) {
+		$u = (string) $u;
+		$u = str_replace( array( '"', "'", '<', '>' ), '', $u );
+		return trim( $u );
+	}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $t, $d = 'default' ) { return (string) $t; }
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $t, $d = 'default' ) { return esc_html( (string) $t ); }
+}
+if ( ! function_exists( '_x' ) ) {
+	function _x( $text, $context = '', $domain = 'default' ) { return (string) $text; }
+}
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $v ) { return (string) $v; }
+}
+if ( ! function_exists( 'wp_kses_allowed_html' ) ) {
+	function wp_kses_allowed_html( $context = 'post' ) {
+		$attrs = array( 'class' => true, 'id' => true, 'style' => true );
+		return array(
+			'p'       => $attrs,
+			'span'    => $attrs,
+			'div'     => $attrs,
+			'section' => $attrs,
+			'details' => $attrs,
+			'summary' => $attrs,
+			'table'   => $attrs,
+			'thead'   => $attrs,
+			'tbody'   => $attrs,
+			'tr'      => $attrs,
+			'th'      => array( 'scope' => true ) + $attrs,
+			'td'      => $attrs,
+			'h1'      => $attrs,
+			'h2'      => $attrs,
+			'h3'      => $attrs,
+			'ul'      => $attrs,
+			'li'      => $attrs,
+			'a'       => array( 'href' => true, 'rel' => true, 'target' => true ) + $attrs,
+			'strong'  => $attrs,
+			'em'      => $attrs,
+			'small'   => $attrs,
+			'br'      => array(),
+		);
+	}
+}
+if ( ! function_exists( 'wp_kses' ) ) {
+	function wp_kses( $html, $allowed = array(), $protocols = array() ) { return (string) $html; }
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $name, $default = false ) {
+		return array_key_exists( $name, $GLOBALS['faz_test_state']['options'] )
+			? $GLOBALS['faz_test_state']['options'][ $name ]
+			: $default;
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '/' ) {
+		return rtrim( $GLOBALS['faz_test_state']['home'], '/' ) . '/' . ltrim( (string) $path, '/' );
+	}
+}
+if ( ! function_exists( 'get_privacy_policy_url' ) ) {
+	function get_privacy_policy_url() { return (string) $GLOBALS['faz_test_state']['privacy_url']; }
+}
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type = 'mysql', $gmt = 0 ) {
+		return 'timestamp' === $type
+			? strtotime( $GLOBALS['faz_test_state']['now'] )
+			: $GLOBALS['faz_test_state']['now'];
+	}
+}
+if ( ! function_exists( 'get_locale' ) ) {
+	function get_locale() { return (string) $GLOBALS['faz_test_state']['locale']; }
+}
+if ( ! function_exists( 'determine_locale' ) ) {
+	function determine_locale() { return get_locale(); }
+}
+if ( ! function_exists( 'switch_to_locale' ) ) {
+	function switch_to_locale( $locale ) {
+		if ( (string) $locale === (string) $GLOBALS['faz_test_state']['locale'] ) {
+			return false;
+		}
+		$GLOBALS['faz_test_state']['locale_stack'][] = $GLOBALS['faz_test_state']['locale'];
+		$GLOBALS['faz_test_state']['locale']         = (string) $locale;
+		return true;
+	}
+}
+if ( ! function_exists( 'restore_previous_locale' ) ) {
+	function restore_previous_locale() {
+		if ( ! empty( $GLOBALS['faz_test_state']['locale_stack'] ) ) {
+			$GLOBALS['faz_test_state']['locale'] = array_pop( $GLOBALS['faz_test_state']['locale_stack'] );
+			return $GLOBALS['faz_test_state']['locale'];
+		}
+		return false;
+	}
+}
+if ( ! function_exists( 'wp_cache_get' ) ) {
+	function wp_cache_get( $key, $group = '', $force = false, &$found = null ) { $found = false; return false; }
+}
+if ( ! function_exists( 'wp_cache_set' ) ) {
+	function wp_cache_set( $key, $data, $group = '', $expire = 0 ) { return true; }
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $hook, $cb, $priority = 10, $args = 1 ) { return true; }
+}
+if ( ! function_exists( 'did_action' ) ) {
+	function did_action( $hook ) { return 0; }
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can( $cap ) { return ! empty( $GLOBALS['faz_test_state']['is_admin_user'] ); }
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) { return $value; }
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $v, $flags = 0, $depth = 512 ) { return json_encode( $v, $flags, $depth ); }
+}
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $v ) { return is_string( $v ) ? stripslashes( $v ) : $v; }
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) { return parse_url( $url, $component ); }
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $v ) { return abs( (int) $v ); }
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $v ) { return trim( strip_tags( (string) $v ) ); }
+}
+if ( ! function_exists( 'number_format_i18n' ) ) {
+	function number_format_i18n( $n, $decimals = 0 ) { return number_format( (float) $n, (int) $decimals ); }
+}
+
+// ---------------------------------------------------------------------------
+// Fake $wpdb — same three calls the renderer makes.
+// ---------------------------------------------------------------------------
+class FAZ_Fake_WPDB {
+	public $prefix         = 'wp_';
+	public $tables_present = true;
+	public $rows           = array();
+
+	public function prepare( $query, ...$args ) {
+		foreach ( $args as $arg ) {
+			$query = preg_replace( '/%s/', "'" . (string) $arg . "'", $query, 1 );
+		}
+		return $query;
+	}
+
+	public function get_var( $query ) {
+		if ( ! $this->tables_present ) {
+			return null;
+		}
+		if ( preg_match( "/SHOW TABLES LIKE '([^']+)'/", (string) $query, $m ) ) {
+			return $m[1];
+		}
+		return null;
+	}
+
+	public function get_results( $query, $output = OBJECT ) {
+		return $this->rows;
+	}
+}
+if ( ! defined( 'OBJECT' ) ) { define( 'OBJECT', 'OBJECT' ); }
+if ( ! defined( 'ARRAY_A' ) ) { define( 'ARRAY_A', 'ARRAY_A' ); }
+
+$GLOBALS['wpdb'] = new FAZ_Fake_WPDB();
+
+// ---------------------------------------------------------------------------
+// Units under test.
+// ---------------------------------------------------------------------------
+$faz_root = dirname( __DIR__, 2 );
+require_once $faz_root . '/admin/modules/cookie-policy-generator/includes/class-generator.php';
+require_once $faz_root . '/admin/modules/cookie-policy-generator/includes/class-template-translations.php';
+require_once $faz_root . '/admin/modules/cookie-policy-generator/includes/class-section-overrides.php';
+require_once $faz_root . '/admin/modules/cookie-policy-generator/includes/class-document-config.php';
+require_once $faz_root . '/admin/modules/cookie-policy-generator/includes/class-document-registry.php';
+require_once $faz_root . '/admin/modules/cookie-policy-generator/includes/class-renderer.php';
+
+use FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes\Document_Config;
+use FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes\Document_Registry;
+use FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes\Generator;
+use FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes\Renderer;
+use FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes\Template_Translations;
+
+// ---------------------------------------------------------------------------
+// Assertions.
+// ---------------------------------------------------------------------------
+$tests_run = $tests_passed = $tests_failed = 0;
+
+function assert_true( $cond, $label ) {
+	global $tests_run, $tests_passed, $tests_failed;
+	$tests_run++;
+	if ( $cond ) { $tests_passed++; echo "  \033[32m✓\033[0m $label\n"; }
+	else { $tests_failed++; echo "  \033[31m✗\033[0m $label\n"; }
+}
+
+/** Reset the renderer's three per-request caches between comparable renders. */
+function faz_reset_renderer_statics() {
+	foreach ( array(
+		'cookie_list_cache'        => array(),
+		'transfer_cache'           => array(),
+		'public_cookie_rows_cache' => null,
+	) as $prop => $value ) {
+		$ref = new ReflectionProperty( Renderer::class, $prop );
+		$ref->setAccessible( true );
+		$ref->setValue( null, $value );
+	}
+}
+
+// ===========================================================================
+echo "\n\033[1mDocument_Registry — contents\033[0m\n";
+// ===========================================================================
+
+assert_true(
+	array( 'cookie-policy' ) === Document_Registry::slugs(),
+	'the registry holds exactly one document: cookie-policy'
+);
+assert_true(
+	Document_Registry::get( 'cookie-policy' ) instanceof Document_Config,
+	'get("cookie-policy") returns a Document_Config'
+);
+assert_true(
+	null === Document_Registry::get( 'privacy-policy' ),
+	'an unregistered slug returns null rather than a half-built config'
+);
+assert_true(
+	Document_Registry::get( 'cookie-policy' ) === Document_Registry::all()['cookie-policy'],
+	'configs are built once and memoised (same instance on every access)'
+);
+
+$config = Document_Registry::get( 'cookie-policy' );
+
+// ===========================================================================
+echo "\n\033[1mDocument_Config — cookie-policy integrity\033[0m\n";
+// ===========================================================================
+
+assert_true( 'cookie-policy' === $config->slug(), 'slug()' );
+assert_true( 'faz_cookie_policy_data' === $config->option(), 'option() is the shipped wp_options key' );
+assert_true( 'faz_cookie_policy_complete' === $config->shortcode(), 'shortcode() matches the registered tag' );
+assert_true( 'faz-cookie-policy' === $config->wrapper_class(), 'wrapper_class() matches the shipped CSS hook' );
+assert_true( Generator::JURISDICTIONS === $config->jurisdictions(), 'jurisdictions() mirrors Generator::JURISDICTIONS' );
+assert_true(
+	'gdpr-strict' === $config->jurisdictions()[0],
+	'gdpr-strict is FIRST — it is the fallback regime resolve_jurisdiction() falls back to'
+);
+assert_true( Generator::HTML_TOKENS === $config->html_tokens(), 'html_tokens() mirrors Generator::HTML_TOKENS' );
+assert_true( Generator::templates_dir() === $config->templates_dir(), 'templates_dir() points at the shipped template tree' );
+assert_true( is_readable( $config->gettext_catalog() ), 'gettext_catalog() points at a readable catalogue file' );
+
+foreach ( Generator::NATIVE_LANG as $jurisdiction => $native ) {
+	assert_true(
+		$native === $config->native_lang( $jurisdiction ),
+		"native_lang( $jurisdiction ) === $native"
+	);
+}
+assert_true(
+	'en' === $config->native_lang( 'not-a-jurisdiction' ),
+	'native_lang() defaults to en for an unmapped jurisdiction'
+);
+
+foreach ( $config->jurisdictions() as $jurisdiction ) {
+	assert_true(
+		is_readable( $config->templates_dir() . '/' . $jurisdiction . '/en.md' ),
+		"$jurisdiction ships an English scaffold under templates_dir()"
+	);
+}
+
+// The two callables must reach the real implementations, not a stale copy.
+assert_true(
+	array() === $config->missing_required_settings( 'gdpr-strict', array() ),
+	'missing_required_settings() delegates to the POPIA-only gating (GDPR needs nothing)'
+);
+assert_true(
+	in_array( 'company.name', $config->missing_required_settings( 'popia-southafrica', array() ), true ),
+	'missing_required_settings() still reports the POPIA mandatory fields'
+);
+$built = $config->build_data( array(), 'gdpr-strict', 'en' );
+assert_true(
+	isset( $built['COOKIE_CATEGORIES'] ) && isset( $built['JURISDICTION_NAME'] ),
+	'build_data() delegates to the renderer token builder'
+);
+
+// ===========================================================================
+echo "\n\033[1mDocument_Config — constructor validation\033[0m\n";
+// ===========================================================================
+
+/** Run a constructor call and report whether it threw InvalidArgumentException. */
+function faz_rejects( array $config ) {
+	try {
+		new Document_Config( $config );
+	} catch ( InvalidArgumentException $e ) {
+		return true;
+	} catch ( Throwable $e ) {
+		return false;
+	}
+	return false;
+}
+
+/** A structurally valid entry, used as the base for the mutation cases below. */
+function faz_valid_config_array() {
+	return array(
+		'slug'            => 'cookie-policy',
+		'shortcode'       => 'faz_cookie_policy_complete',
+		'option'          => Renderer::SETTINGS_OPTION,
+		'templates_dir'   => Generator::templates_dir(),
+		'jurisdictions'   => Generator::JURISDICTIONS,
+		'native_lang'     => Generator::NATIVE_LANG,
+		'html_tokens'     => Generator::HTML_TOKENS,
+		'gettext_catalog' => Template_Translations::CATALOG_FILE,
+		'wrapper_class'   => 'faz-cookie-policy',
+		'data_builder'    => array( Renderer::class, 'build_data' ),
+		'required_fields' => array( Generator::class, 'missing_required_settings' ),
+	);
+}
+
+assert_true( faz_rejects( array() ), 'an empty config is rejected' );
+assert_true(
+	faz_rejects( array_merge( faz_valid_config_array(), array( 'jurisdictions' => 'gdpr-strict' ) ) ),
+	'a scalar where an array belongs (jurisdictions) is rejected'
+);
+assert_true(
+	faz_rejects( array_merge( faz_valid_config_array(), array( 'jurisdictions' => array() ) ) ),
+	'an empty jurisdiction list is rejected — there would be no fallback regime'
+);
+assert_true(
+	faz_rejects( array_merge( faz_valid_config_array(), array( 'data_builder' => 'faz_not_a_function' ) ) ),
+	'a non-callable data_builder is rejected'
+);
+assert_true(
+	! faz_rejects( faz_valid_config_array() ),
+	'the shipped shape is accepted'
+);
+
+// ===========================================================================
+echo "\n\033[1mGenerator::resolve_template_path() — with and without \$doc\033[0m\n";
+// ===========================================================================
+
+// 'sk' has no bundled scaffold (it exercises the fallback chain) and '' is the
+// invalid-code branch that falls back to the jurisdiction's native language.
+$path_langs = array_merge( Generator::LANGUAGES, array( 'sk', '' ) );
+$path_drift = array();
+foreach ( Generator::JURISDICTIONS as $jurisdiction ) {
+	foreach ( $path_langs as $lang ) {
+		$without = Generator::resolve_template_path( $jurisdiction, $lang );
+		$with    = Generator::resolve_template_path( $jurisdiction, $lang, $config );
+		if ( $without !== $with ) {
+			$path_drift[] = $jurisdiction . '/' . ( '' === $lang ? '(empty)' : $lang );
+		}
+	}
+}
+assert_true(
+	array() === $path_drift,
+	'every jurisdiction × language resolves to the same file with or without the config'
+		. ( $path_drift ? ' — drifted: ' . implode( ', ', $path_drift ) : '' )
+);
+assert_true(
+	null === Generator::resolve_template_path( 'not-a-jurisdiction', 'en', $config ),
+	'an unknown jurisdiction still resolves to null when a config is passed'
+);
+
+// ===========================================================================
+echo "\n\033[1mTemplate_Translations::apply() — with and without \$doc\033[0m\n";
+// ===========================================================================
+
+$translation_drift = array();
+foreach ( Generator::JURISDICTIONS as $jurisdiction ) {
+	$path     = Generator::resolve_template_path( $jurisdiction, 'en' );
+	$scaffold = (string) file_get_contents( $path );
+	$without  = Template_Translations::apply( $jurisdiction, 'en', $scaffold );
+	$with     = Template_Translations::apply( $jurisdiction, 'en', $scaffold, $config );
+	if ( $without !== $with ) {
+		$translation_drift[] = $jurisdiction;
+	}
+}
+assert_true(
+	array() === $translation_drift,
+	'the gettext merge produces the same scaffold with or without the config'
+		. ( $translation_drift ? ' — drifted: ' . implode( ', ', $translation_drift ) : '' )
+);
+
+// ===========================================================================
+echo "\n\033[1mRenderer::render() === Renderer::render_for( cookie-policy )\033[0m\n";
+// ===========================================================================
+
+$GLOBALS['faz_test_state']['options'][ Renderer::SETTINGS_OPTION ] = array(
+	'company'          => array(
+		'name'     => 'Esempio S.r.l.',
+		'address'  => 'Via Roma 1, 35100 Padova, Italy',
+		'email'    => 'privacy@example.test',
+		'registry' => 'IT01234567890',
+	),
+	'dpo'              => array(
+		'name'  => 'Dott.ssa A. Bianchi',
+		'email' => 'dpo@example.test',
+	),
+	'retention_months' => 6,
+	'jurisdiction'     => 'gdpr-strict',
+	'language'         => 'en',
+	'services'         => array( 'Google Analytics', 'YouTube' ),
+);
+$GLOBALS['wpdb']->rows = array(
+	array(
+		'cookie_id'            => 1,
+		'cookie_name'          => '_ga',
+		'cookie_domain'        => '.example.test',
+		'cookie_duration'      => '{"en":"2 years"}',
+		'cookie_description'   => '{"en":"Google Analytics visitor id."}',
+		'cookie_meta'          => '',
+		'category_id'          => 3,
+		'category_name'        => '{"en":"Analytics"}',
+		'category_description' => '{"en":"Measure how visitors use the site."}',
+		'category_slug'        => 'analytics',
+	),
+	array(
+		'cookie_id'            => 2,
+		'cookie_name'          => 'fazcookie-consent',
+		'cookie_domain'        => 'example.test',
+		'cookie_duration'      => '{"en":"6 months"}',
+		'cookie_description'   => '{"en":"Stores the visitor consent choice."}',
+		'cookie_meta'          => '',
+		'category_id'          => 1,
+		'category_name'        => '{"en":"Necessary"}',
+		'category_description' => '{"en":"Required for the site to work."}',
+		'category_slug'        => 'necessary',
+	),
+);
+
+faz_reset_renderer_statics();
+$via_render = Renderer::render( array() );
+faz_reset_renderer_statics();
+$via_render_for = Renderer::render_for( $config, array() );
+
+assert_true( '' !== $via_render, 'render() produced a document (the comparison is not two empty strings)' );
+assert_true( $via_render === $via_render_for, 'render() and render_for( cookie-policy ) are byte-identical' );
+
+// The same must hold on the attribute-driven branches, where render_for() reads
+// the jurisdiction list and the mandatory-field gate off the config.
+foreach ( array(
+	'lang attribute'         => array( 'lang' => 'it' ),
+	'jurisdiction attribute' => array( 'jurisdiction' => 'ccpa-california' ),
+	'unknown jurisdiction'   => array( 'jurisdiction' => 'not-a-jurisdiction' ),
+	'show_title'             => array( 'show_title' => 'true' ),
+) as $label => $atts ) {
+	faz_reset_renderer_statics();
+	$a = Renderer::render( $atts );
+	faz_reset_renderer_statics();
+	$b = Renderer::render_for( $config, $atts );
+	assert_true( $a === $b, "render() === render_for() with the $label" );
+}
+
+// The refusal path too: POPIA without its mandatory fields must refuse
+// identically through both entry points.
+$GLOBALS['faz_test_state']['options'][ Renderer::SETTINGS_OPTION ]['jurisdiction'] = 'popia-southafrica';
+$GLOBALS['faz_test_state']['options'][ Renderer::SETTINGS_OPTION ]['dpo']          = array();
+faz_reset_renderer_statics();
+$refuse_a = Renderer::render( array() );
+faz_reset_renderer_statics();
+$refuse_b = Renderer::render_for( $config, array() );
+assert_true(
+	$refuse_a === $refuse_b && false !== strpos( $refuse_a, 'faz-cookie-policy' ),
+	'the POPIA incomplete-configuration refusal is identical through both entry points'
+);
+
+// ===========================================================================
+echo "\n\033[1mrender_for() reads the config, not the old constants\033[0m\n";
+// ===========================================================================
+//
+// The equivalence checks above cannot catch a render_for() that accepted a
+// $doc and then ignored it — render() delegates to it, so both sides would
+// move together. These two cases pass a config that DIFFERS from the shipped
+// one and require the difference to show up in the output.
+
+$GLOBALS['faz_test_state']['options'][ Renderer::SETTINGS_OPTION ]['jurisdiction'] = 'gdpr-strict';
+$GLOBALS['faz_test_state']['options'][ Renderer::SETTINGS_OPTION ]['dpo']          = array(
+	'name'  => 'Dott.ssa A. Bianchi',
+	'email' => 'dpo@example.test',
+);
+
+$other_wrapper = new Document_Config(
+	array_merge( faz_valid_config_array(), array( 'wrapper_class' => 'faz-test-document' ) )
+);
+faz_reset_renderer_statics();
+$baseline = Renderer::render( array() );
+faz_reset_renderer_statics();
+$rewrapped = Renderer::render_for( $other_wrapper, array() );
+assert_true(
+	0 === strpos( $rewrapped, '<article class="faz-test-document"' ),
+	'wrapper_class() from the config reaches the <article> wrapper'
+);
+assert_true(
+	str_replace( 'faz-test-document', 'faz-cookie-policy', $rewrapped ) === $baseline,
+	'the wrapper class is the ONLY difference — the body is untouched by the swap'
+);
+
+$GLOBALS['faz_test_state']['options']['faz_test_other_document'] = array(
+	'company'      => array( 'name' => 'Altra Ditta S.p.A.' ),
+	'jurisdiction' => 'gdpr-strict',
+	'language'     => 'en',
+);
+$other_option = new Document_Config(
+	array_merge( faz_valid_config_array(), array( 'option' => 'faz_test_other_document' ) )
+);
+faz_reset_renderer_statics();
+$other_settings = Renderer::render_for( $other_option, array() );
+assert_true(
+	false !== strpos( $other_settings, 'Altra Ditta S.p.A.' )
+		&& false === strpos( $other_settings, 'Esempio S.r.l.' ),
+	'option() from the config decides which saved settings are rendered'
+);
+
+// ---------------------------------------------------------------------------
+echo "\n────────────────────────────────────────────────────────────\n";
+if ( 0 === $tests_failed ) {
+	echo "\033[32mALL PASS\033[0m — {$tests_passed}/{$tests_run} checks\n\n";
+	exit( 0 );
+}
+echo "\033[31mFAILED\033[0m — {$tests_failed} of {$tests_run} checks failed\n\n";
+exit( 1 );

--- a/tests/unit/test-legal-documents-registry.php
+++ b/tests/unit/test-legal-documents-registry.php
@@ -397,6 +397,72 @@ assert_true(
 	'the shipped shape is accepted'
 );
 
+// native_lang must name every jurisdiction and nothing else. The missing-key
+// case is the one with teeth: native_lang() would answer 'en' and the document
+// would render in the wrong language with no error anywhere.
+$faz_short_langs = Generator::NATIVE_LANG;
+unset( $faz_short_langs['lgpd-brazil'] );
+assert_true(
+	faz_rejects( array_merge( faz_valid_config_array(), array( 'native_lang' => $faz_short_langs ) ) ),
+	'a jurisdiction with no native_lang entry is rejected'
+);
+assert_true(
+	faz_rejects(
+		array_merge(
+			faz_valid_config_array(),
+			array( 'native_lang' => array_merge( Generator::NATIVE_LANG, array( 'not-a-jurisdiction' => 'fr' ) ) )
+		)
+	),
+	'a native_lang entry for an undeclared jurisdiction is rejected'
+);
+
+// ===========================================================================
+echo "\n\033[1mDocument_Config — the required_fields callback receives the document\033[0m\n";
+// ===========================================================================
+
+// Generator::missing_required_settings() gates on the document it is handed.
+// The gate only works if Document_Config actually passes it, so assert through
+// the config rather than by calling the Generator directly.
+$faz_other_doc = new Document_Config(
+	array_merge( faz_valid_config_array(), array( 'slug' => 'privacy-policy' ) )
+);
+assert_true(
+	array() === $faz_other_doc->missing_required_settings( 'popia-southafrica', array() ),
+	'a document other than the cookie policy gets no cookie-policy mandatory fields'
+);
+assert_true(
+	in_array( 'company.name', $config->missing_required_settings( 'popia-southafrica', array() ), true ),
+	'…while the cookie policy itself still gets the POPIA mandatory fields'
+);
+
+// ===========================================================================
+echo "\n\033[1mTemplate_Translations — the catalogue path stays inside the plugin\033[0m\n";
+// ===========================================================================
+
+// catalogue_for_current_locale() require()s a path that now arrives from a
+// Document_Config. Prove the confinement executes: a catalogue outside the
+// plugin tree must never be included, not merely produce no translations.
+$faz_outside_catalog = rtrim( sys_get_temp_dir(), '/' ) . '/faz-outside-catalog.php';
+file_put_contents(
+	$faz_outside_catalog,
+	"<?php\n\$GLOBALS['faz_outside_catalog_was_required'] = true;\nreturn array();\n"
+);
+$faz_outside_doc = new Document_Config(
+	array_merge( faz_valid_config_array(), array( 'gettext_catalog' => $faz_outside_catalog ) )
+);
+$faz_en_path     = Generator::resolve_template_path( 'gdpr-strict', 'en' );
+$faz_en_scaffold = (string) file_get_contents( $faz_en_path );
+$faz_outside_out = Template_Translations::apply( 'gdpr-strict', 'en', $faz_en_scaffold, $faz_outside_doc );
+assert_true(
+	! isset( $GLOBALS['faz_outside_catalog_was_required'] ),
+	'a catalogue outside the plugin tree is never require()d'
+);
+assert_true(
+	$faz_outside_out === $faz_en_scaffold,
+	'a refused catalogue leaves the bundled scaffold untouched'
+);
+unlink( $faz_outside_catalog );
+
 // ===========================================================================
 echo "\n\033[1mGenerator::resolve_template_path() — with and without \$doc\033[0m\n";
 // ===========================================================================


### PR DESCRIPTION
Implements §3 of `docs/legal-documents-generator-plan.md`. Pure refactor: only the cookie policy is registered, and its rendered output is byte-identical.

This PR is stacked on `test/cookie-policy-golden-render` (merged in): that branch contributes the plan document and the 16-fixture golden-render suite that acts as the backward-compatibility gate for this work.

## What I changed

Two new files under `admin/modules/cookie-policy-generator/includes/`:

- `class-document-config.php` — an immutable value object describing one document type: slug, shortcode, option key, templates dir, jurisdictions, native-language map, HTML tokens, gettext catalogue, wrapper class, plus a data-builder and a required-fields callable.
- `class-document-registry.php` — a static registry with `get()` / `all()` / `slugs()`. One entry: `cookie-policy`.

Three files modified:

- `class-renderer.php` — the body of `render()` moved verbatim into a new `render_for( Document_Config $doc, $atts )`, with each hardcoded coordinate replaced by a config read. `render( $atts )` is now a one-line delegate. `resolve_jurisdiction()` takes the document; `build_data()` goes private → public.
- `class-generator.php` — `resolve_template_path()` and `missing_required_settings()` grow a trailing optional document parameter.
- `class-template-translations.php` — `apply()` grows the same parameter; the catalogue memo key becomes locale + catalogue path.

`class-section-overrides.php` is untouched — `git diff main` on it is empty.

## Why it is shaped this way

**A value object, not an interface.** The documents differ in *data*, not behaviour — same pipeline, different coordinates — and the one behavioural difference (which tokens get built) is a single callable. An interface hierarchy would give me four classes with nothing to override. A bare config array would give me neither validation nor a single place to catch a typo'd key, so the constructor validates eagerly and throws `InvalidArgumentException`. A malformed registry entry should fail when the registry is built, not appear as a blank token halfway down a published legal document.

**No `apply_filters` on the registry.** The plan defers third-party document registration on purpose. Opening it before the config shape has settled would create a compatibility contract I cannot yet honour, for a use case nobody has asked for. A filter can be added later; it cannot be taken away.

**The registry builds lazily.** The golden-render suite loads these class files by hand, with no autoloader and no plugin bootstrap. Building the configs at file-load time would make load order a trap for exactly that context. For the same reason the shortcode is a literal string rather than a reference to the module bootstrap's constant, and `class-renderer.php` `require_once`'s both new files itself, so loading that one file is still enough to render.

**The catalogue memo key changed.** `Template_Translations` memoised the loaded catalogue per locale for the whole request. That was correct with a single catalogue; with one per document type the slot collides, and whichever document rendered first would silently serve its sections to every document after it. The key is now locale + catalogue path. The per-locale semantics the `gdpr-gettext-merge` fixture depends on (en_GB gets its own slot) are unchanged.

**One deliberate deviation from the spec I was given.** The document parameters are declared `?Document_Config $doc = null` rather than the implicitly-nullable `Document_Config $doc = null`. Both are valid on the PHP 7.4 floor and both are backward compatible, but the implicit form emits `Deprecated: Implicitly marking parameter $doc as nullable` on PHP 8.4 — which would land in the debug log of every install running it. The explicit nullable syntax has been available since PHP 7.1, so it costs nothing.

**`build_data()` had to become public.** PHP cannot invoke a private method through a callable registered outside the class. It carries a docblock marking it internal API; the intended entry point is `Document_Config::build_data()`. Every other renderer helper keeps its current visibility and signature, because `test-czech-renderer-php.php` and `test-third-country-transfer-php.php` reach them through Reflection.

## Backward compatibility

- `Renderer::render( $atts )`, `Generator::resolve_template_path( $j, $l )`, `Generator::missing_required_settings( $j, $s )` and `Template_Translations::apply( $j, $l, $s )` all keep their pre-refactor arity. Passing no document reproduces the old behaviour exactly — same constants, same directory, same catalogue.
- The registry's `required_fields` callable is invoked with two arguments, so `Generator`'s own `$doc` stays null and the POPIA-only gating runs verbatim. No recursion back into the registry.
- `resolve_jurisdiction()`'s final fallback is now `jurisdictions()[0]`, which is `gdpr-strict` — the value it previously hardcoded. Reordering that array would change the default legal regime, so the new suite asserts the order.
- The existing callers in `class-cookie-policy-api.php` and `class-cookie-policy-generator.php` are unmodified.
- No `frontend/` changes, so no `npm run build:min`. No admin views or assets, no readme/CHANGELOG entry (this ships inside the next feature release), no i18n resync — no translatable string moved.

## What I tested

- `php tests/unit/test-cookie-policy-golden-render.php` → **ALL PASS, 65/65**, with the committed goldens untouched (`git status` clean under `tests/unit/fixtures/cookie-policy-golden/`). I never ran `--update`.
- `npm run test:unit` → **58 suites passed, 0 failed** (56 on `main`, +1 golden suite from the merged branch, +1 new suite here). Nothing turned red or was skipped.
- PHP syntax sweep across the plugin → clean, and no deprecation notices on PHP 8.4.
- New suite `tests/unit/test-legal-documents-registry.php` (43 checks): registry contents and memoisation; config integrity against the shipped constants; constructor rejection of malformed entries; `resolve_template_path()` equivalence across every jurisdiction × language (including the unbundled `sk` and the empty-code branch); `Template_Translations::apply()` equivalence; and `render()` === `render_for()` on the default, `lang`, `jurisdiction`, unknown-jurisdiction, `show_title` and POPIA-refusal paths.

Because `render()` delegates to `render_for()`, that equivalence check is nearly tautological on its own — it would stay green even if `render_for()` ignored its `$doc` entirely. So I added two cases that pass a config which *differs* from the shipped one and require the difference to show up: a changed `wrapper_class` must reach the `<article>` and change nothing else, and a changed `option` must select different saved settings. Those are what actually prove the parameter is threaded rather than decorative.

I did not run the Playwright E2E suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Il generatore di documenti legali ora supporta configurazioni dedicate per ciascun tipo di documento.
  * La gestione di giurisdizioni, lingue, modelli, traduzioni e contenuti obbligatori è più flessibile.
  * È stata predisposta la registrazione di documenti legali aggiuntivi, oltre alla Cookie Policy.

* **Documentazione**
  * Aggiunto un piano per l’evoluzione verso Privacy Policy, Termini e condizioni e Disclaimer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->