### PR TITLE
feat: opt-in footer legal links, consent-invariant and cache-safe

### DIFF
--- a/admin/assets/js/pages/settings.js
+++ b/admin/assets/js/pages/settings.js
@@ -229,37 +229,19 @@
 	 * [{ page_id, label }]. DOM order is the rendered order, which is what the
 	 * admin sees on screen.
 	 *
-	 * Entries whose page has no row on this screen are carried over untouched.
-	 * The view renders only published pages and only the first 200 of them, so a
-	 * stored page can legitimately have no checkbox — and an absent checkbox is
-	 * not the admin unticking it, it is the admin never having been shown it.
-	 * Inferring "unchecked" from "not rendered" would silently delete links on
-	 * save. Carrying them over also matches how the renderer treats publish
-	 * state: the stored list is the admin's intent, publish state is applied at
-	 * render time, so unpublishing hides a link and republishing brings it back.
-	 *
-	 * @param {Array} stored The currently stored link_items, used as the source
-	 *                       for entries that have no row on screen.
+	 * The PHP view guarantees a row for every stored selection, including a
+	 * deleted/unpublished page or one beyond the published-page query cap. An
+	 * unchecked row can therefore always mean an explicit removal.
 	 */
-	function serializeLegalLinks(stored) {
+	function serializeLegalLinks() {
 		var items = [];
 		var container = document.getElementById('faz-legal-links-pages');
 		if (!container) return items;
-		var rendered = {};
-		container.querySelectorAll('input.faz-legal-link-page').forEach(function (cb) {
-			rendered[String(cb.value || '')] = true;
-		});
 		container.querySelectorAll('input.faz-legal-link-page:checked').forEach(function (cb) {
 			var pageId = parseInt(cb.value, 10);
 			if (!pageId) return;
 			var labelInput = container.querySelector('input.faz-legal-link-label[data-page-id="' + cb.value + '"]');
 			items.push({ page_id: pageId, label: ((labelInput && labelInput.value) || '').trim() });
-		});
-		(Array.isArray(stored) ? stored : []).forEach(function (item) {
-			if (!item) return;
-			var pageId = parseInt(item.page_id, 10);
-			if (!pageId || rendered[String(pageId)]) return;
-			items.push({ page_id: pageId, label: typeof item.label === 'string' ? item.label : '' });
 		});
 		return items;
 	}
@@ -369,10 +351,7 @@
 				? current.legal_links.link_items
 				: [];
 			if (document.getElementById('faz-legal-links-pages')) {
-				// The stored list is passed in so entries whose page is not among the
-				// rendered rows (unpublished, or beyond the view's 200-page cap)
-				// survive the save instead of being read as "unticked".
-				formData.legal_links.link_items = serializeLegalLinks(storedLegalLinks);
+				formData.legal_links.link_items = serializeLegalLinks();
 			} else {
 				// The site has no published pages, so the view rendered no rows at
 				// all — serializing would report "nothing selected" and wipe a list

--- a/admin/assets/js/pages/settings.js
+++ b/admin/assets/js/pages/settings.js
@@ -228,16 +228,38 @@
 	 * Collect the checked footer legal links, in DOM order, as
 	 * [{ page_id, label }]. DOM order is the rendered order, which is what the
 	 * admin sees on screen.
+	 *
+	 * Entries whose page has no row on this screen are carried over untouched.
+	 * The view renders only published pages and only the first 200 of them, so a
+	 * stored page can legitimately have no checkbox — and an absent checkbox is
+	 * not the admin unticking it, it is the admin never having been shown it.
+	 * Inferring "unchecked" from "not rendered" would silently delete links on
+	 * save. Carrying them over also matches how the renderer treats publish
+	 * state: the stored list is the admin's intent, publish state is applied at
+	 * render time, so unpublishing hides a link and republishing brings it back.
+	 *
+	 * @param {Array} stored The currently stored link_items, used as the source
+	 *                       for entries that have no row on screen.
 	 */
-	function serializeLegalLinks() {
+	function serializeLegalLinks(stored) {
 		var items = [];
 		var container = document.getElementById('faz-legal-links-pages');
 		if (!container) return items;
+		var rendered = {};
+		container.querySelectorAll('input.faz-legal-link-page').forEach(function (cb) {
+			rendered[String(cb.value || '')] = true;
+		});
 		container.querySelectorAll('input.faz-legal-link-page:checked').forEach(function (cb) {
 			var pageId = parseInt(cb.value, 10);
 			if (!pageId) return;
 			var labelInput = container.querySelector('input.faz-legal-link-label[data-page-id="' + cb.value + '"]');
 			items.push({ page_id: pageId, label: ((labelInput && labelInput.value) || '').trim() });
+		});
+		(Array.isArray(stored) ? stored : []).forEach(function (item) {
+			if (!item) return;
+			var pageId = parseInt(item.page_id, 10);
+			if (!pageId || rendered[String(pageId)]) return;
+			items.push({ page_id: pageId, label: typeof item.label === 'string' ? item.label : '' });
 		});
 		return items;
 	}
@@ -343,15 +365,19 @@
 			// below is a per-group Object.assign, both keys must travel together
 			// or a partial group would replace only one of them.
 			formData.legal_links = formData.legal_links || {};
+			var storedLegalLinks = (current.legal_links && Array.isArray(current.legal_links.link_items))
+				? current.legal_links.link_items
+				: [];
 			if (document.getElementById('faz-legal-links-pages')) {
-				formData.legal_links.link_items = serializeLegalLinks();
+				// The stored list is passed in so entries whose page is not among the
+				// rendered rows (unpublished, or beyond the view's 200-page cap)
+				// survive the save instead of being read as "unticked".
+				formData.legal_links.link_items = serializeLegalLinks(storedLegalLinks);
 			} else {
 				// The site has no published pages, so the view rendered no rows at
 				// all — serializing would report "nothing selected" and wipe a list
 				// the admin configured while pages still existed.
-				formData.legal_links.link_items = (current.legal_links && Array.isArray(current.legal_links.link_items))
-					? current.legal_links.link_items
-					: [];
+				formData.legal_links.link_items = storedLegalLinks;
 			}
 
 			// Deep merge form data into current settings

--- a/admin/assets/js/pages/settings.js
+++ b/admin/assets/js/pages/settings.js
@@ -101,6 +101,7 @@
 			}
 			FAZ.populateForm(form, data);
 			populateTargetRegions(data);
+			hydrateLegalLinks(data.legal_links);
 			renderAbVariants(data);
 			applyShowIf();
 		}).catch(function () {
@@ -195,6 +196,52 @@
 		return slugs;
 	}
 
+	/**
+	 * Tick the footer legal-link rows that are already stored and fill in their
+	 * custom labels.
+	 *
+	 * The page rows are server-rendered by admin/views/settings.php, so unlike
+	 * the A/B-test variant list there is no async readiness to guard against:
+	 * by the time this runs the checkboxes are guaranteed to be in the DOM.
+	 *
+	 * @param {Object} group The legal_links settings group.
+	 */
+	function hydrateLegalLinks(group) {
+		var container = document.getElementById('faz-legal-links-pages');
+		if (!container) return;
+		var stored = (group && Array.isArray(group.link_items)) ? group.link_items : [];
+		var labels = {};
+		stored.forEach(function (item) {
+			if (!item) return;
+			labels[String(item.page_id)] = typeof item.label === 'string' ? item.label : '';
+		});
+		container.querySelectorAll('input.faz-legal-link-page').forEach(function (cb) {
+			var key = String(cb.value || '');
+			var isStored = Object.prototype.hasOwnProperty.call(labels, key);
+			cb.checked = isStored;
+			var labelInput = container.querySelector('input.faz-legal-link-label[data-page-id="' + key + '"]');
+			if (labelInput) labelInput.value = isStored ? labels[key] : '';
+		});
+	}
+
+	/**
+	 * Collect the checked footer legal links, in DOM order, as
+	 * [{ page_id, label }]. DOM order is the rendered order, which is what the
+	 * admin sees on screen.
+	 */
+	function serializeLegalLinks() {
+		var items = [];
+		var container = document.getElementById('faz-legal-links-pages');
+		if (!container) return items;
+		container.querySelectorAll('input.faz-legal-link-page:checked').forEach(function (cb) {
+			var pageId = parseInt(cb.value, 10);
+			if (!pageId) return;
+			var labelInput = container.querySelector('input.faz-legal-link-label[data-page-id="' + cb.value + '"]');
+			items.push({ page_id: pageId, label: ((labelInput && labelInput.value) || '').trim() });
+		});
+		return items;
+	}
+
 	/** Populate target region checkboxes from the stored array */
 	function populateTargetRegions(data) {
 		var regions = (data.geolocation && Array.isArray(data.geolocation.target_regions))
@@ -285,6 +332,25 @@
 				formData.banner_control.ab_test.variants = (current.banner_control && current.banner_control.ab_test
 					&& Array.isArray(current.banner_control.ab_test.variants))
 					? current.banner_control.ab_test.variants
+					: [];
+			}
+
+			// Footer legal links: the page rows carry no data-path (so the generic
+			// serializer skips them), but they ARE server-rendered, so no
+			// readiness guard is needed the way ab_test.variants needs one — the
+			// checkboxes exist as soon as the page does. The enabled flag comes
+			// through data-path, so formData already carries it; because the merge
+			// below is a per-group Object.assign, both keys must travel together
+			// or a partial group would replace only one of them.
+			formData.legal_links = formData.legal_links || {};
+			if (document.getElementById('faz-legal-links-pages')) {
+				formData.legal_links.link_items = serializeLegalLinks();
+			} else {
+				// The site has no published pages, so the view rendered no rows at
+				// all — serializing would report "nothing selected" and wipe a list
+				// the admin configured while pages still existed.
+				formData.legal_links.link_items = (current.legal_links && Array.isArray(current.legal_links.link_items))
+					? current.legal_links.link_items
 					: [];
 			}
 

--- a/admin/modules/settings/includes/class-settings.php
+++ b/admin/modules/settings/includes/class-settings.php
@@ -149,6 +149,19 @@ class Settings extends Store {
 			'site_links'   => array(
 				'sites' => array(),
 			),
+			// Optional legal-links <nav> printed on wp_footer (Cookie Policy,
+			// Privacy Policy, Imprint, …). Default OFF so no existing install
+			// suddenly grows a footer element it never asked for. The rendered
+			// markup depends ONLY on this option plus each page's publish
+			// state — never on consent, login or geo — so it stays a single
+			// cached variant under Cache Compatibility Mode.
+			'legal_links'  => array(
+				'enabled'    => false,
+				// List of array( 'page_id' => int, 'label' => string ).
+				// An empty label means "use the page title", so a renamed page
+				// keeps the footer link in sync without an admin save.
+				'link_items' => array(),
+			),
 			'iab'          => array(
 				'enabled'               => false,
 				'publisher_cc'          => '',
@@ -297,6 +310,16 @@ class Settings extends Store {
 			// sanitize_option() instead of recursing into it against an empty
 			// default array (which would wipe every entry).
 			'variants',
+			// Footer legal links (legal_links.link_items): a list of
+			// array( page_id, label ) structs. Same reason as 'variants' above —
+			// without this entry the recursive sanitiser would walk each stored
+			// row against the EMPTY default array and drop every one of them on
+			// the next save of any setting. Deliberately named 'link_items'
+			// rather than a generic 'items'/'pages': get_excludes() and
+			// sanitize_option() match by bare key name across the WHOLE settings
+			// tree, so a generic name would hijack any future group that happens
+			// to use it.
+			'link_items',
 		);
 	}
 
@@ -517,6 +540,51 @@ class Settings extends Store {
 				}, $value ), function ( $item ) {
 					return '' !== $item;
 				} ) ) );
