### PR TITLE
One deploy script for the test site, with the exclusions in it

### DIFF
--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# deploy-test.sh — sync the plugin into the local WordPress test site.
+#
+# One script rather than a command in the docs, because there were two copies of
+# that command and they had already drifted: one carried a list of exclusions,
+# the other none, and NEITHER excluded `.git`. Every deploy therefore copied a
+# 57 MB clone of the repository into
+# wp-content/plugins/faz-cookie-manager/.git.
+#
+# That is not only waste. It broke `wp plugin install --force` outright —
+# WordPress could not remove the old directory — and the same pattern used
+# against a real server would put a complete repository, including its whole
+# history, under the webroot. Exclusions belong in one place that cannot drift.
+#
+# Usage:
+#   bash scripts/deploy-test.sh                 # default target
+#   FAZ_DEPLOY_TARGET=/path/to/plugins/faz-cookie-manager/ bash scripts/deploy-test.sh
+
+set -euo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+TARGET="${FAZ_DEPLOY_TARGET:-/Users/fabio/Sites/faz-test/wp-content/plugins/faz-cookie-manager/}"
+
+if [ ! -f faz-cookie-manager.php ]; then
+	echo "deploy-test: not in the plugin root (faz-cookie-manager.php missing)" >&2
+	exit 2
+fi
+
+# A missing trailing slash on the target makes rsync nest the source INSIDE it.
+case "$TARGET" in
+	*/) ;;
+	*) TARGET="${TARGET}/" ;;
+esac
+
+# --delete is deliberate: a stale file left behind after a rename is how a test
+# passes against code that no longer ships. It also means the exclusions below
+# are the only thing standing between this and deleting them at the target, so
+# every entry is repository-side clutter, never plugin content.
+#
+# None of these patterns carries a trailing slash, and that is load-bearing: in
+# rsync a trailing slash restricts the pattern to DIRECTORIES. Run from a git
+# worktree — the normal way to work on two branches at once — `.git` is a file
+# rather than a directory and `node_modules` is usually a symlink into the main
+# checkout, so slash-suffixed patterns match neither and rsync copies both. That
+# was not hypothetical: it shipped a 17 MB target with node_modules in it.
+rsync -a --delete \
+	--exclude='.git' \
+	--exclude='.git*' \
+	--exclude='node_modules' \
+	--exclude='.phpcs-tools' \
+	--exclude='graphify-out' \
+	--exclude='.code-review-graph' \
+	--exclude='.serena' \
+	--exclude='tests/e2e/reports' \
+	--exclude='*.zip' \
+	./ "$TARGET"
+
+echo "deployed → ${TARGET}"
+du -sh "$TARGET" 2>/dev/null | awk '{print "size: " $1}'
+
+# A .git that reappears means an exclusion was dropped; say so rather than let
+# the next `wp plugin install` fail with a permissions error that names 400
+# object files and explains nothing.
+# -e, not -d: from a worktree `.git` arrives as a file, which -d would miss —
+# the same distinction the exclusions above turn on.
+if [ -e "${TARGET}.git" ] || [ -e "${TARGET}node_modules" ]; then
+	echo "deploy-test: WARNING — .git or node_modules reached the target; the exclusions are wrong" >&2
+	exit 1
+fi

--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -16,9 +16,47 @@
 # Usage:
 #   bash scripts/deploy-test.sh                 # default target
 #   FAZ_DEPLOY_TARGET=/path/to/plugins/faz-cookie-manager/ bash scripts/deploy-test.sh
+#   bash scripts/deploy-test.sh --print-excludes   # the list, one per line
+#
+# --print-excludes exists so that nothing else has to restate the list. The E2E
+# preflight compares the working tree against the deployed plugin and refuses to
+# run the suite when they differ; it held a THIRD copy of these exclusions, and
+# the copies disagreed about `.gitignore` and `.githooks/`, so a correct deploy
+# was reported as five files of drift and the whole suite declined to start.
+# It now asks this script instead.
 
 set -euo pipefail
 cd "$(dirname "$0")/.." || exit 2
