### PR TITLE
test(policy): make the ledger-seeding test establish the state it claims to test

### DIFF
--- a/tests/e2e/specs/policy-revision-link.spec.ts
+++ b/tests/e2e/specs/policy-revision-link.spec.ts
@@ -17,10 +17,31 @@ import { test, expect, completeAdminLogin } from '../fixtures/wp-fixture';
 import type { Browser, BrowserContext, Page } from '@playwright/test';
 import { getAdminNonce, fazApiGet, fazApiPost } from '../utils/faz-api';
 import { clickFirstVisible } from '../utils/ui';
+import { WP_PATH, wpEval } from '../utils/wp-env';
 
 const ADMIN_PAGE = '/wp-admin/admin.php?page=faz-cookie-manager-cookie-policy';
 const NOTICE = '#faz-cp-version-notice';
 const HASH_PAIR_RE = /[0-9a-f]{6}\.[0-9a-f]{6}\s*→\s*[0-9a-f]{6}\.[0-9a-f]{6}/;
+const HASH_RE = /^[0-9a-f]{6}\.[0-9a-f]{6}$/;
+
+// Version_Ledger::OPTION / ::DOCUMENT. Read through wp-cli rather than through
+// the admin page, because the page is the thing under test: asking it whether
+// seeding happened would only ever return its own opinion.
+const LEDGER_OPTION = 'faz_legal_doc_acknowledged';
+const LEDGER_DOCUMENT = 'cookie-policy';
+
+/** The hash currently recorded as acknowledged, or '' when none is. */
+function acknowledgedHash(): string {
+  return wpEval(
+    `$l = get_option( '${LEDGER_OPTION}', array() );` +
+    `echo ( is_array( $l ) && isset( $l['${LEDGER_DOCUMENT}']['hash'] ) ) ? $l['${LEDGER_DOCUMENT}']['hash'] : '';`,
+  ).trim();
+}
+
+/** Return the ledger to the never-acknowledged state a fresh install is in. */
+function clearLedger(): void {
+  wpEval(`delete_option( '${LEDGER_OPTION}' );`);
+}
 
 type PolicySettings = Record<string, unknown> & { company?: Record<string, unknown> };
 