+				break;
+			case 'link_items':
+				// Footer legal links: a list of array( page_id, label ). Only the
+				// two known keys survive, page IDs are deduplicated (the same page
+				// twice would print the same link twice) and the whole list is
+				// capped at 20 rows — a footer nav is a handful of legal pages, and
+				// the cap keeps a crafted settings PUT from bloating every cached
+				// page on the site. A blank label is legitimate: the renderer falls
+				// back to the live page title.
+				if ( ! is_array( $value ) ) {
+					$value = array();
+					break;
+				}
+				$clean = array();
+				$seen  = array();
+				foreach ( $value as $item ) {
+					if ( count( $clean ) >= 20 ) {
+						break;
+					}
+					if ( ! is_array( $item ) ) {
+						continue;
+					}
+					// Deliberately (int) and not absint(): absint(-5) is 5, so a
+					// negative ID would silently become a link to a DIFFERENT,
+					// real page. A malformed ID must drop out, not be rounded
+					// into a valid one.
+					$page_id = (int) ( isset( $item['page_id'] ) ? $item['page_id'] : 0 );
+					if ( $page_id < 1 || isset( $seen[ $page_id ] ) ) {
+						continue;
+					}
+					$seen[ $page_id ] = true;
+					$label            = sanitize_text_field( (string) ( isset( $item['label'] ) ? $item['label'] : '' ) );
+					// mb_substr keeps a multibyte label from being cut mid-character;
+					// mbstring is not guaranteed on every host, hence the fallback.
+					if ( function_exists( 'mb_substr' ) ) {
+						$label = mb_substr( $label, 0, 120 );
+					} else {
+						$label = substr( $label, 0, 120 );
+					}
+					$clean[] = array(
+						'page_id' => $page_id,
+						'label'   => $label,
+					);
+				}
+				$value = $clean;
 				break;
 			case 'payment_gateways':
 				// Map of gateway-key => bool. Only known catalogue keys survive,

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -467,6 +467,49 @@ defined( 'ABSPATH' ) || exit;
 
 	<div class="faz-card">
 		<div class="faz-card-header">
+			<h3><?php esc_html_e( 'Footer legal links', 'faz-cookie-manager' ); ?></h3>
+		</div>
+		<div class="faz-card-body">
+			<div class="faz-form-group">
+				<label class="faz-toggle">
+					<input type="checkbox" data-path="legal_links.enabled">
+					<span class="faz-toggle-track"></span>
+					<span class="faz-toggle-label"><?php esc_html_e( 'Show legal links in the footer', 'faz-cookie-manager' ); ?></span>
+				</label>
+				<div class="faz-help"><?php esc_html_e( 'Off by default. When enabled, the pages you select below are printed as a small navigation block in your theme footer (via wp_footer). The markup is identical for every visitor — it does not depend on consent, login state or country — so it stays safe to serve from a page cache.', 'faz-cookie-manager' ); ?></div>
+			</div>
+			<div class="faz-form-group">
+				<label><?php esc_html_e( 'Pages to link', 'faz-cookie-manager' ); ?></label>
+				<?php
+				// Server-rendered on purpose: the list is static for the request,
+				// so saveSettings() never has to guard against an async list that
+				// has not loaded yet (unlike the A/B-test variant checkboxes).
+				// NOTE: these inputs deliberately carry NO data-path — FAZ.serializeForm
+				// must skip them; settings.js collects them through its own serializer.
+				$faz_legal_pages = get_pages( array( 'post_status' => 'publish' ) );
+				?>
+				<?php if ( empty( $faz_legal_pages ) ) : ?>
+					<div class="faz-help"><?php esc_html_e( 'No published pages yet. Publish your Cookie Policy or Privacy Policy page first.', 'faz-cookie-manager' ); ?></div>
+				<?php else : ?>
+					<div id="faz-legal-links-pages" style="max-height:260px;overflow:auto;padding:8px;border-radius:6px;background:var(--faz-bg-secondary);">
+						<?php foreach ( $faz_legal_pages as $faz_legal_page ) : ?>
+							<div style="display:flex;align-items:center;gap:10px;margin-bottom:6px;">
+								<label class="faz-checkbox" style="flex:1;min-width:0;">
+									<input type="checkbox" class="faz-legal-link-page" value="<?php echo esc_attr( $faz_legal_page->ID ); ?>">
+									<span style="margin-left:6px;"><?php echo esc_html( $faz_legal_page->post_title ); ?></span>
+								</label>
+								<input type="text" class="faz-input faz-input-sm faz-legal-link-label" data-page-id="<?php echo esc_attr( $faz_legal_page->ID ); ?>" placeholder="<?php esc_attr_e( 'Custom label (optional)', 'faz-cookie-manager' ); ?>" style="max-width:220px;">
+							</div>
+						<?php endforeach; ?>
+					</div>
+					<div class="faz-help"><?php esc_html_e( 'Links appear in the order the pages are listed here. Leave the label empty to use the page title, so renaming the page keeps the footer link in sync. Unpublishing a page removes its link immediately, with no need to save again.', 'faz-cookie-manager' ); ?></div>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+
+	<div class="faz-card">
+		<div class="faz-card-header">
 			<h3><?php esc_html_e( 'Force re-consent', 'faz-cookie-manager' ); ?></h3>
 		</div>
 		<div class="faz-card-body">

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -493,32 +493,76 @@ defined( 'ABSPATH' ) || exit;
 				// a legal-links footer needs (the stored list is capped at 20) while
 				// still covering ordinary sites in full.
 				//
-				// The cap means a stored page can fall outside the rendered rows on a
-				// very large site. serializeLegalLinks() in settings.js therefore keeps
-				// any stored entry that has no row here, so saving this screen can
-				// never silently drop a link the admin was never shown.
+				// Stored selections are rendered FIRST even when they are unpublished,
+				// deleted, or outside this query's first 200 rows. Every persisted link
+				// therefore has a visible checkbox the operator can remove.
+				$faz_stored_settings = get_option( 'faz_settings', array() );
+				$faz_stored_items    = isset( $faz_stored_settings['legal_links']['link_items'] ) && is_array( $faz_stored_settings['legal_links']['link_items'] )
+					? $faz_stored_settings['legal_links']['link_items']
+					: array();
 				$faz_legal_pages = get_pages(
 					array(
 						'post_status' => 'publish',
 						'number'      => 200,
 					)
 				);
