### PR TITLE
Revive the per-service edge-case suite that sat unmerged since June

### DIFF
--- a/tests/e2e/specs/per-service-edge-suite.spec.ts
+++ b/tests/e2e/specs/per-service-edge-suite.spec.ts
@@ -1,0 +1,261 @@
+import { test, expect } from '../fixtures/wp-fixture';
+import type { BrowserContext, Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { clickFirstVisible } from '../utils/ui';
+import { WP_PATH } from '../utils/wp-env';
+
+/**
+ * Per-service consent — EDGE-CASE integration suite (reusable).
+ *
+ * Fills gaps the existing per-service specs don't cover, with two "particular
+ * service" scenarios that exercise real server blocking + runtime reveal +
+ * enforcement end-to-end:
+ *
+ *   A. youtube-nocookie.com — the privacy-friendly YouTube domain. It is a
+ *      DISTINCT pattern ("youtube-nocookie.com/embed") that must still resolve
+ *      to the single "youtube" service: blocked into a placeholder, revealed as
+ *      one toggle, and unblocked by a youtube consent. A boundary/alias bug here
+ *      would silently leak the embed (the youtube.com vs youtube-nocookie.com
+ *      boundary is unit-guarded in test-per-service-gateway-boundary-php.php and
+ *      tests/unit/js/per-service-boundary-ckkey.test.mjs; this is the live proof).
+ *
+ *   B. Multiple embeds of the SAME provider on one page — each iframe must be
+ *      blocked independently (not just the first), reveal a single shared
+ *      toggle, and ALL unblock together when the service is consented. A
+ *      "first-match-only" blocking bug would leave later embeds live before
+ *      consent.
+ *
+ * Determinism: every test seeds the `fazcookie-consent` cookie (addCookies)
+ * with the live revision and asserts the resulting DOM — no flaky UI save flow.
+ * Self-contained: pages are created in beforeAll and deleted in afterAll;
+ * per_service_consent is enabled in beforeAll and the original settings restored
+ * in afterAll. Safe to run in isolation or as part of the full suite.
+ */
+
+const NOCOOKIE = 'https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ';
+const YT_A = 'https://www.youtube.com/embed/M7lc1UVf-VE';
+const YT_B = 'https://www.youtube.com/embed/dQw4w9WgXcQ';
+
+function wp(args: string[]): string {
+  return execFileSync('wp', [`--path=${WP_PATH}`, ...args], { encoding: 'utf8' }).trim();
+}
+
+function wpEval(php: string): string {
+  return execFileSync('wp', [`--path=${WP_PATH}`, 'eval', php], { encoding: 'utf8' }).trim();
+}
+
+/** `wp post create --porcelain` should print only the new ID; fail loudly otherwise. */
+function wpCreatePostId(args: string[]): string {
+  const rawId = wp(args);
+  if (!/^\d+$/.test(rawId)) {
+    throw new Error(`Expected a numeric post ID from "wp post create", got: ${JSON.stringify(rawId)}`);
+  }
+  return rawId;
+}
+
+type FazSettings = Record<string, unknown>;
+
+async function getAdminNonce(page: Page): Promise<string> {
+  return page.evaluate(() => window.fazConfig?.api?.nonce ?? '');
+}
+async function getSettings(page: Page, nonce: string): Promise<FazSettings> {
+  const res = await page.request.get('/?rest_route=/faz/v1/settings/', { headers: { 'X-WP-Nonce': nonce } });
+  expect(res.status()).toBe(200);
+  return (await res.json()) as FazSettings;
+}
+async function postSettings(page: Page, nonce: string, payload: FazSettings): Promise<void> {
+  const res = await page.request.post('/?rest_route=/faz/v1/settings/', {
+    headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
+    data: payload,
+  });
+  expect(res.status(), `settings update status ${res.status()}`).toBe(200);
+}
+
+async function seedConsent(ctx: BrowserContext, url: string, value: string): Promise<void> {
+  await ctx.addCookies([{ name: 'fazcookie-consent', value, url, sameSite: 'Lax' }]);
+}
+
+async function openPreferenceCenter(page: Page): Promise<void> {
+  const opened = await clickFirstVisible(page, [
+    '[data-faz-tag="settings-button"] button',
+    '[data-faz-tag="settings-button"]',
+    '.faz-btn-customize',
+  ]);
+  expect(opened, 'preference-center button is reachable').toBeTruthy();
+  await expect(page.locator('[data-faz-tag="detail"]')).toBeVisible({ timeout: 5000 });
+}
+
+async function waitFazReady(page: Page): Promise<void> {
+  await page.waitForFunction(() => document.documentElement.classList.contains('faz-ready'), { timeout: 8000 });
+}
+
+test.describe('Per-service consent — edge cases (nocookie alias + multi-embed)', () => {
+  test.skip(!WP_PATH, 'requires WP_PATH to toggle settings + seed pages via wp-cli');
+  test.describe.configure({ mode: 'serial' });
+
+  let original: FazSettings | null = null;
+  let nonce = '';
+  let rev = '1';
+  let nocookieUrl = '';
+  let nocookiePostId = '';
+  let multiUrl = '';
+  let multiPostId = '';
+
+  test.beforeAll(async ({ browser, loginAsAdmin }) => {
+    const page = await browser.newPage();
+    await loginAsAdmin(page);
+    await page.goto('/wp-admin/admin.php?page=faz-cookie-manager-settings', { waitUntil: 'domcontentloaded' });
+    nonce = await getAdminNonce(page);
+    expect(nonce.length).toBeGreaterThan(0);
+    original = await getSettings(page, nonce);
+    const bc = { ...(original.banner_control as Record<string, unknown> | undefined) };
+    await postSettings(page, nonce, { banner_control: { ...bc, per_service_consent: true } });
+    await page.close();
+
+    rev = wpEval('echo faz_get_consent_revision();').trim() || '1';
+
+    // A page with a single youtube-nocookie.com embed.
+    nocookiePostId = wpCreatePostId([
+      'post', 'create', '--post_type=page', '--post_status=publish',
+      '--post_title=FAZ E2E nocookie embed',
+      `--post_content=<iframe width="560" height="315" src="${NOCOOKIE}" title="YouTube nocookie"></iframe>`,
+      '--porcelain',
+    ]);
+    nocookieUrl = wp(['post', 'get', nocookiePostId, '--field=url']);
+
+    // A page with TWO distinct youtube.com embeds (same provider).
+    multiPostId = wpCreatePostId([
+      'post', 'create', '--post_type=page', '--post_status=publish',
+      '--post_title=FAZ E2E multi youtube',
+      `--post_content=<iframe width="560" height="315" src="${YT_A}" title="A"></iframe><p>between</p><iframe width="560" height="315" src="${YT_B}" title="B"></iframe>`,
+      '--porcelain',
+    ]);
+    multiUrl = wp(['post', 'get', multiPostId, '--field=url']);
+
+    // Warm both pages so the first real assertion isn't racing a cold cache.
+    const warm = await browser.newContext();
+    const wpg = await warm.newPage();
+    for (const u of [nocookieUrl, multiUrl]) {
+      await wpg.goto(u, { waitUntil: 'domcontentloaded' }).catch(() => {});
+      await wpg.waitForFunction(() => document.documentElement.classList.contains('faz-ready'), { timeout: 20000 }).catch(() => {});
+    }
+    await warm.close();
+  });
+
+  test.afterAll(async ({ browser, loginAsAdmin }) => {
+    if (nocookiePostId) wp(['post', 'delete', nocookiePostId, '--force']);
+    if (multiPostId) wp(['post', 'delete', multiPostId, '--force']);
+    if (!original?.banner_control) return;
+    const page = await browser.newPage();
+    await loginAsAdmin(page);
+    await page.goto('/wp-admin/admin.php?page=faz-cookie-manager-settings', { waitUntil: 'domcontentloaded' });
+    const n = await getAdminNonce(page);
+    await postSettings(page, n, { banner_control: original.banner_control as FazSettings });
+    await page.close();
+  });
+
+  // ── A. youtube-nocookie.com alias ──────────────────────────────────────
+
+  test('A1 nocookie embed is blocked into a placeholder before consent', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(nocookieUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    // The live nocookie iframe is gone, replaced by a youtube placeholder.
+    expect(await page.locator('iframe[src*="youtube-nocookie.com"]').count()).toBe(0);
+    expect(await page.locator('.faz-placeholder[data-faz-service="youtube"]').count()).toBeGreaterThan(0);
+    await ctx.close();
+  });
+
+  test('A2 nocookie embed reveals exactly one youtube toggle in the preference center', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(nocookieUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    await openPreferenceCenter(page);
+    // The distinct nocookie pattern resolves to the single "youtube" service.
+    const inServices = await page.evaluate(
+      () => (window as unknown as { _fazConfig?: { _services?: Array<{ id?: string }> } })._fazConfig?._services?.some((s) => s && s.id === 'youtube') ?? false,
+    );
+    expect(inServices).toBe(true);
+    expect(await page.locator('.faz-service-toggle[data-service="youtube"]').count()).toBe(1);
+    await ctx.close();
+  });
+
+  test('A3 nocookie embed goes live when youtube is consented (marketing:yes)', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    await seedConsent(ctx, nocookieUrl, `action:yes,necessary:yes,marketing:yes,rev:${rev}`);
+    const page = await ctx.newPage();
+    await page.goto(nocookieUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    await expect.poll(() => page.locator('iframe[src*="youtube-nocookie.com"]').count(), { timeout: 8000 }).toBeGreaterThan(0);
+    await ctx.close();
+  });
+
+  test('A4 nocookie embed stays blocked under reject-all (marketing:no)', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    await seedConsent(ctx, nocookieUrl, `action:yes,necessary:yes,marketing:no,rev:${rev}`);
+    const page = await ctx.newPage();
+    await page.goto(nocookieUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    expect(await page.locator('iframe[src*="youtube-nocookie.com"]').count()).toBe(0);
+    expect(await page.locator('.faz-placeholder[data-faz-service="youtube"]').count()).toBeGreaterThan(0);
+    await ctx.close();
+  });
+
+  test('A5 a granular svc.youtube:yes unblocks the nocookie embed under a denied category', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    await seedConsent(ctx, nocookieUrl, `action:yes,necessary:yes,marketing:no,rev:${rev},svc.youtube:yes`);
+    const page = await ctx.newPage();
+    await page.goto(nocookieUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    await expect.poll(() => page.locator('iframe[src*="youtube-nocookie.com"]').count(), { timeout: 8000 }).toBeGreaterThan(0);
+    await ctx.close();
+  });
+
+  // ── B. Multiple embeds of the same provider ────────────────────────────
+
+  test('B1 both same-provider embeds are blocked independently before consent', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(multiUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    // Neither live iframe survives; BOTH are placeholdered (not just the first).
+    expect(await page.locator('iframe[src*="youtube.com/embed"]').count()).toBe(0);
+    expect(await page.locator('.faz-placeholder[data-faz-service="youtube"]').count()).toBe(2);
+    await ctx.close();
+  });
+
+  test('B2 the two embeds reveal a single shared youtube toggle (no duplicate)', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(multiUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    await openPreferenceCenter(page);
+    // One service, one toggle — two embeds must not produce two toggles.
+    expect(await page.locator('.faz-service-toggle[data-service="youtube"]').count()).toBe(1);
+    await ctx.close();
+  });
+
+  test('B3 both same-provider embeds go live together when youtube is consented', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    await seedConsent(ctx, multiUrl, `action:yes,necessary:yes,marketing:no,rev:${rev},svc.youtube:yes`);
+    const page = await ctx.newPage();
+    await page.goto(multiUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    // ALL instances unblock — a "first-match-only" restore bug would leave one blocked.
+    await expect.poll(() => page.locator('iframe[src*="youtube.com/embed"]').count(), { timeout: 8000 }).toBe(2);
+    await ctx.close();
+  });
+
+  test('B4 both same-provider embeds stay blocked under reject-all', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    await seedConsent(ctx, multiUrl, `action:yes,necessary:yes,marketing:no,rev:${rev}`);
+    const page = await ctx.newPage();
+    await page.goto(multiUrl, { waitUntil: 'domcontentloaded' });
+    await waitFazReady(page);
+    expect(await page.locator('iframe[src*="youtube.com/embed"]').count()).toBe(0);
+    expect(await page.locator('.faz-placeholder[data-faz-service="youtube"]').count()).toBe(2);
+    await ctx.close();
+  });
+});

