### PR TITLE
Clear the seven Plugin Check errors blocking the 1.26.0 package

### DIFF
--- a/admin/modules/cookie-policy-generator/includes/class-document-config.php
+++ b/admin/modules/cookie-policy-generator/includes/class-document-config.php
@@ -134,7 +134,7 @@ class Document_Config {
 		foreach ( array( 'slug', 'shortcode', 'option', 'templates_dir', 'gettext_catalog', 'wrapper_class' ) as $key ) {
 			if ( ! isset( $config[ $key ] ) || ! is_string( $config[ $key ] ) || '' === trim( $config[ $key ] ) ) {
 				throw new \InvalidArgumentException(
-					sprintf( 'Document_Config: "%s" must be a non-empty string.', $key )
+					sprintf( 'Document_Config: "%s" must be a non-empty string.', esc_html( $key ) )
 				);
 			}
 		}
@@ -165,13 +165,13 @@ class Document_Config {
 		$missing_langs = array_diff( $config['jurisdictions'], array_keys( $config['native_lang'] ) );
 		if ( array() !== $missing_langs ) {
 			throw new \InvalidArgumentException(
-				sprintf( 'Document_Config: "native_lang" has no entry for %s.', implode( ', ', $missing_langs ) )
+				sprintf( 'Document_Config: "native_lang" has no entry for %s.', esc_html( implode( ', ', $missing_langs ) ) )
 			);
 		}
 		$unknown_langs = array_diff( array_keys( $config['native_lang'] ), $config['jurisdictions'] );
 		if ( array() !== $unknown_langs ) {
 			throw new \InvalidArgumentException(
-				sprintf( 'Document_Config: "native_lang" names unknown jurisdiction(s) %s.', implode( ', ', $unknown_langs ) )
+				sprintf( 'Document_Config: "native_lang" names unknown jurisdiction(s) %s.', esc_html( implode( ', ', $unknown_langs ) ) )
 			);
 		}
 
@@ -187,7 +187,7 @@ class Document_Config {
 		foreach ( array( 'data_builder', 'required_fields' ) as $key ) {
 			if ( ! isset( $config[ $key ] ) || ! is_callable( $config[ $key ] ) ) {
 				throw new \InvalidArgumentException(
-					sprintf( 'Document_Config: "%s" must be callable.', $key )
+					sprintf( 'Document_Config: "%s" must be callable.', esc_html( $key ) )
 				);
 			}
 		}

--- a/admin/modules/cookie-policy-generator/includes/class-generator.php
+++ b/admin/modules/cookie-policy-generator/includes/class-generator.php
@@ -196,7 +196,7 @@ class Generator {
 			if ( in_array( $path, array( 'company.email', 'dpo.email' ), true ) ) {
 				$invalid = $invalid || false === filter_var( $value, FILTER_VALIDATE_EMAIL );
 			} elseif ( 'privacy_policy_url' === $path ) {
-				$scheme  = strtolower( (string) parse_url( $value, PHP_URL_SCHEME ) );
+				$scheme  = strtolower( (string) wp_parse_url( $value, PHP_URL_SCHEME ) );
 				$invalid = $invalid || false === filter_var( $value, FILTER_VALIDATE_URL ) || ! in_array( $scheme, array( 'http', 'https' ), true );
 			}
 			if ( $invalid ) {

--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -868,7 +868,7 @@ class Frontend {
 			// stat cache populated by the file_exists() above.
 			$mtime = @filemtime( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( $mtime && ( time() - $mtime ) > DAY_IN_SECONDS ) {
-				@touch( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.touch_touch -- last-used marker for the daily reaper; WP_Filesystem has no touch primitive.
+				@touch( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_touch -- last-used marker for the daily reaper; WP_Filesystem has no touch primitive, and this runs on the frontend hot path where loading it would cost more than the write it replaces.
 			}
 			return $dir_info['url'] . $filename;
 		}

--- a/includes/class-cookie-content-i18n.php
+++ b/includes/class-cookie-content-i18n.php
@@ -341,6 +341,12 @@ class Cookie_Content_I18n {
 	 * @return string
 	 */
 	private static function lookup_duration( $source, $lang ) {
+		// The function_exists() guard is NOT about old WordPress versions —
+		// wp_strip_all_tags() has shipped since 2.9, far below this plugin's floor.
+		// It is what lets tests/unit/ load this class with no WordPress at all, which
+		// is the only environment where the fallback actually runs. Removing it as
+		// dead code takes six unit suites down with a fatal.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- see above: the fallback exists for the WordPress-less unit harness.
 		$source = function_exists( 'wp_strip_all_tags' ) ? wp_strip_all_tags( (string) $source ) : strip_tags( (string) $source );
 		$raw    = trim( $source );
 		$source = strtolower( $raw );

--- a/tests/unit/test-cookie-policy-generator.php
+++ b/tests/unit/test-cookie-policy-generator.php
@@ -49,6 +49,14 @@ if ( ! function_exists( 'wp_json_encode' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	// Stubbed rather than avoided in the source: production code should call
+	// the WordPress wrapper, and the harness is what has to keep up.
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- this stub IS the WordPress-less substitute.
+	}
+}
+
 require_once dirname( __DIR__, 2 ) . '/admin/modules/cookie-policy-generator/includes/class-generator.php';
 use FazCookie\Admin\Modules\Cookie_Policy_Generator\Includes\Generator;
 


### PR DESCRIPTION
The release gate requires `wp plugin check --categories=plugin_repo` to report **0 ERRORS** on the wp.org-shape ZIP. It reported 7.

- `Document_Config` threw four exceptions interpolating a config key or a list of language codes without escaping → `esc_html()`.
- `parse_url()` → `wp_parse_url()` in the policy generator.
- The `@touch()` marker already carried a suppression naming `WordPress.WP.AlternativeFunctions.touch_touch`. **That sniff code does not exist** — the one that fires is `file_system_operations_touch`. A `phpcs:ignore` pointing at the wrong code is indistinguishable from no ignore at all, except that it reads as handled in review.

The `strip_tags()` one needed the opposite treatment, and I got it wrong first. I removed the `function_exists( 'wp_strip_all_tags' )` fallback as dead code, reasoning the function has shipped since WP 2.9 — true, and beside the point. That guard is not about old WordPress: it is what lets `tests/unit/` load the class with **no WordPress at all**, the only environment where the fallback runs. Removing it took six unit suites down with a fatal. Restored, with a comment saying what it is for, and the sniff suppressed instead.

`wp_parse_url()` cut the other way: production code should call the WordPress wrapper, so the WordPress-less harness is what has to keep up — stubbed in the test rather than avoided in the source.

**0 ERRORS** after the fix (433 warnings, unchanged and documented). 81/81 unit suites.