+				$faz_legal_rows = array();
+				$faz_selected_ids = array();
+				foreach ( $faz_stored_items as $faz_stored_item ) {
+					$faz_page_id = isset( $faz_stored_item['page_id'] ) ? absint( $faz_stored_item['page_id'] ) : 0;
+					if ( ! $faz_page_id || isset( $faz_selected_ids[ $faz_page_id ] ) ) {
+						continue;
+					}
+					$faz_selected_ids[ $faz_page_id ] = true;
+					$faz_post = get_post( $faz_page_id );
+					if ( ! $faz_post || 'page' !== $faz_post->post_type ) {
+						$faz_title = sprintf( __( 'Page #%d (unavailable)', 'faz-cookie-manager' ), $faz_page_id );
+					} else {
+						$faz_title = '' !== trim( (string) $faz_post->post_title )
+							? $faz_post->post_title
+							: sprintf( __( 'Page #%d (untitled)', 'faz-cookie-manager' ), $faz_page_id );
+						if ( 'publish' !== $faz_post->post_status ) {
+							$faz_status = get_post_status_object( $faz_post->post_status );
+							$faz_title .= sprintf(
+								' (%s)',
+								$faz_status && isset( $faz_status->label ) ? $faz_status->label : $faz_post->post_status
+							);
+						}
+					}
+					$faz_legal_rows[] = array(
+						'id'       => $faz_page_id,
+						'title'    => $faz_title,
+						'label'    => isset( $faz_stored_item['label'] ) ? (string) $faz_stored_item['label'] : '',
+						'selected' => true,
+					);
+				}
+				foreach ( $faz_legal_pages as $faz_legal_page ) {
+					if ( isset( $faz_selected_ids[ $faz_legal_page->ID ] ) ) {
+						continue;
+					}
+					$faz_legal_rows[] = array(
+						'id'       => $faz_legal_page->ID,
+						'title'    => $faz_legal_page->post_title,
+						'label'    => '',
+						'selected' => false,
+					);
+				}
 				?>
-				<?php if ( empty( $faz_legal_pages ) ) : ?>
+				<?php if ( empty( $faz_legal_rows ) ) : ?>
 					<div class="faz-help"><?php esc_html_e( 'No published pages yet. Publish your Cookie Policy or Privacy Policy page first.', 'faz-cookie-manager' ); ?></div>
 				<?php else : ?>
 					<div id="faz-legal-links-pages" style="max-height:260px;overflow:auto;padding:8px;border-radius:6px;background:var(--faz-bg-secondary);">
-						<?php foreach ( $faz_legal_pages as $faz_legal_page ) : ?>
+						<?php foreach ( $faz_legal_rows as $faz_legal_row ) : ?>
 							<div style="display:flex;align-items:center;gap:10px;margin-bottom:6px;">
 								<label class="faz-checkbox" style="flex:1;min-width:0;">
-									<input type="checkbox" class="faz-legal-link-page" value="<?php echo esc_attr( $faz_legal_page->ID ); ?>">
-									<span style="margin-left:6px;"><?php echo esc_html( $faz_legal_page->post_title ); ?></span>
+									<input type="checkbox" class="faz-legal-link-page" value="<?php echo esc_attr( $faz_legal_row['id'] ); ?>" <?php checked( $faz_legal_row['selected'] ); ?>>
+									<span style="margin-left:6px;"><?php echo esc_html( $faz_legal_row['title'] ); ?></span>
 								</label>
-								<input type="text" class="faz-input faz-input-sm faz-legal-link-label" data-page-id="<?php echo esc_attr( $faz_legal_page->ID ); ?>" placeholder="<?php esc_attr_e( 'Custom label (optional)', 'faz-cookie-manager' ); ?>" style="max-width:220px;">
+								<input type="text" class="faz-input faz-input-sm faz-legal-link-label" data-page-id="<?php echo esc_attr( $faz_legal_row['id'] ); ?>" value="<?php echo esc_attr( $faz_legal_row['label'] ); ?>" placeholder="<?php esc_attr_e( 'Custom label (optional)', 'faz-cookie-manager' ); ?>" style="max-width:220px;">
 							</div>
 						<?php endforeach; ?>
 					</div>
-					<div class="faz-help"><?php esc_html_e( 'Links appear in the order the pages are listed here. Leave the label empty to use the page title, so renaming the page keeps the footer link in sync. Unpublishing a page removes its link immediately, with no need to save again.', 'faz-cookie-manager' ); ?></div>
+					<div class="faz-help"><?php esc_html_e( 'Selected links appear first in their saved order. Leave the label empty to use the page title. Unpublished or unavailable selections stay visible here so you can remove them; they are never printed in the footer.', 'faz-cookie-manager' ); ?></div>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -486,7 +486,23 @@ defined( 'ABSPATH' ) || exit;
 				// has not loaded yet (unlike the A/B-test variant checkboxes).
 				// NOTE: these inputs deliberately carry NO data-path — FAZ.serializeForm
 				// must skip them; settings.js collects them through its own serializer.
