### PR TITLE
Map the Personalization category instead of dropping it

### DIFF
--- a/includes/class-cookie-definitions.php
+++ b/includes/class-cookie-definitions.php
@@ -52,11 +52,17 @@ class Cookie_Definitions {
 	 * @var array
 	 */
 	private static $category_map = array(
-		'necessary'  => 'necessary',
-		'functional' => 'functional',
-		'analytics'  => 'analytics',
-		'marketing'  => 'marketing',
-		'security'   => 'necessary',
+		'necessary'       => 'necessary',
+		'functional'      => 'functional',
+		'analytics'       => 'analytics',
+		'marketing'       => 'marketing',
+		'security'        => 'necessary',
+		// Google's taxonomy, not the GDPR one: personalization_storage is a
+		// Consent Mode v2 signal, and gcm.js already drives it from the
+		// functional category. Without this row the database's own
+		// "Personalization" entries fell through to uncategorized, so the same
+		// cookie was functional to Google and unclassified to the banner.
+		'personalization' => 'functional',
 	);
 
 	/**


### PR DESCRIPTION
The bundled database carries three Salesforce entries categorised `Personalization` — `sidebarPinned`, `waveUserPrefFinderLeftNav`, `waveUserPrefFinderListView`, all of which remember a UI choice. `$category_map` had no row for it, so they fell through to `uncategorized`.

The category is not GDPR vocabulary, which is why it looks foreign: **it is Google's.** `personalization_storage` is one of the seven Consent Mode v2 signals, and `gcm.js` already drives it from the functional category:

```js
frontend/js/gcm.js:152  personalization_storage: regionSetting.functional
frontend/js/gcm.js:273  personalization_storage: fazCat( cookieObj, "functional" )
```

So the plugin had already made this decision on the Google side and never told the lookup table — one cookie described two ways, functional to Google and unclassified in the banner.

Every category value the bundle uses is now mapped, with `Uncategorized` the sole intentional fall-through. 86/86 unit suites.