### PR TITLE
Stop update_item from discarding description and duration edits

### DIFF
--- a/admin/modules/cookies/includes/class-cookie-controller.php
+++ b/admin/modules/cookies/includes/class-cookie-controller.php
@@ -309,7 +309,15 @@ class Cookie_Controller extends Base_Controller {
 		global $wpdb;
 		$date_modified = current_time( 'mysql' );
 		$object->set_date_modified( $date_modified );
-		$stored = $object->get_data();
+		// Revisions merged over data, and that is the whole point. On an object
+		// LOADED from the database, set_object_data() stages every change in
+		// $this->revisions and leaves $this->data holding the values as read;
+		// get_data() returns only the latter. Reading description and duration
+		// straight from it therefore wrote back exactly what was already stored and
+		// dropped the edit — silently, because name, category and every other field
+		// go through getters, which DO consult revisions, so a save looked like it
+		// worked while the two multilingual fields snapped back.
+		$stored = array_merge( $object->get_data(), $object->get_revisions() );
 		$result = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 			$wpdb->prefix . 'faz_cookies',
 			array(

--- a/tests/e2e/specs/v170-deep-flows.spec.ts
+++ b/tests/e2e/specs/v170-deep-flows.spec.ts
@@ -191,7 +191,14 @@ test.describe.serial('v1.7.0 deep flows', () => {
       });
       await page.reload({ waitUntil: 'domcontentloaded' });
 
-      const templates = page.locator('#faz-blocker-templates > button');
+      // The clickable element is the button INSIDE each card, not the card. The
+      // cards became `<div class="faz-template-card"><button
+      // class="faz-template-card-action">` when the "not applied" badge landed;
+      // a direct-child button selector matches nothing now, and the test failed
+      // with "Expected 1, Received 0" against a UI doing exactly the right
+      // thing. Anchored on the action class rather than on the DOM shape, so
+      // wrapping the card again does not break it a third time.
+      const templates = page.locator('#faz-blocker-templates button.faz-template-card-action');
       // Anchor on the card *name* element (`.faz-template-card-name`) so we
       // match only the canonical "Google Analytics" template — not other
       // Google-* templates whose descriptions mention Google Analytics.


### PR DESCRIPTION
Every REST update of a cookie silently threw away the **description** and the **duration**. The save looked like it worked — name, category, domain and the rest all changed — while those two fields snapped back to what was already stored.

### Why only those two
The code splits reads deliberately: on an object **loaded** from the database, `set_object_data()` stages changes in `$this->revisions` and leaves `$this->data` holding the values as read (`class-store.php:400-410`), and `get_object_data()` then prefers revisions over data (`373-379`). Every field written through a getter picks the edit up. Description and duration were the only two read from `$object->get_data()`, which returns `$this->data` alone (`class-store.php:220-222`).

Introduced in `4564868`, which moved those two fields off their getters to stop translated display fallbacks being persisted. That concern was real; the replacement just reached for the half of the object that does not hold the edit. `array_merge( get_data(), get_revisions() )` writes exactly what the caller set, without going back through the translating getters.

### How it reached main untested
`4564868` landed at 22:06 on 12 Aug. The last full E2E suite finished at 18:22. It rode into main inside merge #223 with two other commits made in that window, so "yesterday green, today red" was never a comparison of the PRs merged since — it spanned three commits no suite had ever executed.

### Also: one stale locator
`d5c5ffa` rewrapped the blocker-template cards as `<div class="faz-template-card"><button class="faz-template-card-action">` for the "not applied" badge, so the spec `#faz-blocker-templates > button` matched nothing and reported `Expected 1, Received 0` against a UI behaving correctly. Now anchored on the action class rather than the DOM shape.

### Verification
`pr-regression.spec.ts` + `settings-options-behavior.spec.ts`: **33 passed, 0 failed**. `scan-catalog-deep:728` and `v170-deep-flows:169` pass individually.

`pr-regression:161` still fails when run alone and always would — that block is `mode: 'serial'` and the test opens with `expect(cookieId).toBeTruthy()`, where `cookieId` is created by an earlier test. Measuring it in isolation cannot work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Migliorata la gestione del salvataggio dei cookie: le modifiche multilingue a descrizione e durata vengono ora preservate correttamente.
* **Test**
  * Aggiornati i test dei flussi principali per riconoscere in modo più affidabile le azioni nei template dei blocchi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->