### PR TITLE
Put the translators comment where the sniff looks for it

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -2376,7 +2376,8 @@ class Frontend {
 				// reuses the text the template already rendered (translated), but
 				// falls back when that element is empty — which happened, and put
 				// an English sentence under an Italian success message on a
-				// non-English site. translators: %d is a number of seconds.
+				// non-English site.
+				// translators: %d is a number of seconds.
 				'optout_autoclose_countdown'            => sprintf( __( 'Banner closes automatically in %d s...', 'faz-cookie-manager' ), 0 ),
 			),
 			'_rtl'          => $this->is_rtl(),


### PR DESCRIPTION
One Plugin Check ERROR on a gate that requires zero.

`WordPress.WP.I18n.MissingTranslatorsComment` wants the note on the line **directly above** the `__()` call. Mine was the closing sentence of a five-line explanatory block — perfectly readable to a human, invisible to the sniff.