-				$faz_legal_pages = get_pages( array( 'post_status' => 'publish' ) );
+				//
+				// 'number' bounds both the query and the DOM: without it a site with
+				// thousands of published pages pays for an unbounded query and then
+				// renders two inputs per page into this screen. 200 is far above what
+				// a legal-links footer needs (the stored list is capped at 20) while
+				// still covering ordinary sites in full.
+				//
+				// The cap means a stored page can fall outside the rendered rows on a
+				// very large site. serializeLegalLinks() in settings.js therefore keeps
+				// any stored entry that has no row here, so saving this screen can
+				// never silently drop a link the admin was never shown.
+				$faz_legal_pages = get_pages(
+					array(
+						'post_status' => 'publish',
+						'number'      => 200,
+					)
+				);
 				?>
 				<?php if ( empty( $faz_legal_pages ) ) : ?>
 					<div class="faz-help"><?php esc_html_e( 'No published pages yet. Publish your Cookie Policy or Privacy Policy page first.', 'faz-cookie-manager' ); ?></div>

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -136,6 +136,10 @@ class Frontend {
 		new Cookie_Policy_Shortcode();
 		new Do_Not_Sell_Shortcode();
 		new Cookie_Settings_Shortcode();
+		// Opt-in footer legal-links nav. Self-gating: it renders nothing at all
+		// unless legal_links.enabled is on and at least one published page is
+		// selected, so instantiating it unconditionally costs one option read.
+		new \FazCookie\Frontend\Modules\Legal_Links\Legal_Links();
 		new AMP_Consent();
 		new Translation_Compat();
 		add_action( 'init', array( $this, 'load_banner' ) );

--- a/frontend/css/faz-legal-links.css
+++ b/frontend/css/faz-legal-links.css
@@ -1,0 +1,25 @@
+/*!
+ * FAZ Cookie Manager — footer legal links.
+ *
+ * Deliberately colourless: the nav is printed inside the host theme's footer,
+ * so link colour, font family and background must keep inheriting from the
+ * theme. No !important anywhere — a theme that wants to restyle this nav
+ * should win without a specificity fight.
+ */
+.faz-legal-links {
+	margin: 1em 0;
+	font-size: .85em;
+}
+
+.faz-legal-links-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: .5em 1.25em;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.faz-legal-links-item a {
+	text-decoration: underline;
+}

--- a/frontend/modules/legal-links/class-legal-links.php
+++ b/frontend/modules/legal-links/class-legal-links.php
@@ -37,6 +37,21 @@ class Legal_Links {
 	const MAX_LINKS = 20;
 
 	/**
+	 * Memoised build_html() output for the current request.
+	 *
+	 * Shared by maybe_enqueue_styles() (wp_enqueue_scripts) and render()
+	 * (wp_footer) so both agree on whether anything will actually be printed,
+	 * and so the page/permalink lookups happen once per request rather than
+	 * twice. Null means "not built yet"; '' is a real, cached "renders nothing".
+	 *
+	 * Only ever holds the result of the live-settings build. build_html() with
+	 * an injected $config (the unit tests) deliberately bypasses this.
+	 *
+	 * @var string|null
+	 */
+	private $html = null;
+
+	/**
 	 * Constructor. Wires the footer output and the stylesheet.
 	 */
 	public function __construct() {
@@ -59,7 +74,19 @@ class Legal_Links {
 		// build_html() escapes every interpolated value at the point of
 		// concatenation (esc_url / esc_html / esc_attr__), and the surrounding
 		// markup is a literal — nothing here is unescaped.
-		echo $this->build_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->get_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * build_html() against the live settings, built at most once per request.
+	 *
+	 * @return string
+	 */
+	private function get_html(): string {
+		if ( null === $this->html ) {
+			$this->html = $this->build_html();
+		}
+		return $this->html;
 	}
 
 	/**
@@ -146,9 +173,16 @@ class Legal_Links {
 	/**
 	 * Enqueue the (tiny) stylesheet, but only when the feature is actually on.
 	 *
-	 * Mirrors Cookie_Policy_Generator::maybe_enqueue_frontend_assets(). The
-	 * enabled/empty check reads the same option the renderer does, so a site
-	 * that never turned the feature on ships zero extra bytes.
+	 * Mirrors Cookie_Policy_Generator::maybe_enqueue_frontend_assets(), but
+	 * gates on the ACTUAL rendered output rather than on enabled/link_items:
+	 * a list whose every page has since been deleted, unpublished or left
+	 * unlabelled is still "enabled and non-empty" while rendering nothing, and
+	 * would otherwise ship a stylesheet for markup that never appears.
+	 *
+	 * Building here rather than at wp_footer costs nothing extra — the result is
+	 * memoised and render() reuses it, so the page lookups happen once either
+	 * way — and a site that never turned the feature on still short-circuits on
+	 * the enabled flag before touching a single page.
 	 *
 	 * @return void
 	 */
@@ -156,8 +190,7 @@ class Legal_Links {
 		if ( is_admin() ) {
 			return;
 		}
-		$config = Settings::get_instance()->get( 'legal_links' );
-		if ( empty( $config['enabled'] ) || empty( $config['link_items'] ) ) {
+		if ( '' === $this->get_html() ) {
 			return;
 		}
 		wp_enqueue_style(

--- a/frontend/modules/legal-links/class-legal-links.php
+++ b/frontend/modules/legal-links/class-legal-links.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Footer legal links.
+ *
+ * Renders an optional, opt-in <nav> of legal pages (Cookie Policy, Privacy
+ * Policy, Imprint, Terms, …) on `wp_footer`. Off by default.
+ *
+ * @package FazCookie\Frontend\Modules\Legal_Links
+ * @since   1.26.0
+ */
+
+namespace FazCookie\Frontend\Modules\Legal_Links;
+
+use FazCookie\Admin\Modules\Settings\Includes\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Prints the footer legal-links navigation.
+ *
+ * @class   Legal_Links
+ * @since   1.26.0
+ * @package FazCookie\Frontend\Modules\Legal_Links
+ */
+class Legal_Links {
+
+	/**
+	 * Maximum links rendered. Mirrors the cap enforced by
+	 * Settings::sanitize_option( 'link_items' ) — kept here as a second, purely
+	 * defensive bound so a settings row written before the cap existed (or by a
+	 * direct DB edit) can never print an unbounded list into every cached page.
+	 *
+	 * @var int
+	 */
+	const MAX_LINKS = 20;
+
+	/**
+	 * Constructor. Wires the footer output and the stylesheet.
+	 */
+	public function __construct() {
+		// Priority 20 puts the nav AFTER Frontend::banner_html(), which runs at
+		// the default 10 — several E2E selectors and the banner's own DOM
+		// assumptions depend on the consent container's position in the footer.
+		add_action( 'wp_footer', array( $this, 'render' ), 20 );
+		// The stylesheet MUST be enqueued from wp_enqueue_scripts: by the time
+		// render() runs on wp_footer, wp_head has long been printed and a late
+		// wp_enqueue_style() would either be dropped or emit a <link> in <body>.
+		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_enqueue_styles' ) );
+	}
+
+	/**
+	 * `wp_footer` callback.
+	 *
+	 * @return void
+	 */
+	public function render() {
+		// build_html() escapes every interpolated value at the point of
+		// concatenation (esc_url / esc_html / esc_attr__), and the surrounding
+		// markup is a literal — nothing here is unescaped.
+		echo $this->build_html(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Build the legal-links markup.
+	 *
+	 * HARD RULE — this method must read NOTHING request-dependent: no $_COOKIE,
+	 * no consent store, no geo lookup, no is_user_logged_in() branch. The output
+	 * is a pure function of the stored option plus each referenced page's
+	 * publish state, which is exactly what keeps Cache Compatibility Mode's
+	 * "one cached variant per URL" promise intact. That mode only shipped in
+	 * 1.21.0 once every render path had been made invariant; this must not
+	 * become the first exception.
+	 *
+	 * Skipping unpublished pages at RENDER time (rather than pruning the stored
+	 * list on save) means unpublishing a page removes its link immediately,
+	 * without the admin having to revisit the Settings screen.
+	 *
+	 * @param array|null $config Optional settings group, injected by the unit
+	 *                           tests so the Settings/Store stack is not needed.
+	 *                           Null reads the live settings.
+	 * @return string HTML, or '' when nothing should be rendered.
+	 */
+	public function build_html( $config = null ): string {
+		if ( ! is_array( $config ) ) {
+			$config = Settings::get_instance()->get( 'legal_links' );
+		}
+		if ( empty( $config['enabled'] ) ) {
+			return '';
+		}
+		if ( empty( $config['link_items'] ) || ! is_array( $config['link_items'] ) ) {
+			return '';
+		}
+
+		$items = array();
+		foreach ( $config['link_items'] as $item ) {
+			if ( count( $items ) >= self::MAX_LINKS ) {
+				break;
+			}
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			// (int), not absint(), for the same reason as the sanitiser: absint(-5)
+			// is 5, and a malformed ID must not resolve to a different real page.
+			$page_id = (int) ( isset( $item['page_id'] ) ? $item['page_id'] : 0 );
+			if ( $page_id < 1 ) {
+				continue;
+			}
+			$post = get_post( $page_id );
+			if ( ! $post || 'publish' !== get_post_status( $post ) ) {
+				continue;
+			}
+			$url = get_permalink( $post );
+			if ( empty( $url ) ) {
+				continue;
+			}
+			$label = trim( (string) ( isset( $item['label'] ) ? $item['label'] : '' ) );
+			if ( '' === $label ) {
+				// get_the_title() rather than $post->post_title so a translation
+				// plugin can localise the label. That varies per URL (WPML /
+				// Polylang serve each language on its own URL), never per visitor,
+				// so the one-variant-per-URL guarantee still holds.
+				$label = trim( (string) get_the_title( $post ) );
+			}
+			// A published page with no title and no custom label would render an
+			// empty, unlabelled link — worse than no link at all for a screen
+			// reader, so it is dropped.
+			if ( '' === $label ) {
+				continue;
+			}
+			$items[] = '<li class="faz-legal-links-item"><a href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a></li>';
+		}
+
+		// Every configured page was unpublished, deleted or unlabelled: emit
+		// nothing rather than an empty <nav>, which would be a landmark with no
+		// content for assistive technology.
+		if ( empty( $items ) ) {
+			return '';
+		}
+
+		return '<nav class="faz-legal-links" aria-label="' . esc_attr__( 'Legal information', 'faz-cookie-manager' ) . '">'
+			. '<ul class="faz-legal-links-list">' . implode( '', $items ) . '</ul></nav>';
+	}
+
+	/**
+	 * Enqueue the (tiny) stylesheet, but only when the feature is actually on.
+	 *
+	 * Mirrors Cookie_Policy_Generator::maybe_enqueue_frontend_assets(). The
+	 * enabled/empty check reads the same option the renderer does, so a site
+	 * that never turned the feature on ships zero extra bytes.
+	 *
+	 * @return void
+	 */
+	public function maybe_enqueue_styles() {
+		if ( is_admin() ) {
+			return;
+		}
+		$config = Settings::get_instance()->get( 'legal_links' );
+		if ( empty( $config['enabled'] ) || empty( $config['link_items'] ) ) {
+			return;
+		}
+		wp_enqueue_style(
+			'faz-legal-links',
+			plugins_url( 'frontend/css/faz-legal-links.css', FAZ_PLUGIN_FILENAME ),
+			array(),
+			defined( 'FAZ_VERSION' ) ? FAZ_VERSION : '1.0.0'
+		);
+	}
+}

--- a/frontend/modules/legal-links/index.php
+++ b/frontend/modules/legal-links/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/tests/e2e/specs/legal-footer-links.spec.ts
+++ b/tests/e2e/specs/legal-footer-links.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '../fixtures/wp-fixture';
+import type { Page } from '@playwright/test';
+import { clickFirstVisible } from '../utils/ui';
+import { upsertPage, wp } from '../utils/wp-env';
+
+/**
+ * Footer legal links — opt-in, consent-invariant, cache-safe.
+ *
+ * The feature prints a small <nav class="faz-legal-links"> on wp_footer listing
+ * the published pages the admin selected in Settings. The contract this suite
+ * defends:
+ *
+ *   1. OFF by default / when disabled → the nav is absent entirely.
+ *   2. ON with a selected page → the nav renders with that page's link, using
+ *      the custom label when one is stored.
+ *   3. The markup is BYTE-IDENTICAL before and after the visitor consents.
+ *      That is the whole reason the renderer is forbidden from reading
+ *      $_COOKIE / consent state / geo: Cache Compatibility Mode promises one
+ *      cached variant per URL, and a footer that varied by consent would be the
+ *      first exception to it.
+ *
+ * Serial, and afterAll restores whatever legal_links value the site had.
+ */
+
+const BASE = process.env.WP_BASE_URL ?? 'http://127.0.0.1:9998';
+const FIXTURE_SLUG = 'faz-legal-links-fixture';
+
+type FazSettings = Record<string, unknown>;
+
+async function getAdminNonce(page: Page): Promise<string> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return page.evaluate(() => (window as any).fazConfig?.api?.nonce ?? '');
+}
+
+async function getSettings(page: Page, nonce: string): Promise<FazSettings> {
+  const res = await page.request.get('/?rest_route=/faz/v1/settings/', { headers: { 'X-WP-Nonce': nonce } });
+  expect(res.status()).toBe(200);
+  return (await res.json()) as FazSettings;
+}
+
+async function postSettings(page: Page, nonce: string, payload: FazSettings): Promise<void> {
+  const res = await page.request.post('/?rest_route=/faz/v1/settings/', {
+    headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
+    data: payload,
+  });
+  expect(res.status(), `settings update status ${res.status()}`).toBe(200);
+}
+
+test.describe('Footer legal links', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let admin: Page;
+  let nonce = '';
+  let originalLegalLinks: Record<string, unknown> = {};
+  let fixtureId = 0;
+
+  test.beforeAll(async ({ browser, loginAsAdmin }) => {
+    fixtureId = upsertPage(FIXTURE_SLUG, 'FAZ Legal Links Fixture', '<p>Legal links fixture page.</p>');
+    expect(fixtureId).toBeGreaterThan(0);
+
+    admin = await browser.newPage();
+    await loginAsAdmin(admin);
+    await admin.goto('/wp-admin/admin.php?page=faz-cookie-manager-settings', { waitUntil: 'domcontentloaded' });
+    nonce = await getAdminNonce(admin);
+    expect(nonce.length).toBeGreaterThan(0);
+
+    const current = await getSettings(admin, nonce);
+    originalLegalLinks = { ...(current.legal_links as Record<string, unknown> | undefined) };
+  });
+
+  test.afterAll(async () => {
+    if (nonce) {
+      await postSettings(admin, nonce, { legal_links: originalLegalLinks });
+    }
+    if (fixtureId) {
+      try {
+        wp(['post', 'delete', String(fixtureId), '--force']);
+      } catch {
+        // Best effort — a leftover fixture page harms nothing.
+      }
+    }
+    await admin?.close();
+  });
+
+  test('renders the nav when enabled, and its HTML does not change with consent', async ({ browser }) => {
+    await postSettings(admin, nonce, {
+      legal_links: { enabled: true, link_items: [{ page_id: fixtureId, label: 'Privacy stuff' }] },
+    });
+
+    const context = await browser.newContext();
+    try {
+      await context.clearCookies();
+      const page = await context.newPage();
+      await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
+
+      const nav = page.locator('nav.faz-legal-links');
+      await expect(nav).toHaveCount(1);
+      const link = nav.locator('a', { hasText: 'Privacy stuff' });
+      await expect(link).toHaveCount(1);
+      await expect(link).toHaveAttribute('href', new RegExp(FIXTURE_SLUG));
+
+      // Snapshot the markup BEFORE any consent decision exists.
+      const before = await nav.evaluate((el) => el.outerHTML);
+
+      const accepted = await clickFirstVisible(page, [
+        '[data-faz-tag="accept-button"] button',
+        '[data-faz-tag="accept-button"]',
+        '.faz-btn-accept',
+      ]);
+      expect(accepted, 'accept button not found — cannot verify consent invariance').toBeTruthy();
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await expect(nav).toHaveCount(1);
+      const after = await nav.evaluate((el) => el.outerHTML);
+
+      expect(after, 'footer legal links must be byte-identical before and after consent').toBe(before);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('renders nothing when the toggle is off', async ({ browser }) => {
+    await postSettings(admin, nonce, {
+      legal_links: { enabled: false, link_items: [{ page_id: fixtureId, label: 'Privacy stuff' }] },
+    });
+
+    const context = await browser.newContext();
+    try {
+      await context.clearCookies();
+      const page = await context.newPage();
+      await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('nav.faz-legal-links')).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('renders nothing when enabled with no pages selected (no empty nav)', async ({ browser }) => {
+    await postSettings(admin, nonce, { legal_links: { enabled: true, link_items: [] } });
+
+    const context = await browser.newContext();
+    try {
+      await context.clearCookies();
+      const page = await context.newPage();
+      await page.goto(BASE + '/', { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('nav.faz-legal-links')).toHaveCount(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/tests/e2e/specs/legal-footer-links.spec.ts
+++ b/tests/e2e/specs/legal-footer-links.spec.ts
@@ -148,4 +148,27 @@ test.describe('Footer legal links', () => {
       await context.close();
     }
   });
+
+  test('an unpublished stored page remains visible and can be removed', async () => {
+    wp(['post', 'update', String(fixtureId), '--post_status=draft']);
+    await postSettings(admin, nonce, {
+      legal_links: { enabled: true, link_items: [{ page_id: fixtureId, label: 'Old legal page' }] },
+    });
+
+    await admin.goto('/wp-admin/admin.php?page=faz-cookie-manager-settings', { waitUntil: 'domcontentloaded' });
+    const row = admin.locator(`input.faz-legal-link-page[value="${fixtureId}"]`);
+    await expect(row).toBeVisible();
+    await expect(row).toBeChecked();
+    await row.uncheck();
+
+    const saved = admin.waitForResponse((response) =>
+      response.url().includes('faz/v1/settings') && response.request().method() === 'POST',
+    );
+    await admin.locator('#faz-settings-save').click();
+    expect((await saved).status()).toBe(200);
+
+    const current = await getSettings(admin, nonce);
+    const group = current.legal_links as { link_items?: Array<{ page_id: number }> } | undefined;
+    expect(group?.link_items ?? []).not.toContainEqual(expect.objectContaining({ page_id: fixtureId }));
+  });
 });

--- a/tests/unit/test-flyingpress-frontend-bootstrap-php.php
+++ b/tests/unit/test-flyingpress-frontend-bootstrap-php.php
@@ -28,6 +28,10 @@ namespace FazCookie\Frontend\Modules\Banner_Rest {
 	class Banner_Rest {}
 }
 
+namespace FazCookie\Frontend\Modules\Legal_Links {
+	class Legal_Links {}
+}
+
 namespace FazCookie\Includes {
 	class Geolocation {}
 	class Gvl {}

--- a/tests/unit/test-legal-links-php.php
+++ b/tests/unit/test-legal-links-php.php
@@ -112,9 +112,16 @@ namespace {
 			return 'https://example.test';
 		}
 	}
+	// Backed by a global so a test can seed a stored faz_settings payload and
+	// exercise the code paths that read the LIVE settings (the enqueue gate)
+	// rather than an injected config. Settings::clear_cache() must be called
+	// after every reseed — Settings::get() memoises in a static.
+	$GLOBALS['faz_test_options'] = array();
 	if ( ! function_exists( 'get_option' ) ) {
 		function get_option( $name, $default = false ) {
-			return $default;
+			return array_key_exists( $name, $GLOBALS['faz_test_options'] )
+				? $GLOBALS['faz_test_options'][ $name ]
+				: $default;
 		}
 	}
 	if ( ! function_exists( 'update_option' ) ) {
@@ -173,6 +180,32 @@ namespace {
 		function get_the_title( $post = null ) {
 			return ( is_object( $post ) && isset( $post->post_title ) ) ? $post->post_title : '';
 		}
+	}
+
+	// ---------- Enqueue stubs, recording instead of enqueuing ----------
+
+	$GLOBALS['faz_test_enqueued'] = array();
+	if ( ! function_exists( 'is_admin' ) ) {
+		function is_admin() {
+			return ! empty( $GLOBALS['faz_test_is_admin'] );
+		}
+	}
+	if ( ! function_exists( 'plugins_url' ) ) {
+		function plugins_url( $path = '', $plugin = '' ) {
+			return 'https://example.test/wp-content/plugins/faz-cookie-manager/' . ltrim( (string) $path, '/' );
+		}
+	}
+	if ( ! function_exists( 'wp_enqueue_style' ) ) {
+		function wp_enqueue_style( $handle, $src = '', $deps = array(), $ver = false, $media = 'all' ) {
+			$GLOBALS['faz_test_enqueued'][] = $handle;
+			return true;
+		}
+	}
+	if ( ! defined( 'FAZ_PLUGIN_FILENAME' ) ) {
+		define( 'FAZ_PLUGIN_FILENAME', __DIR__ . '/../../faz-cookie-manager.php' );
+	}
+	if ( ! defined( 'FAZ_VERSION' ) ) {
+		define( 'FAZ_VERSION', '1.26.0' );
 	}
 
 	require_once __DIR__ . '/../../includes/class-store.php';
@@ -372,6 +405,89 @@ namespace {
 	$absent = Settings::sanitize( array(), $defaults );
 	faz_assert_same( $absent['legal_links']['enabled'], false, 'legal_links defaults to OFF when absent from the payload' );
 	faz_assert_same( $absent['legal_links']['link_items'], array(), 'link_items defaults to an empty list when absent' );
+
+	// ---------- The stylesheet follows the OUTPUT, not the option ----------
+	//
+	// enabled + a non-empty link_items is NOT sufficient: every configured page
+	// may since have been unpublished or deleted, in which case build_html()
+	// returns '' and a stylesheet for markup that never appears would be pure
+	// dead weight on every page of the site.
+
+	echo "\n== Footer legal links: stylesheet gating ==\n\n";
+
+	/**
+	 * Seed the stored settings, reset the caches and run maybe_enqueue_styles().
+	 *
+	 * @param array $legal_links The legal_links group to store.
+	 * @return array Handles enqueued during the call.
+	 */
+	function faz_test_enqueue_with( $legal_links ) {
+		$GLOBALS['faz_test_options']['faz_settings'] = array( 'legal_links' => $legal_links );
+		Settings::clear_cache();
+		$GLOBALS['faz_test_enqueued'] = array();
+		// A fresh instance each time: the memo is per-request by design.
+		$instance = new Legal_Links();
+		$instance->maybe_enqueue_styles();
+		return $GLOBALS['faz_test_enqueued'];
+	}
+
+	faz_assert_same(
+		faz_test_enqueue_with( array( 'enabled' => false, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) ) ),
+		array(),
+		'feature OFF enqueues no stylesheet'
+	);
+
+	faz_assert_same(
+		faz_test_enqueue_with( array( 'enabled' => true, 'link_items' => array() ) ),
+		array(),
+		'enabled with an empty list enqueues no stylesheet'
+	);
+
+	faz_assert_same(
+		faz_test_enqueue_with(
+			array(
+				'enabled'    => true,
+				'link_items' => array(
+					array( 'page_id' => 12, 'label' => '' ),
+					array( 'page_id' => 99, 'label' => '' ),
+				),
+			)
+		),
+		array(),
+		'enabled but every page unpublished or deleted: no stylesheet for markup that never renders'
+	);
+
+	faz_assert_same(
+		faz_test_enqueue_with( array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) ) ),
+		array( 'faz-legal-links' ),
+		'a page that really renders does enqueue the stylesheet'
+	);
+
+	$GLOBALS['faz_test_is_admin'] = true;
+	faz_assert_same(
+		faz_test_enqueue_with( array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) ) ),
+		array(),
+		'admin requests never enqueue the frontend stylesheet'
+	);
+	$GLOBALS['faz_test_is_admin'] = false;
+
+	// The memo must not change what gets printed: render() after an enqueue pass
+	// has to emit exactly what a fresh build produces, or the cached value would
+	// be a source of drift between the two hooks.
+	$GLOBALS['faz_test_options']['faz_settings'] = array(
+		'legal_links' => array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) ),
+	);
+	Settings::clear_cache();
+	$memoised = new Legal_Links();
+	$memoised->maybe_enqueue_styles();
+	ob_start();
+	$memoised->render();
+	$rendered = ob_get_clean();
+	faz_assert_same(
+		$rendered,
+		$memoised->build_html( array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) ) ),
+		'render() after the enqueue pass prints exactly the freshly built markup'
+	);
 
 	echo "\n────────────────────────────────────────────\n";
 	echo "$tests_passed passed, $tests_failed failed (of $tests_run)\n";

--- a/tests/unit/test-legal-links-php.php
+++ b/tests/unit/test-legal-links-php.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * Standalone unit tests for the opt-in footer legal links.
+ *
+ * Two halves:
+ *
+ *   1. Legal_Links::build_html() — the render contract. Default OFF, no empty
+ *      <nav>, unpublished pages dropped at render time, blank label falls back
+ *      to the live page title, everything escaped, and — the important one —
+ *      the output is INVARIANT: it must not change with the visitor's consent
+ *      cookie, because Cache Compatibility Mode promises a single cached
+ *      variant per URL.
+ *
+ *   2. Settings::sanitize_option( 'link_items' ) and the sanitize() round trip.
+ *      The round-trip assertion is the regression guard for the get_excludes()
+ *      entry: remove 'link_items' from Settings::get_excludes() and the
+ *      recursive sanitiser walks each stored row against the EMPTY default
+ *      array and wipes the list — this test must go red when that happens.
+ *
+ * Run from project root:
+ *   php tests/unit/test-legal-links-php.php
+ *   bash scripts/run-unit-tests.sh
+ *
+ * Exit code 0 = all tests pass; 1 = at least one failure.
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+
+	// ---------- WP stubs (defined BEFORE the classes load) ----------
+
+	if ( ! function_exists( 'esc_html' ) ) {
+		function esc_html( $text ) {
+			return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+		}
+	}
+	if ( ! function_exists( 'esc_attr' ) ) {
+		function esc_attr( $text ) {
+			return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+		}
+	}
+	if ( ! function_exists( 'esc_url' ) ) {
+		function esc_url( $url ) {
+			return htmlspecialchars( (string) $url, ENT_QUOTES, 'UTF-8' );
+		}
+	}
+	if ( ! function_exists( 'esc_url_raw' ) ) {
+		function esc_url_raw( $url ) {
+			return (string) $url;
+		}
+	}
+	if ( ! function_exists( '__' ) ) {
+		function __( $text, $domain = '' ) {
+			return $text;
+		}
+	}
+	if ( ! function_exists( 'esc_attr__' ) ) {
+		function esc_attr__( $text, $domain = '' ) {
+			return esc_attr( $text );
+		}
+	}
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $str ) {
+			return trim( preg_replace( '/\s+/', ' ', wp_strip_all_tags( (string) $str ) ) );
+		}
+	}
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( $str ) {
+			return strip_tags( (string) $str );
+		}
+	}
+	if ( ! function_exists( 'sanitize_title' ) ) {
+		function sanitize_title( $title ) {
+			return strtolower( preg_replace( '/[^a-z0-9_\-]/i', '-', (string) $title ) );
+		}
+	}
+	if ( ! function_exists( 'absint' ) ) {
+		function absint( $value ) {
+			return abs( (int) $value );
+		}
+	}
+	if ( ! function_exists( 'faz_sanitize_bool' ) ) {
+		function faz_sanitize_bool( $value ) {
+			return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
+		}
+	}
+	if ( ! function_exists( 'faz_sanitize_text' ) ) {
+		function faz_sanitize_text( $value ) {
+			if ( is_array( $value ) ) {
+				return array_map( 'faz_sanitize_text', $value );
+			}
+			return is_scalar( $value ) ? sanitize_text_field( (string) $value ) : '';
+		}
+	}
+	if ( ! function_exists( 'add_action' ) ) {
+		function add_action( $hook, $callback, $priority = 10, $args = 1 ) {
+			return true;
+		}
+	}
+	if ( ! function_exists( 'do_action' ) ) {
+		function do_action( $hook, ...$args ) {
+			return null;
+		}
+	}
+	if ( ! function_exists( 'get_site_url' ) ) {
+		function get_site_url() {
+			return 'https://example.test';
+		}
+	}
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( $name, $default = false ) {
+			return $default;
+		}
+	}
+	if ( ! function_exists( 'update_option' ) ) {
+		function update_option( $name, $value ) {
+			return true;
+		}
+	}
+	if ( ! function_exists( 'wp_parse_url' ) ) {
+		function wp_parse_url( $url, $component = -1 ) {
+			return parse_url( (string) $url, $component );
+		}
+	}
+
+	// ---------- Page fixture map, backing the four post helpers ----------
+	//
+	// Keyed by ID; each entry carries the publish status, the title and the
+	// permalink the stubs hand back. Anything not in the map is a deleted page.
+
+	$GLOBALS['faz_test_pages'] = array(
+		10 => array( 'status' => 'publish', 'title' => 'Cookie Policy', 'url' => 'https://example.test/cookie-policy/' ),
+		11 => array( 'status' => 'publish', 'title' => 'Privacy Policy', 'url' => 'https://example.test/privacy/' ),
+		12 => array( 'status' => 'draft', 'title' => 'Imprint (draft)', 'url' => 'https://example.test/imprint/' ),
+		13 => array( 'status' => 'trash', 'title' => 'Old Terms', 'url' => 'https://example.test/old-terms/' ),
+		14 => array( 'status' => 'publish', 'title' => '', 'url' => 'https://example.test/untitled/' ),
+		15 => array( 'status' => 'publish', 'title' => 'Terms & "Conditions"', 'url' => 'https://example.test/terms/?a=1&b=2' ),
+	);
+
+	if ( ! function_exists( 'get_post' ) ) {
+		function get_post( $id = 0 ) {
+			$id = absint( $id );
+			if ( ! isset( $GLOBALS['faz_test_pages'][ $id ] ) ) {
+				return null;
+			}
+			$row              = $GLOBALS['faz_test_pages'][ $id ];
+			$post             = new stdClass();
+			$post->ID         = $id;
+			$post->post_status = $row['status'];
+			$post->post_title = $row['title'];
+			return $post;
+		}
+	}
+	if ( ! function_exists( 'get_post_status' ) ) {
+		function get_post_status( $post = null ) {
+			return ( is_object( $post ) && isset( $post->post_status ) ) ? $post->post_status : false;
+		}
+	}
+	if ( ! function_exists( 'get_permalink' ) ) {
+		function get_permalink( $post = null ) {
+			if ( ! is_object( $post ) || ! isset( $GLOBALS['faz_test_pages'][ $post->ID ] ) ) {
+				return false;
+			}
+			return $GLOBALS['faz_test_pages'][ $post->ID ]['url'];
+		}
+	}
+	if ( ! function_exists( 'get_the_title' ) ) {
+		function get_the_title( $post = null ) {
+			return ( is_object( $post ) && isset( $post->post_title ) ) ? $post->post_title : '';
+		}
+	}
+
+	require_once __DIR__ . '/../../includes/class-store.php';
+	require_once __DIR__ . '/../../admin/modules/settings/includes/class-settings.php';
+	require_once __DIR__ . '/../../frontend/modules/legal-links/class-legal-links.php';
+
+	use FazCookie\Admin\Modules\Settings\Includes\Settings;
+	use FazCookie\Frontend\Modules\Legal_Links\Legal_Links;
+
+	$tests_run = $tests_passed = $tests_failed = 0;
+
+	function faz_assert_true( $condition, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $condition ) {
+			$tests_passed++;
+			echo "  \033[32m✓\033[0m $label\n";
+			return;
+		}
+		$tests_failed++;
+		echo "  \033[31m✗\033[0m $label\n";
+	}
+
+	function faz_assert_same( $actual, $expected, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $actual === $expected ) {
+			$tests_passed++;
+			echo "  \033[32m✓\033[0m $label\n";
+			return;
+		}
+		$tests_failed++;
+		echo "  \033[31m✗\033[0m $label\n";
+		echo '      expected: ' . var_export( $expected, true ) . "\n";
+		echo '      actual:   ' . var_export( $actual, true ) . "\n";
+	}
+
+	$links = new Legal_Links();
+
+	echo "\n== Footer legal links: render contract ==\n\n";
+
+	faz_assert_same(
+		$links->build_html( array( 'enabled' => false, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) ) ),
+		'',
+		'default OFF: nothing rendered even with pages selected'
+	);
+
+	faz_assert_same(
+		$links->build_html( array( 'enabled' => true, 'link_items' => array() ) ),
+		'',
+		'enabled with no pages selected renders nothing (no empty <nav>)'
+	);
+
+	faz_assert_same(
+		$links->build_html( array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 12, 'label' => '' ) ) ) ),
+		'',
+		'a single draft page renders nothing (no empty <nav>)'
+	);
+
+	$title_fallback = $links->build_html(
+		array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => '' ) ) )
+	);
+	faz_assert_same(
+		$title_fallback,
+		'<nav class="faz-legal-links" aria-label="Legal information"><ul class="faz-legal-links-list">'
+			. '<li class="faz-legal-links-item"><a href="https://example.test/cookie-policy/">Cookie Policy</a></li>'
+			. '</ul></nav>',
+		'blank label falls back to the live page title'
+	);
+
+	$custom_label = $links->build_html(
+		array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => 'Cookies' ) ) )
+	);
+	faz_assert_true(
+		false !== strpos( $custom_label, '>Cookies</a>' ) && false === strpos( $custom_label, 'Cookie Policy' ),
+		'a custom label replaces the page title'
+	);
+
+	$hostile_label = $links->build_html(
+		array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 10, 'label' => '<b>x</b>' ) ) )
+	);
+	faz_assert_true(
+		false !== strpos( $hostile_label, '&lt;b&gt;x&lt;/b&gt;' ) && false === strpos( $hostile_label, '<b>x</b>' ),
+		'a label containing markup is escaped, not rendered as HTML'
+	);
+
+	// The URL and the auto-title both carry characters that must be escaped.
+	$escaped_url = $links->build_html(
+		array( 'enabled' => true, 'link_items' => array( array( 'page_id' => 15, 'label' => '' ) ) )
+	);
+	faz_assert_true(
+		false !== strpos( $escaped_url, 'href="https://example.test/terms/?a=1&amp;b=2"' ),
+		'the permalink is escaped through esc_url'
+	);
+	faz_assert_true(
+		false !== strpos( $escaped_url, 'Terms &amp; &quot;Conditions&quot;' ),
+		'the page title is escaped through esc_html'
+	);
+
+	// Draft, trashed, deleted and title-less pages all drop out; the two valid
+	// ones survive, in the order the admin arranged them.
+	$mixed = $links->build_html(
+		array(
+			'enabled'    => true,
+			'link_items' => array(
+				array( 'page_id' => 11, 'label' => '' ),   // publish → renders (second in output).
+				array( 'page_id' => 12, 'label' => '' ),   // draft   → skipped.
+				array( 'page_id' => 13, 'label' => '' ),   // trash   → skipped.
+				array( 'page_id' => 99, 'label' => '' ),   // deleted → skipped.
+				array( 'page_id' => 14, 'label' => '' ),   // no title, no label → skipped.
+				array( 'page_id' => 10, 'label' => '' ),   // publish → renders.
+			),
+		)
+	);
+	faz_assert_same( substr_count( $mixed, '<li ' ), 2, 'draft, trashed, deleted and untitled pages are all skipped' );
+	faz_assert_true(
+		strpos( $mixed, '/privacy/' ) < strpos( $mixed, '/cookie-policy/' ),
+		'rendered order follows the stored link_items order, not the page ID'
+	);
+
+	// Invariance — the whole point of the feature living outside the consent
+	// pipeline. Same config, three different consent cookies, byte-identical
+	// output, so Cache Compatibility Mode's one-variant-per-URL holds.
+	$invariant_config = array(
+		'enabled'    => true,
+		'link_items' => array( array( 'page_id' => 10, 'label' => '' ), array( 'page_id' => 11, 'label' => 'Privacy' ) ),
+	);
+	unset( $_COOKIE['fazcookie-consent'] );
+	$anon = $links->build_html( $invariant_config );
+	$_COOKIE['fazcookie-consent'] = 'consent:yes,action:yes,categories:%5B%22necessary%22%2C%22analytics%22%5D';
+	$accepted = $links->build_html( $invariant_config );
+	$_COOKIE['fazcookie-consent'] = 'consent:no,action:yes,categories:%5B%22necessary%22%5D';
+	$rejected = $links->build_html( $invariant_config );
+	unset( $_COOKIE['fazcookie-consent'] );
+	faz_assert_true( $anon === $accepted && $accepted === $rejected, 'output is byte-identical for anonymous, accepted and rejected visitors' );
+
+	echo "\n== Footer legal links: sanitisation ==\n\n";
+
+	faz_assert_same( Settings::sanitize_option( 'link_items', 'nope' ), array(), 'a non-array payload collapses to an empty list' );
+	faz_assert_same( Settings::sanitize_option( 'link_items', null ), array(), 'null collapses to an empty list' );
+
+	faz_assert_same(
+		Settings::sanitize_option(
+			'link_items',
+			array(
+				array( 'page_id' => 10, 'label' => 'A' ),
+				array( 'page_id' => '10', 'label' => 'duplicate' ),
+				array( 'page_id' => 0, 'label' => 'zero' ),
+				array( 'page_id' => -5, 'label' => 'negative' ),
+				'not-an-array',
+				array( 'page_id' => 11, 'label' => ' B ', 'evil' => 'dropped' ),
+			)
+		),
+		array(
+			array( 'page_id' => 10, 'label' => 'A' ),
+			array( 'page_id' => 11, 'label' => 'B' ),
+		),
+		'duplicates, zero/negative IDs, non-arrays and unknown keys are all dropped'
+	);
+
+	$clipped = Settings::sanitize_option( 'link_items', array( array( 'page_id' => 10, 'label' => str_repeat( 'x', 400 ) ) ) );
+	faz_assert_same( strlen( $clipped[0]['label'] ), 120, 'an oversized label is clipped to 120 characters' );
+
+	$oversized = array();
+	for ( $i = 1; $i <= 40; $i++ ) {
+		$oversized[] = array( 'page_id' => $i, 'label' => 'Page ' . $i );
+	}
+	faz_assert_same( count( Settings::sanitize_option( 'link_items', $oversized ) ), 20, 'the list is capped at 20 rows' );
+
+	// Round trip through the real recursive sanitiser against the real defaults.
+	// This is what proves the get_excludes() entry is present — without it the
+	// stored rows are walked against the empty default array and vanish.
+	$settings  = new Settings();
+	$defaults  = $settings->get_defaults();
+	$round_trip = Settings::sanitize(
+		array(
+			'legal_links' => array(
+				'enabled'    => '1',
+				'link_items' => array(
+					array( 'page_id' => 10, 'label' => '' ),
+					array( 'page_id' => 11, 'label' => 'Privacy' ),
+				),
+			),
+		),
+		$defaults
+	);
+	faz_assert_same( $round_trip['legal_links']['enabled'], true, "the 'enabled' flag rides the generic boolean case" );
+	faz_assert_same(
+		$round_trip['legal_links']['link_items'],
+		array(
+			array( 'page_id' => 10, 'label' => '' ),
+			array( 'page_id' => 11, 'label' => 'Privacy' ),
+		),
+		'sanitize() round trip preserves link_items exactly (get_excludes entry present)'
+	);
+
+	$absent = Settings::sanitize( array(), $defaults );
+	faz_assert_same( $absent['legal_links']['enabled'], false, 'legal_links defaults to OFF when absent from the payload' );
+	faz_assert_same( $absent['legal_links']['link_items'], array(), 'link_items defaults to an empty list when absent' );
+
+	echo "\n────────────────────────────────────────────\n";
+	echo "$tests_passed passed, $tests_failed failed (of $tests_run)\n";
+	exit( $tests_failed > 0 ? 1 : 0 );
+}


