### PR TITLE
Invalidate the script map when service registration fails

### DIFF
--- a/admin/modules/cookies/api/class-cookies-api.php
+++ b/admin/modules/cookies/api/class-cookies-api.php
@@ -351,6 +351,14 @@ class Cookies_API extends API_Controller {
 		try {
 			\call_user_func( array( $scanner, 'get_instance' ) )->save_cookies( $payload );
 		} catch ( \Throwable $e ) {
+			// save_cookies() writes row by row, so an exception on one entry
+			// leaves the earlier ones persisted. The runtime map is rebuilt from
+			// that table, and it is what decides which scripts are held before
+			// consent: leaving it stale means cookies that ARE registered are
+			// not yet blocked. Failing the request does not undo the writes, so
+			// the map has to be invalidated on the way out too — the error path
+			// needs this more than the success path, not less.
+			delete_transient( 'faz_cookie_scripts_map' );
 			error_log( 'FAZ: service registration failed: ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- preserve diagnostics while returning a safe REST error.
 			return new WP_Error(
 				'faz_service_registration_failed',


### PR DESCRIPTION
The `register_service` endpoint invalidated `faz_cookie_scripts_map` only on the success path, and the `catch` returns before reaching it.

`save_cookies()` persists row by row, so an exception on one entry leaves the earlier ones written. That transient is what the runtime rebuilds the blocking map from — the map that decides which scripts are held before consent. A half-completed registration therefore left cookies present in the table but absent from the map, so the scripts setting them kept loading pre-consent until some unrelated write refreshed it.

The failure path needs the invalidation **more** than the success path does, not less: it is the one that ends with the table and the map disagreeing. Failing the request does not roll the writes back, so the fix invalidates on the way out rather than pretending nothing was written.

Found while verifying the CodeRabbit findings on #223 against current code. Of that set this was the only still-open Major one; the rest were either already closed by `4564868` or did not hold against the current code.

81/81 unit suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Migliorata la gestione degli errori durante il salvataggio delle impostazioni dei cookie.
  * In caso di errore, vengono invalidate le informazioni temporanee correlate prima di restituire la risposta di errore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->