### PR TITLE
Keep Composer's vendor/ out of the test deploy

### DIFF
--- a/scripts/deploy-test.sh
+++ b/scripts/deploy-test.sh
@@ -45,6 +45,7 @@ EXCLUDES=(
 	'.github'
 	'node_modules'
 	'.phpcs-tools'
+	'vendor'
 	'graphify-out'
 	'.code-review-graph'
 	'.serena'


### PR DESCRIPTION
It is gitignored, absent from every release ZIP, and holds dev tooling only — phpstan, php-stubs, composer. The deploy still copied all 31 MB of it under the test site webroot: repository clutter served from a web root, the same category as node_modules.

The E2E preflight reads this exclusion list from the script, so both sides pick the change up together — which is the point of having one list rather than two.

Deploy drops from 52 MB to 21 MB. No effect on the shipped package.