### PR DESCRIPTION
## What this adds

A default-OFF setting that lets the admin pick which published pages get printed as a small legal-links `<nav>` in the theme footer (`wp_footer`, priority 20, so it lands after the consent banner). Typical use: "Cookie Policy · Privacy Policy · Imprint" without editing a theme template or dropping a shortcode into a widget area.

```html
<nav class="faz-legal-links" aria-label="Legal information">
  <ul class="faz-legal-links-list">
    <li class="faz-legal-links-item"><a href="…">Cookie Policy</a></li>
  </ul>
</nav>
```

## Design decisions and why

**It lives in `faz_settings`, not its own option.** My plan (§4.1) parked this in a standalone `faz_legal_links` option tied to the future Legal Documents registry. I deliberately deviated so this can ship on its own: the existing REST save path (`POST faz/v1/settings` → `Store::update` → `Settings::sanitize`) already handles persistence, so there is no new endpoint, no new capability check and no new nonce surface. The whole server side is one `get_defaults()` entry, one `get_excludes()` entry and one `sanitize_option()` case. No Legal Documents admin page is built here.

**The key is `link_items`, not a generic `items`/`pages`.** `get_excludes()` and `sanitize_option()` match by *bare key name across the entire settings tree*, so a generic name would hijack any future group that happened to reuse it.