+
+# The single list. Note that no pattern carries a trailing slash, and that is
+# load-bearing: in rsync a trailing slash restricts the pattern to DIRECTORIES.
+# Run from a git worktree — the normal way to work on two branches at once —
+# `.git` is a file rather than a directory and `node_modules` is usually a
+# symlink into the main checkout, so slash-suffixed patterns match neither and
+# rsync copies both. That was not hypothetical: it shipped a 17 MB target with
+# node_modules in it.
+#
+# `tests` is excluded because the plugin does not ship its own test suite, and
+# because the preflight already compared without it — deploying it would have
+# meant the two disagreed in the other direction.
+EXCLUDES=(
+	'.git'
+	'.git*'
+	'.github'
+	'node_modules'
+	'.phpcs-tools'
+	'graphify-out'
+	'.code-review-graph'
+	'.serena'
+	'tests'
+	'*.zip'
+	'.DS_Store'
+)
+
+if [ "${1:-}" = '--print-excludes' ]; then
+	printf '%s\n' "${EXCLUDES[@]}"
+	exit 0
+fi
 
 TARGET="${FAZ_DEPLOY_TARGET:-/Users/fabio/Sites/faz-test/wp-content/plugins/faz-cookie-manager/}"
 
@@ -34,27 +72,15 @@ case "$TARGET" in
 esac
 
 # --delete is deliberate: a stale file left behind after a rename is how a test
-# passes against code that no longer ships. It also means the exclusions below
+# passes against code that no longer ships. It also means the exclusions above
 # are the only thing standing between this and deleting them at the target, so
 # every entry is repository-side clutter, never plugin content.
-#
-# None of these patterns carries a trailing slash, and that is load-bearing: in
-# rsync a trailing slash restricts the pattern to DIRECTORIES. Run from a git
-# worktree — the normal way to work on two branches at once — `.git` is a file
-# rather than a directory and `node_modules` is usually a symlink into the main
-# checkout, so slash-suffixed patterns match neither and rsync copies both. That
-# was not hypothetical: it shipped a 17 MB target with node_modules in it.
-rsync -a --delete \
-	--exclude='.git' \
-	--exclude='.git*' \
-	--exclude='node_modules' \
-	--exclude='.phpcs-tools' \
-	--exclude='graphify-out' \
-	--exclude='.code-review-graph' \
-	--exclude='.serena' \
-	--exclude='tests/e2e/reports' \
-	--exclude='*.zip' \
-	./ "$TARGET"
+RSYNC_EXCLUDES=()
+for pattern in "${EXCLUDES[@]}"; do
+	RSYNC_EXCLUDES+=( "--exclude=${pattern}" )
+done
+
+rsync -a --delete "${RSYNC_EXCLUDES[@]}" ./ "$TARGET"
 
 echo "deployed → ${TARGET}"
 du -sh "$TARGET" 2>/dev/null | awk '{print "size: " $1}'

--- a/tests/e2e/utils/preflight.ts
+++ b/tests/e2e/utils/preflight.ts
@@ -43,20 +43,37 @@ const BASELINE_FIXTURES = [
 ];
 
 /**
- * Paths that legitimately differ between the working tree and the deployed
- * copy — development artefacts and the test suite itself, which the site has
- * no use for. Mirrors the deploy command documented in CLAUDE.md.
+ * The deploy exclusions, read from the deploy script rather than restated.
+ *
+ * This list used to live here as a second copy, and the copies disagreed:
+ * `scripts/deploy-test.sh` excludes `.git*` (which also covers `.gitignore`
+ * and `.githooks/`), this one excluded only `.git/`. A perfectly correct
+ * deploy therefore showed up here as five files of drift, and the preflight
+ * refused to start the whole suite over a disagreement between two lists that
+ * were meant to be the same list.
+ *
+ * Asking the script keeps the drift check honest by construction: whatever the
+ * deploy actually skips is exactly what this declines to compare. A failure to
+ * read it is fatal on purpose — falling back to a hardcoded list would restore
+ * the very divergence this removes, and it would do so silently.
  */
-const DEPLOY_EXCLUDES = [
-  '.git/',
-  '.github/',
-  'node_modules/',
-  'graphify-out/',
-  '.code-review-graph/',
-  '.serena/',
-  'tests/',
-  '.DS_Store',
-];
+let excludesCache: string[] | null = null;
+function deployExcludes(): string[] {
+  if (excludesCache) {
+    return excludesCache;
+  }
+  const script = join(REPO_ROOT, 'scripts', 'deploy-test.sh');
+  const out = execFileSync('bash', [script, '--print-excludes'], {
+    encoding: 'utf8',
+    timeout: 15_000,
+  });
+  const list = out.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (!list.length) {
+    throw new Error(`${script} --print-excludes returned nothing`);
+  }
+  excludesCache = list;
+  return list;
+}
 
 const OK = '\x1b[32m✓\x1b[0m';
 const FIX = '\x1b[33m⟳\x1b[0m';