@@ -138,13 +159,34 @@ test.afterAll(async ({ browser, wpCreds }) => {
 });
 
 test('first load seeds the ledger silently — the feature itself never prompts', async ({ page, loginAsAdmin }) => {
+  test.skip(!WP_PATH, 'requires WP_PATH to put the ledger back to its unacknowledged state');
+
+  // The precondition IS the subject here. Seeding only happens when nothing has
+  // been acknowledged yet (Version_Ledger::evaluate returns 'seeded' on an empty
+  // ledger and adopts the current hash), so a test that inherits whatever ledger
+  // state the site happens to carry is not exercising seeding at all — it is
+  // asserting "no notice pending", which is a different claim from the one in
+  // its own name. It passed for that weaker reason, and failed outright on any
+  // site holding a genuine unacknowledged change, including a run left half
+  // finished. Establish the state rather than hope for it.
+  clearLedger();
+  expect(acknowledgedHash()).toBe('');
+
   await loginAsAdmin(page);
   await openAdmin(page);
   await expect(page.locator(NOTICE)).toHaveCount(0);
 
-  // Second load, still nothing: seeding is a one-off, not a per-load reset.
+  // Silence on its own would also be the outcome if the feature had done
+  // nothing at all, so assert the other half of "seeds silently": the ledger
+  // really did adopt the current hash on that first load.
+  const seeded = acknowledgedHash();
+  expect(seeded).toMatch(HASH_RE);
+
+  // Second load, still nothing: seeding is a one-off, not a per-load reset —
+  // and it must not quietly re-seed to some other value either.
   await openAdmin(page);
   await expect(page.locator(NOTICE)).toHaveCount(0);
+  expect(acknowledgedHash()).toBe(seeded);
 });
 
 test('a material change re-prompts a visitor who had already consented', async ({ page, loginAsAdmin, wpBaseURL }) => {

--- a/tests/e2e/specs/policy-revision-link.spec.ts
+++ b/tests/e2e/specs/policy-revision-link.spec.ts
@@ -43,6 +43,20 @@ function clearLedger(): void {
   wpEval(`delete_option( '${LEDGER_OPTION}' );`);
 }
 
+/**
+ * The review token the policy currently hashes to, computed without going
+ * through the code path under test.
+ *
+ * review_hash() is what the notice compares against, and it neither reads nor
+ * writes the ledger — so it can say which value a correct seeding must land on,
+ * where the ledger itself can only say which value it happened to store.
+ */
+function currentReviewHash(): string {
+  return wpEval(
+    "echo \\FazCookie\\Admin\\Modules\\Cookie_Policy_Generator\\Includes\\Version_Ledger::review_hash();",
+  ).trim();
+}
+
 type PolicySettings = Record<string, unknown> & { company?: Record<string, unknown> };
 
 let settingsSnapshot: PolicySettings | null = null;
@@ -172,15 +186,22 @@ test('first load seeds the ledger silently — the feature itself never prompts'
   clearLedger();
   expect(acknowledgedHash()).toBe('');
 
+  // Captured before the page runs, so the expected value cannot be derived from
+  // whatever the page decided to store.
+  const expected = currentReviewHash();
+  expect(expected).toMatch(HASH_RE);
+
   await loginAsAdmin(page);
   await openAdmin(page);
   await expect(page.locator(NOTICE)).toHaveCount(0);
 
   // Silence on its own would also be the outcome if the feature had done
   // nothing at all, so assert the other half of "seeds silently": the ledger
-  // really did adopt the current hash on that first load.
+  // really did adopt the CURRENT hash on that first load. Checking only the
+  // <6hex>.<6hex> shape would pass on any well-formed value, including a stale
+  // one — the shape is not the claim, the value is.
   const seeded = acknowledgedHash();
-  expect(seeded).toMatch(HASH_RE);
+  expect(seeded).toBe(expected);
 
   // Second load, still nothing: seeding is a one-off, not a per-load reset —
   // and it must not quietly re-seed to some other value either.


### PR DESCRIPTION
`policy-revision-link.spec.ts` opens with a test called *"first load seeds the ledger silently — the feature itself never prompts"* that never arranged a first load. The file's `beforeAll` only snapshots the policy settings, so this test — the first in the file — inherited whatever ledger state the site happened to be carrying, and asserted only that no notice was on screen.

That left it wrong in both directions.

**It failed for no defect.** A site holding a genuine unacknowledged policy change shows the notice *correctly*, and the test read that correct behaviour as a failure. That is exactly what happened here: a half-finished suite run left the ledger acknowledged at an older hash, and the test went red on `main` and on every branch alike — pointing at the feature instead of at the leftover state. I only established it was environmental by deploying `main` and finding the identical hash and the identical `changed` status there.

**And it passed while blind.** `Version_Ledger::evaluate()` returns `'seeded'` whether or not it actually records anything, so deleting the `acknowledge()` call inside it — breaking seeding completely — still renders no notice, and the old assertion still passed. A test named after seeding could not distinguish working seeding from absent seeding.

## What changed

The test now establishes its precondition instead of hoping for it: it clears the ledger through WP-CLI so the page really is meeting an unacknowledged install, then asserts **both** halves of the claim — that no notice appeared, and that the ledger now holds the current hash. A second load must still be silent and must not have quietly re-seeded to a different value.

The ledger is read through WP-CLI rather than through the admin page on purpose. The page is the thing under test; asking it whether seeding happened would only ever return its own opinion.

## Verification

A test-hygiene change that is itself unverified is just a different guess, so this was checked in three directions:

| scenario | result |
|---|---|
| clean ledger | 4/4 green |
| the `changed` state that used to break it | green — the point of the change |
| seeding removed from `Version_Ledger::evaluate()` | red on the new assertion (`Received string: ""`), where the old test passed |

`tests/unit/test-version-ledger.php` — 47/47, untouched.

## Notes

Skips when `WP_PATH` is absent, matching the other WP-CLI-dependent specs: without it the precondition cannot be established, and a test that cannot arrange its own state should say so rather than run on someone else's.

No product code is touched — this is a test-only change, branched from `main`, independent of the open PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Test**
  * Rafforzata la verifica del primo accesso alla pagina delle policy.
  * Verificata la generazione di un identificativo di revisione completo e valido.
  * Confermata la persistenza dello stesso identificativo nelle aperture successive, senza notifiche indesiderate.
  * Aggiunti controlli sullo stato iniziale e sulla sua pulizia, garantendo risultati affidabili e riproducibili.
  * Gestita l’assenza dell’ambiente necessario per eseguire correttamente il test di primo caricamento.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->