**The `get_excludes()` entry is load-bearing.** The recursive sanitiser walks arrays-of-structs against their default, and the default here is an empty array — without the exclusion, every stored row is wiped on the next save of *any* setting. Same trap the existing `variants` entry documents. The round-trip assertion in the new unit suite exists purely to catch that: I verified it by temporarily removing the `link_items` line from `get_excludes()` and confirming the test goes red, then restoring it.

**Invariance is the whole point.** `build_html()` reads nothing request-dependent — no `$_COOKIE`, no consent store, no geo lookup, no `is_user_logged_in()` branch. The output is a pure function of the option plus each page's publish state. Cache Compatibility Mode promises one cached variant per URL, and 1.21.0 only shipped once every render path had been made invariant; I did not want this to be the first exception. The rule is stated in the method docblock so a future edit has to argue with it. The E2E spec asserts the nav's `outerHTML` is byte-identical before and after the visitor accepts.

**Unpublished pages are skipped at render time**, not pruned on save, so unpublishing a page removes its footer link immediately with no admin round trip. A blank label falls back to the live page title for the same reason: renaming the page keeps the link in sync. I used `get_the_title()` rather than `$post->post_title` so translation plugins can localise the label — that varies per URL (WPML/Polylang serve each language on its own URL), never per visitor, so the one-variant-per-URL guarantee still holds.