--- a/tests/unit/js/per-service-boundary-ckkey.test.mjs
+++ b/tests/unit/js/per-service-boundary-ckkey.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * JS unit test (jsdom) — parity guards for two pure per-service helpers in
+ * frontend/js/script.js whose logic is duplicated on the PHP server side:
+ *
+ *   - _fazCkKey()              mirror of Frontend::ck_escape_cookie_name()
+ *   - _fazHasProviderBoundary() mirror of Frontend::has_provider_boundary()
+ *
+ * Why parity matters: the boundary delimiter sets and the ck.* escaping order
+ * MUST be byte-identical between PHP and JS, otherwise a cookie blocked on the
+ * client is shredded under a different key on the server (or a provider matched
+ * client-side is missed server-side). The PHP side is asserted in
+ * tests/unit/test-per-service-gateway-boundary-php.php and
+ * tests/unit/test-percookie-php.php; this file pins the JS side to the SAME
+ * expected outputs so a one-sided edit fails loudly.
+ *
+ * The test loads the REAL shipped script.js (source of truth), neutralising only
+ * its DOMContentLoaded auto-bootstrap so _fazInit() never runs. Both helpers are
+ * pure (no store / DOM dependency) and hoist to global scope as Annex-B
+ * block-scoped function declarations in the sloppy-mode classic script.
+ *
+ * Run: node tests/unit/js/per-service-boundary-ckkey.test.mjs   (npm run test:unit:js)
+ */
+
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = resolve(HERE, '../../../frontend/js/script.js');
+
+let passed = 0;
+let failed = 0;
+function eq(label, actual, expected) {
+  if (actual === expected) {
+    passed += 1;
+    console.log(`  \x1b[32mPASS\x1b[0m ${label}`);
+  } else {
+    failed += 1;
+    console.log(`  \x1b[31mFAIL\x1b[0m ${label}`);
+    console.log(`       expected: ${JSON.stringify(expected)}`);
+    console.log(`       actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+/** Load script.js in jsdom with its DOMContentLoaded bootstrap neutralised. */
+function loadFrontend() {
+  const code = readFileSync(SCRIPT_PATH, 'utf8');
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    runScripts: 'outside-only',
+    url: 'http://localhost/',
+  });
+  const { window } = dom;
+  // Minimal config so script.js eval doesn't throw; these helpers don't use it.
+  window._fazConfig = { _categories: [], _services: [], i18n: {} };
+  const realAdd = window.document.addEventListener.bind(window.document);
+  window.document.addEventListener = (type, ...rest) => {
+    if (type === 'DOMContentLoaded') return undefined;
+    return realAdd(type, ...rest);
+  };
+  window.eval(code);
+  window.document.addEventListener = realAdd;
+  return window;
+}
+
+console.log('per-service ck.* escaping + provider boundary parity (jsdom)');
+
+const w = loadFrontend();
+const ckKey = (s, c) => w.eval(`_fazCkKey(${JSON.stringify(s)}, ${JSON.stringify(c)})`);
+const boundary = (t, i, l) => w.eval(`_fazHasProviderBoundary(${JSON.stringify(t)}, ${i}, ${l})`);
+
+// ---------------------------------------------------------------------------
+// _fazCkKey() — must match Frontend::ck_escape_cookie_name() exactly.
+// ---------------------------------------------------------------------------
+console.log('\n_fazCkKey()');
+eq('plain name unchanged', ckKey('youtube', 'YSC'), 'ck.youtube.YSC');
+eq('colon -> %3A', ckKey('x', 'a:b'), 'ck.x.a%3Ab');
+eq('comma -> %2C', ckKey('x', 'a,b'), 'ck.x.a%2Cb');
+eq('percent -> %25', ckKey('x', 'a%b'), 'ck.x.a%25b');
+// Percent must be escaped FIRST; a literal "%3A" must become "%253A", not "%3A".
+eq('literal %3A double-escapes (percent first)', ckKey('x', '%3A'), 'ck.x.%253A');
+// Dots are NOT escaped — parity with the PHP _pk_id.1 case in test-percookie-php.
+eq('dotted cookie name keeps its dots', ckKey('matomo', '_pk_id.1'), 'ck.matomo._pk_id.1');
+
+// ---------------------------------------------------------------------------
+// _fazHasProviderBoundary(target, index, length) — mirror of PHP boundary set.
+// Indices below are the real offsets of the pattern inside the target string.
+// ---------------------------------------------------------------------------
+console.log('\n_fazHasProviderBoundary()');
+// "https://www.youtube.com/embed" — "youtube.com" at index 12, len 11.
+// before '.', after '/'  → boundary present.
+eq('real youtube embed: . before, / after → true', boundary('https://www.youtube.com/embed', 12, 11), true);
+// "https://notyoutube.com/x" — "youtube.com" at index 11; char before is 't'.
+eq('notyoutube.com: t before → false', boundary('https://notyoutube.com/x', 11, 11), false);
+// "connect.facebook.net" — "facebook.net" at index 8, len 12; match ends at EOS.
+eq('end-of-string after-guard skipped → true', boundary('connect.facebook.net', 8, 12), true);
+// "xfacebook.net" — "facebook.net" at index 1; char before is 'x'.
+eq('xfacebook.net: x before → false', boundary('xfacebook.net', 1, 12), false);
+// "youtube.com/embed" — pattern at index 0; before-guard skipped, after '/'.
+eq('index 0 before-guard skipped, / after → true', boundary('youtube.com/embed', 0, 11), true);
+// "youtube-nocookie.com" — if "youtube.com" were (wrongly) located here, the
+// char after would be a domain char; assert a non-boundary after rejects.
+eq('non-boundary after char (letter) → false', boundary('ayoutube.comX', 1, 11), false);
+
+console.log(`\n${failed === 0 ? '\x1b[32m' : '\x1b[31m'}${passed} passed, ${failed} failed\x1b[0m`);
+process.exit(failed === 0 ? 0 : 1);

--- a/tests/unit/test-per-service-gateway-boundary-php.php
+++ b/tests/unit/test-per-service-gateway-boundary-php.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Standalone unit tests for the per-service GATEWAY exemption and provider URL
+ * BOUNDARY matching (server side).
+ *
+ * Subsystem: per-service-gateway-boundary-php
+ *
+ * These two pure helpers guard two launch-critical correctness properties that
+ * are NOT covered elsewhere:
+ *
+ *   - Frontend::is_always_allowed_gateway_pattern()
+ *       A payment-gateway provider (Stripe) must stay exempt from blocking /
+ *       shredding so checkout keeps working, WITHOUT a short or unrelated
+ *       custom pattern accidentally exempting itself (false-positive guard).
+ *
+ *   - Frontend::provider_url_pattern_matches() / has_provider_boundary()
+ *       A provider pattern must match only at a real token boundary, so
+ *       "youtube.com" never matches inside "notyoutube.com" and
+ *       "facebook.net" never matches inside "fakefacebook.net". This PHP set is
+ *       the mirror of the JS _fazHasProviderBoundary (see the jsdom parity test
+ *       tests/unit/js/per-service-boundary-ckkey.test.mjs).
+ *
+ * Pure-logic tests: no browser, DB, or live WordPress. The Frontend object is
+ * built with ReflectionClass::newInstanceWithoutConstructor() and the private
+ * methods are invoked via reflection (same pattern as test-percookie-php.php).
+ *
+ * Run from project root:
+ *   php tests/unit/test-per-service-gateway-boundary-php.php
+ *
+ * Exit code 0 = all tests pass; 1 = at least one failure.
+ *
+ * @package FazCookie\Tests\Unit
+ */
+
+namespace FazCookie\Includes {
+
+	class Known_Providers {
+		public static function get_all() {
+			return array();
+		}
+		public static function get_cookie_map() {
+			return array();
+		}
+		public static function get_pattern_map() {
+			return array();
+		}
+	}
+}
+
+namespace {
+
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', __DIR__ . '/' );
+	}
+	if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+		define( 'HOUR_IN_SECONDS', 3600 );
+	}
+
+	if ( ! function_exists( 'wp_strip_all_tags' ) ) {
+		function wp_strip_all_tags( $str ) {
+			return trim( preg_replace( '/<[^>]*>/', '', (string) $str ) );
+		}
+	}
+	if ( ! function_exists( 'sanitize_text_field' ) ) {
+		function sanitize_text_field( $str ) {
+			$str = (string) $str;
+			$str = preg_replace( '/[\r\n\t ]+/', ' ', $str );
+			return trim( wp_strip_all_tags( $str ) );
+		}
+	}
+	if ( ! function_exists( 'sanitize_key' ) ) {
+		function sanitize_key( $key ) {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+		}
+	}
+	if ( ! function_exists( 'apply_filters' ) ) {
+		function apply_filters( $tag, $value ) {
+			return $value;
+		}
+	}
+
+	if ( ! class_exists( 'FazTest_WPDB' ) ) {
+		class FazTest_WPDB {
+			public $prefix = 'wp_';
+			public function get_col( $query ) {
+				return array();
+			}
+		}
+	}
+	$GLOBALS['wpdb'] = new FazTest_WPDB();
+
+	require_once dirname( __DIR__, 2 ) . '/frontend/class-frontend.php';
+
+	use FazCookie\Frontend\Frontend;
+
+	$tests_run    = 0;
+	$tests_passed = 0;
+	$tests_failed = 0;
+
+	function assert_eq( $actual, $expected, $label ) {
+		global $tests_run, $tests_passed, $tests_failed;
+		$tests_run++;
+		if ( $actual === $expected ) {
+			$tests_passed++;
+			echo "  \033[32m✓\033[0m " . $label . "\n";
+		} else {
+			$tests_failed++;
+			echo "  \033[31m✗\033[0m " . $label . "\n";
+			echo '      expected: ' . var_export( $expected, true ) . "\n";
+			echo '      actual:   ' . var_export( $actual, true ) . "\n";
+		}
+	}
+
+	function faz_new_frontend() {
+		$rc = new ReflectionClass( Frontend::class );
+		return $rc->newInstanceWithoutConstructor();
+	}
+
+	function faz_call( $fe, $method, array $args = array() ) {
+		$m = new ReflectionMethod( Frontend::class, $method );
+		$m->setAccessible( true );
+		return $m->invokeArgs( $fe, $args );
+	}
+
+	echo "\n\033[1mPer-service gateway exemption + provider URL boundary\033[0m\n\n";
+	$fe = faz_new_frontend();
+
+	// ---------------------------------------------------------------------
+	// is_always_allowed_gateway_pattern(): Stripe stays exempt, unrelated /
+	// short patterns must NOT silently exempt themselves.
+	// ---------------------------------------------------------------------
+	echo "is_always_allowed_gateway_pattern()\n";
+	$gw = function ( $pattern ) use ( $fe ) {
+		return faz_call( $fe, 'is_always_allowed_gateway_pattern', array( $pattern ) );
+	};
+
+	// Stripe's own provider patterns must be exempt (checkout must keep working).
+	assert_eq( $gw( 'js.stripe.com' ), true, 'exact gateway token js.stripe.com is exempt' );
+	assert_eq( $gw( 'wc-stripe-blocks' ), true, 'forward match: pattern containing wc-stripe- is exempt' );
+	// Reverse match: a provider pattern that is itself a substring of a gateway
+	// token (>= 4 chars) is exempt — "stripe.com" lives inside "js.stripe.com".
+	assert_eq( $gw( 'stripe.com' ), true, 'reverse match: stripe.com (inside js.stripe.com) is exempt' );
+
+	// False-positive guards — the launch risk: an unrelated/custom provider must
+	// NOT inherit Stripe's exemption and skip blocking/shredding.
+	assert_eq( $gw( 'notstripe.example' ), false, 'unrelated provider notstripe.example is NOT exempt' );
+	assert_eq( $gw( 'analytics.example.com' ), false, 'unrelated analytics provider is NOT exempt' );
+	// 3-char needle is below the reverse-match minimum (4) even though "upe" is a
+	// substring of "stripe-upe": a generic 3-char pattern must never exempt.
+	assert_eq( $gw( 'upe' ), false, 'short 3-char pattern (upe) does NOT exempt despite being inside stripe-upe' );
+	assert_eq( $gw( '' ), false, 'empty pattern is never exempt' );
+
+	// ---------------------------------------------------------------------
+	// provider_url_pattern_matches(): match only at real token boundaries.
+	// Mirror of JS _fazHasProviderBoundary (jsdom parity test).
+	// ---------------------------------------------------------------------
+	echo "\nprovider_url_pattern_matches()\n";
+	$m = function ( $target, $pattern ) use ( $fe ) {
+		return faz_call( $fe, 'provider_url_pattern_matches', array( $target, $pattern ) );
+	};
+
+	// Legitimate matches.
+	assert_eq( $m( 'https://www.youtube.com/embed/abc', 'youtube.com' ), true, 'youtube.com matches in a real youtube embed URL' );
+	assert_eq( $m( 'https://accounts.youtube.com/login', 'youtube.com' ), true, 'youtube.com matches a sub-domain host' );
+	assert_eq( $m( 'connect.facebook.net/en_US/fbevents.js', 'facebook.net' ), true, 'facebook.net matches in a pixel URL' );
+	assert_eq( $m( 'connect.facebook.net', 'facebook.net' ), true, 'match at end-of-string (after-guard skipped) is allowed' );
+
+	// False positives that MUST be rejected (the whole point of boundary checks).
+	assert_eq( $m( 'https://notyoutube.com/evil', 'youtube.com' ), false, 'youtube.com is NOT matched inside notyoutube.com' );
+	assert_eq( $m( 'https://fakefacebook.net/evil', 'facebook.net' ), false, 'facebook.net is NOT matched inside fakefacebook.net' );
+	// youtube-nocookie.com does not literally contain "youtube.com" → no match;
+	// and the dedicated youtube-nocookie.com pattern matches it correctly.
+	assert_eq( $m( 'https://www.youtube-nocookie.com/embed/abc', 'youtube.com' ), false, 'youtube.com does NOT match a youtube-nocookie.com URL' );
+	assert_eq( $m( 'https://www.youtube-nocookie.com/embed/abc', 'youtube-nocookie.com' ), true, 'youtube-nocookie.com matches its own URL' );
+
+	echo "\n";
+	if ( $tests_failed > 0 ) {
+		echo "\033[31m✗ {$tests_failed} failed\033[0m, {$tests_passed} passed ({$tests_run} total)\n";
+		exit( 1 );
+	}
+	echo "\033[32m✓ all {$tests_passed} passed\033[0m ({$tests_run} total)\n";
+	exit( 0 );
+}

--- a/tests/unit/test-per-service-gateway-boundary-php.php
+++ b/tests/unit/test-per-service-gateway-boundary-php.php
@@ -73,6 +73,23 @@ namespace {
 			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
 		}
 	}
+	// get_faz_settings() memoizes the raw option; that memoization arrived after
+	// this suite was written, so the harness has to supply the option it reads.
+	// The gateway map is what the assertions below turn on: which gateways the
+	// site has opted into loading before consent.
+	if ( ! function_exists( 'get_option' ) ) {
+		function get_option( $name, $default = false ) {
+			if ( 'faz_settings' === $name ) {
+				return array(
+					'script_blocking' => array(
+						'payment_gateways' => $GLOBALS['faz_test_gateways'] ?? array(),
+					),
+				);
+			}
+			return $default;
+		}
+	}
+
 	if ( ! function_exists( 'apply_filters' ) ) {
 		function apply_filters( $tag, $value ) {
 			return $value;
@@ -90,6 +107,10 @@ namespace {
 	$GLOBALS['wpdb'] = new FazTest_WPDB();
 
 	require_once dirname( __DIR__, 2 ) . '/frontend/class-frontend.php';
+	// The gateway map is read through faz_sanitize_bool_strict(), so the real
+	// helper is loaded rather than stubbed: a stub here would let the string
+	// 'false' pass as true, which is exactly the defect that helper exists for.
+	require_once dirname( __DIR__, 2 ) . '/includes/class-formatting.php';
 
 	use FazCookie\Frontend\Frontend;
 
@@ -130,6 +151,18 @@ namespace {
 	// short patterns must NOT silently exempt themselves.
 	// ---------------------------------------------------------------------
 	echo "is_always_allowed_gateway_pattern()\n";
+	$gw = function ( $pattern ) use ( $fe ) {
+		return faz_call( $fe, 'is_always_allowed_gateway_pattern', array( $pattern ) );
+	};
+
+	// Stripe has to be OPTED IN before any of its patterns are exempt. Since
+	// 1.24.0 the gateway exemption is per gateway and defaults to OFF: loading a
+	// payment SDK before consent is an explicit admin decision, not automatic.
+	// This suite predates that change and assumed Stripe was always exempt, so
+	// the opt-in is what it was missing — the boundary rules it checks below are
+	// unchanged and still worth pinning.
+	$GLOBALS['faz_test_gateways'] = array( 'stripe' => true );
+	$fe = faz_new_frontend();
 	$gw = function ( $pattern ) use ( $fe ) {
 		return faz_call( $fe, 'is_always_allowed_gateway_pattern', array( $pattern ) );
 	};


### PR DESCRIPTION
550 lines of coverage on a branch nobody merged: gateway-exemption boundary rules, the per-cookie key parser, and an E2E suite for nocookie hosts and multi-embed pages. **None of it existed on `main`.**

Worth contrasting with `fix/bricks-video-leaflet-blocking`, deleted today: of its 261 added lines, **258 were already on `main`** and the remaining ones asserted a limitation `main` has since removed — merging it would have failed. This branch is the opposite case.

### What it needed
Three alignments where `main` moved and the harness did not:

- `get_faz_settings()` memoizes the raw option now, so the harness has to supply the option it reads.
- The gateway map is read through `faz_sanitize_bool_strict()`, so `includes/class-formatting.php` is **loaded rather than stubbed** — a stub would let the string `'false'` pass as true, which is the exact defect that helper exists for.
- Gateway exemption became **per-gateway opt-in, default OFF** in 1.24.0. The suite predates that and assumed Stripe was always exempt; it now opts in first. The boundary rules it pins are unchanged and still worth having: reverse match down to four characters, no exemption for a three-character needle, no false positive on `notstripe.example`.

### Verification
86/86 unit suites (was 84). `per-service-edge-suite.spec.ts`: 9 passed, 0 failed.