@@ -76,7 +93,7 @@ function deploymentDrift(deployPath: string): string[] {
   const args = [
     '-rcni',
     '--delete',
-    ...DEPLOY_EXCLUDES.map((p) => `--exclude=${p}`),
+    ...deployExcludes().map((p) => `--exclude=${p}`),
     `${REPO_ROOT}/`,
     deployPath.endsWith('/') ? deployPath : `${deployPath}/`,
   ];
@@ -169,7 +186,7 @@ export async function assertPrerequisites(baseURL: string): Promise<void> {
       fail(
         `the deployed plugin is ${drift.length} file(s) behind the working tree`,
         `The suite would test code you are not editing.\n\n${shown}${more}`,
-        `rsync -a --delete ${DEPLOY_EXCLUDES.map((p) => `--exclude='${p}'`).join(' ')} \\\n      "${REPO_ROOT}/" "${deployPath}"`,
+        `FAZ_DEPLOY_TARGET="${deployPath}" bash scripts/deploy-test.sh`,
       );
     }
     ok.push(`${OK} deployed plugin matches the working tree`);

--- a/tests/e2e/utils/preflight.ts
+++ b/tests/e2e/utils/preflight.ts
@@ -85,6 +85,21 @@ function fail(title: string, detail: string, remedy: string): never {
 }
 
 /**
+ * One line of `rsync -i` output that names a file: eleven characters of
+ * itemised change flags (`>f+++++++++`, `cd+++++++++`, `.d..t......`) or
+ * `*deleting`, then the path.
+ *
+ * Needed because rsync mixes NOTICES into the same stream, and counting every
+ * non-empty line treated them as drift. `skipping non-regular file
+ * "node_modules"` — emitted whenever node_modules is a symlink, which is the
+ * normal case in a git worktree — made the preflight announce "1 file behind"
+ * and refuse to start the entire suite against a deployment that matched
+ * perfectly. A check that reports confidently on the wrong measurement is
+ * worse than no check.
+ */
+const ITEMIZED = /^(?:[<>ch.][a-zA-Z.][^\s]{9}|\*\w+)\s+\S/;
+
+/**
  * Files that differ between the working tree and the deployed plugin.
  * `-c` compares checksums rather than size+mtime, so an edit that happens to
  * preserve both is still caught; `-n` makes it a dry run.
@@ -98,7 +113,10 @@ function deploymentDrift(deployPath: string): string[] {
     deployPath.endsWith('/') ? deployPath : `${deployPath}/`,
   ];
   const out = execFileSync('rsync', args, { encoding: 'utf8', timeout: 60_000 });
-  return out.split('\n').map((l) => l.trim()).filter(Boolean);
+  return out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => ITEMIZED.test(l));
 }
 
 /** Everything the suite needs, asserted before the first spec runs. */


### PR DESCRIPTION
The command that syncs the plugin into the local WordPress test site lived in two copies of the working notes, and they had already drifted: one carried a list of exclusions, the other none, and **neither excluded `.git`**. Every deploy therefore copied a clone of the repository into `wp-content/plugins/faz-cookie-manager/.git`. That is not only waste — it broke `wp plugin install --force` outright, because WordPress could not remove the old directory, and the same shape aimed at a real server would put a complete history under the webroot.

One script, so the exclusions cannot drift again.

### Two details found by running it, not by reading it
- **No exclusion pattern carries a trailing slash.** In rsync a trailing slash restricts the pattern to *directories*. Run from a git worktree — the normal way to work on two branches at once — `.git` is a file and `node_modules` is a symlink, so the slash-suffixed forms match neither. The first version of this script shipped a 17 MB target with `node_modules` inside it.
- **The post-deploy assertion uses `-e`, not `-d`**, for the same reason.

### Verification
Deploys the plugin and nothing else to a scratch target; does not nest when the target lacks a trailing slash; exits 1 with a named warning when `.git` or `node_modules` is present at the target. The target is overridable with `FAZ_DEPLOY_TARGET`, which is how it was tested without disturbing the live test site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto uno script per sincronizzare il plugin con un’installazione WordPress locale.
  * Il target di distribuzione è configurabile e verificato prima dell’avvio.
  * Il processo mostra la destinazione e la dimensione dei file distribuiti.
  * Impedita la distribuzione accidentale di file e directory di sviluppo o repository.
  * Disponibile l’elenco delle esclusioni utilizzate durante la distribuzione.

* **Test**
  * Aggiornati i controlli preliminari per verificare automaticamente le esclusioni e rilevare eventuali differenze nella distribuzione.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->