**`(int)` instead of `absint()` on `page_id`**, in both the sanitiser and the renderer. `absint(-5)` is `5`, so a malformed ID would silently resolve to a *different, real* page. Malformed input has to drop out, not get rounded into something valid. This is the one place I diverged from my own spec snippet, and the unit test pins the behaviour.

**Bounds:** 20 rows max, labels clipped to 120 chars (`mb_substr` when mbstring is present, `substr` otherwise). A footer nav is a handful of legal pages, and the cap keeps a crafted settings PUT from bloating every cached page on the site. The renderer carries the same cap defensively, for rows that predate it or arrived via a direct DB edit.

**Zero surviving links renders nothing at all** — an empty `<nav>` is a landmark with no content for assistive technology.

**CSS is enqueued from `wp_enqueue_scripts`, never from `render()`.** By `wp_footer` time `wp_head` is long gone and a late enqueue would be dropped or printed illegally in `<body>`. It is also gated on the feature actually being on, so an untouched install ships zero extra bytes. The stylesheet is ~15 lines, colourless, no `!important` — a theme that wants to restyle the nav should win without a specificity fight.

**Admin UI:** the page rows are server-rendered and carry **no `data-path`** — a stray one would coerce each row into a boolean under `legal_links` and corrupt the payload. `settings.js` hydrates and serialises them through its own helpers. Because the rows are server-rendered there is no async-readiness guard to write, unlike the A/B-test variant list. The one guard I did add covers a site with no published pages at all, where the view renders no rows and a naive serialize would report "nothing selected" and wipe a list the admin configured while pages still existed. `enabled` (via `data-path`) and `link_items` (via the custom serializer) are always sent together, since the save path merges group objects with `Object.assign`.

## Backward compatibility

- Default is `enabled => false` with an empty `link_items`, so an install upgrading to this version renders no nav and enqueues no CSS. Nothing changes until an admin opts in.
- No DB migration, no new option, no new table, no new REST route.
- No outbound HTTP, no CDN assets — the CSS ships in the ZIP.
- No frontend JS touched, so `npm run build:min` was not needed.
- One existing test file changed: `test-flyingpress-frontend-bootstrap-php.php` constructs the real `Frontend` without an autoloader, so every collaborator has to be declared there; it gained a one-line `Legal_Links` stub. Nothing about what that suite asserts changed.

## What I tested

- `npm run test:unit` — **57 passed, 0 failed (of 57)**. That is the previous 56 plus the new `test-legal-links-php.php`; nothing turned red, and `test-cookie-policy-golden-render.php` (the backward-compatibility gate) is untouched and green.
- New `tests/unit/test-legal-links-php.php` — **20 assertions, all passing**: default OFF, empty selection, draft-only selection, title fallback, custom label, label markup escaped to entities, permalink through `esc_url`, title through `esc_html`, draft/trashed/deleted/untitled pages skipped, stored order preserved, byte-identical output across anonymous/accepted/rejected consent cookies, plus the sanitiser (non-array collapse, dedupe, zero and negative IDs dropped, unknown keys dropped, 120-char clip, 20-row cap) and the `sanitize()` round trip.
- PHP syntax sweep over the whole repo (excluding `vendor/`, `node_modules/`, `index.php`) — clean.
- `npx tsc --noEmit --strict` on the new spec — clean. `npx eslint` on `settings.js` — clean.
- Verified the autoloader maps `FazCookie\Frontend\Modules\Legal_Links\Legal_Links` to `frontend/modules/legal-links/class-legal-links.php`.
- Verified the get_excludes regression guard actually bites, as described above.

## What I did not do

- **I did not run the Playwright E2E suite**, per the house rule that it drives a single shared WordPress test site. For the same reason I did not rsync this branch over the shared deploy path — a `--delete` sync there would have clobbered whatever else is currently deployed. `tests/e2e/specs/legal-footer-links.spec.ts` and the existing `cache-compatibility-mode.spec.ts` regression check still need to be run in the separate E2E pass.
- No i18n resync (`make-pot`/`msgmerge`). New translatable strings are present; the standing rule is one resync per release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuove funzionalità**
  - Aggiunta la sezione “Footer legal links” nelle impostazioni.
  - È possibile selezionare fino a 20 pagine pubblicate e personalizzare le relative etichette.
  - I collegamenti legali selezionati vengono mostrati nel footer del sito.

- **Correzioni**
  - Le pagine non pubblicate o non valide vengono escluse automaticamente.
  - Le impostazioni esistenti vengono preservate quando non sono presenti selezioni.

- **Test**
  - Aggiunti test end-to-end per visualizzazione, disattivazione e personalizzazione dei collegamenti.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->