### PR TITLE
Definitions: a stale download no longer shadows a newer bundled snapshot

### DIFF
--- a/includes/class-cookie-definitions.php
+++ b/includes/class-cookie-definitions.php
@@ -29,6 +29,22 @@ class Cookie_Definitions {
 	const BUNDLED_DATA_FILE = 'includes/data/open-cookie-database.json';
 
 	/**
+	 * When the bundled snapshot's DATA was captured, in UTC.
+	 *
+	 * Deliberately not derived from the file's mtime. An unzip sets mtime to
+	 * whatever the extractor decides — usually the moment WordPress installed
+	 * the update — so mtime answers "when was this file written here", not
+	 * "how old is this data". The two differ by however long the release sat
+	 * on wordpress.org before a site took it, and the second question is the
+	 * one both the staleness check below and the admin screen are asking.
+	 *
+	 * MUST be updated whenever includes/data/open-cookie-database.json is
+	 * regenerated. tests/unit/test-bundled-definitions-date-php.php fails if
+	 * the file changes and this does not.
+	 */
+	const BUNDLED_DATA_DATE = '2026-08-14 09:36:46';
+
+	/**
 	 * WP option key where definitions are cached.
 	 */
 	const OPTION_KEY = 'faz_cookie_definitions';
@@ -206,7 +222,11 @@ class Cookie_Definitions {
 	 */
 	public function get_meta() {
 		$stored = get_option( self::OPTION_KEY, false );
-		if ( is_array( $stored ) && ! empty( $stored ) ) {
+		// Report the dataset the lookup actually uses. Describing the stored
+		// copy while get_runtime_data() answers from the bundle would put the
+		// wrong date and the wrong source on the one screen an admin consults
+		// to ask how old their definitions are.
+		if ( is_array( $stored ) && ! empty( $stored ) && ! $this->bundle_supersedes_stored() ) {
 			$meta = get_option( self::META_KEY, array() );
 			// Normalize legacy META_KEY entries that predate the 'source'
 			// field: without this, the UI branch that picks "downloaded"
@@ -388,11 +408,50 @@ class Cookie_Definitions {
 	 */
 	private function get_runtime_data() {
 		$stored = get_option( self::OPTION_KEY, array() );
-		if ( is_array( $stored ) && ! empty( $stored ) ) {
+		if ( is_array( $stored ) && ! empty( $stored ) && ! $this->bundle_supersedes_stored() ) {
 			return $stored;
 		}
 
 		return $this->get_bundled_data();
+	}
+
+	/**
+	 * Whether the bundled snapshot is newer than the downloaded copy.
+	 *
+	 * The stored option used to win unconditionally, and nothing ever revisited
+	 * it — no version check, no clearing on upgrade. That split installs in two:
+	 * a site that never pressed "Update definitions" got fresher data with every
+	 * plugin update, because each release ships a newer bundle; a site that
+	 * pressed it once was pinned to that instant forever, while newer bundles
+	 * shipped past it unused. The button offered as the cure for stale data was
+	 * the thing that made stale data permanent.
+	 *
+	 * Nothing is deleted. The verdict is taken at read time, so a later download
+	 * of a genuinely newer dataset wins again on its own.
+	 *
+	 * @return bool
+	 */
+	private function bundle_supersedes_stored() {
+		$meta       = get_option( self::META_KEY, array() );
+		$downloaded = is_array( $meta ) && ! empty( $meta['updated_at'] ) ? (string) $meta['updated_at'] : '';
+
+		// A stored copy with no date predates the versions that record one, so
+		// it is older than any bundle we could be shipping today.
+		if ( '' === $downloaded ) {
+			return true;
+		}
+
+		$downloaded_ts = strtotime( $downloaded );
+		if ( false === $downloaded_ts ) {
+			return true;
+		}
+
+		// update_definitions() stamps with current_time( 'mysql' ), i.e. site
+		// local time, against a UTC constant. The skew is under a day and the
+		// deltas this decides are weeks or months, so it does not matter here —
+		// worst case two datasets captured the same day resolve to the bundle,
+		// which is the same data.
+		return strtotime( self::BUNDLED_DATA_DATE ) > $downloaded_ts;
 	}
 
 	/**
@@ -446,7 +505,13 @@ class Cookie_Definitions {
 		// keyed by mtime+size instead of re-decoding 2.8 MB per admin screen.
 		$mtime       = (int) filemtime( $file );
 		$size        = (int) filesize( $file );
-		$fingerprint = $mtime . ':' . $size;
+		// The declared capture date is part of the key, not just the file's
+		// mtime and size. Without it a site that already cached this meta keeps
+		// serving the value computed by the previous code — which is how the
+		// old, filemtime-derived date survived this very change on a test site
+		// whose file rsync had left untouched. Any edit to BUNDLED_DATA_DATE
+		// now invalidates the cache by construction.
+		$fingerprint = $mtime . ':' . $size . ':' . self::BUNDLED_DATA_DATE;
 		$cached      = get_option( self::BUNDLED_META_KEY, false );
 		if (
 			is_array( $cached )
@@ -464,7 +529,10 @@ class Cookie_Definitions {
 
 		$meta = array(
 			'count'      => $this->count_definitions( $data ),
-			'updated_at' => gmdate( 'Y-m-d H:i:s', $mtime ),
+			// The capture date, not filemtime(): mtime is when the unzip wrote
+			// the file on this server, so the admin screen was reporting the
+			// install date of the update as the age of the data.
+			'updated_at' => self::BUNDLED_DATA_DATE,
 			'source'     => 'bundled',
 		);
 		update_option(

--- a/tests/unit/test-definitions-bundle-supersedes-php.php
+++ b/tests/unit/test-definitions-bundle-supersedes-php.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * A downloaded definitions copy used to shadow the bundled snapshot forever.
+ *
+ * get_runtime_data() returned the stored option whenever it was non-empty and
+ * nothing ever revisited it — no version check, no comparison, no clearing on
+ * upgrade. So pressing "Update definitions" once converted a site that refreshed
+ * with every plugin update into one pinned to that instant permanently.
+ *
+ * Run: php tests/unit/test-definitions-bundle-supersedes-php.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'FAZ_PLUGIN_BASEPATH', dirname( __DIR__, 2 ) . '/' );
+
+$GLOBALS['OPTS'] = array();
+function get_option( $k, $d = false ) {
+	return array_key_exists( $k, $GLOBALS['OPTS'] ) ? $GLOBALS['OPTS'][ $k ] : $d;
+}
+function update_option( $k, $v, $a = null ) {
+	$GLOBALS['OPTS'][ $k ] = $v;
+	return true;
+}
+function current_time( $t ) {
+	return gmdate( 'Y-m-d H:i:s' );
+}
+function sanitize_text_field( $s ) {
+	return $s;
+}
+function is_wp_error( $x ) {
+	return false;
+}
+
+require_once dirname( __DIR__, 2 ) . '/includes/class-cookie-definitions.php';
+
+use FazCookie\Includes\Cookie_Definitions;
+
+$ok = 0;
+$ko = 0;
+function t( $c, $l ) {
+	global $ok, $ko;
+	if ( $c ) {
+		++$ok;
+		echo "  PASS $l\n";
+	} else {
+		++$ko;
+		echo "  FAIL $l\n";
+	}
+}
+
+$bundle_date = Cookie_Definitions::BUNDLED_DATA_DATE;
+
+// Short-circuit get_bundled_meta()'s 2.5 MB decode by pre-seeding its cache
+// with the fingerprint it will compute. The bundle's CONTENT is irrelevant to
+// what is under test; only which dataset gets chosen is.
+$file = FAZ_PLUGIN_BASEPATH . 'includes/data/open-cookie-database.json';
+$seed_bundled_cache = function () use ( $file, $bundle_date ) {
+	$GLOBALS['OPTS']['faz_cookie_definitions_bundled_meta'] = array(
+		'fingerprint' => ( (int) filemtime( $file ) ) . ':' . ( (int) filesize( $file ) ) . ':' . $bundle_date,
+		'meta'        => array(
+			'count'      => 6754,
+			'updated_at' => $bundle_date,
+			'source'     => 'bundled',
+		),
+	);
+};
+
+$scenario = function ( $downloaded_at ) use ( $seed_bundled_cache ) {
+	$GLOBALS['OPTS'] = array();
+	$seed_bundled_cache();
+	// A non-empty stored dataset, shaped like the real one.
+	$GLOBALS['OPTS']['faz_cookie_definitions'] = array( 'example.com' => array( array( 'cookie' => '_x', 'category' => 'Analytics' ) ) );
+	$meta = array( 'count' => 1, 'source' => Cookie_Definitions::SOURCE_URL );
+	if ( null !== $downloaded_at ) {
+		$meta['updated_at'] = $downloaded_at;
+	}
+	$GLOBALS['OPTS']['faz_cookie_definitions_meta'] = $meta;
+	$defs = new Cookie_Definitions();
+	return $defs->get_meta();
+};
+
+echo "\nbundled snapshot captured: $bundle_date\n\n";
+
+// 1. The reported case: a download older than the shipped bundle. Before this
+//    change the stored copy won and kept winning, however many newer bundles
+//    arrived. The user whose list had been stuck since July is this row.
+$old = $scenario( '2026-07-01 10:00:00' );
+t( 'bundled' === $old['source'], 'a download OLDER than the bundle no longer wins' );
+t( $bundle_date === $old['updated_at'], 'and the reported date is the bundle\'s, not the stale one' );
+
+// 2. The other direction must still hold, or the fix would throw away genuinely
+//    fresher data — the failure mode of "just always prefer the bundle".
+$new = $scenario( gmdate( 'Y-m-d H:i:s', strtotime( $bundle_date ) + 86400 * 30 ) );
+t( Cookie_Definitions::SOURCE_URL === $new['source'], 'a download NEWER than the bundle still wins' );
+
+// 3. Legacy copies predate the versions that stamp a date, so they are old.
+$undated = $scenario( null );
+t( 'bundled' === $undated['source'], 'an undated legacy copy is treated as older' );
+
+// 4. A garbage date must not be read as "year zero beats everything" nor crash.
+$broken = $scenario( 'not a date' );
+t( 'bundled' === $broken['source'], 'an unparseable date falls back to the bundle' );
+
+// 5. No stored copy at all — the pre-existing path, which must be untouched.
+$GLOBALS['OPTS'] = array();
+$seed_bundled_cache();
+$fresh = ( new Cookie_Definitions() )->get_meta();
+t( 'bundled' === $fresh['source'], 'a fresh install still reads the bundle' );
+
+// 6. TRIPWIRE. BUNDLED_DATA_DATE is hand-maintained, and a constant that can
+//    silently drift from the file it describes is a future bug, not a fix. If
+//    the snapshot is regenerated without bumping the date, this goes red.
+$expected_sha = '0e3693aa951c0154933bb97d2636b86a';
+$actual_sha   = md5_file( $file );
+t(
+	$expected_sha === $actual_sha,
+	'the bundled JSON matches the hash this date was recorded for'
+	. ( $expected_sha === $actual_sha ? '' : "\n       the snapshot changed: set BUNDLED_DATA_DATE to its new capture date,\n       then update \$expected_sha here to $actual_sha" )
+);
+t( false !== strtotime( $bundle_date ), 'BUNDLED_DATA_DATE parses as a date' );
+
+echo "\ndefinitions bundle supersedes: $ok passed, $ko failed\n";
+exit( $ko > 0 ? 1 : 0 );


### PR DESCRIPTION
Refs #258, and inverts its premise.

#258 says the cookie definitions never auto-update after the first download, and asks for a weekly cron. Both halves turned out to be wrong. The plugin already bundles a 2.5 MB / 6,754-entry snapshot and already uses it as the fallback, so definitions **do** refresh — at release cadence, with zero outbound calls, because every plugin update ships a newer bundle.

What is broken is narrower and worse.

`get_runtime_data()` returned the stored option whenever it was non-empty and nothing ever revisited it. No version check, no date comparison, no clearing on upgrade — I looked for all three. That splits installs in two:

| site | what happens |
|---|---|
| never pressed "Update definitions" | fresh data with every plugin update |
| pressed it **once**, ever | pinned to that instant, permanently |

The button offered as the cure for stale definitions is the thing that makes staleness permanent, and the gap widens for as long as the site keeps running. A list "stuck since July" is that second row.

I reproduced it on a real install before changing anything: a one-entry copy dated July beat the 6,754-entry bundle sitting next to it.

## The fix needs no network

Which is the point — it takes the guideline question (see the discussion on #258) off the critical path entirely. `bundle_supersedes_stored()` compares capture dates and lets the bundle answer when it is newer. Nothing is deleted; the verdict is taken at read time, so a later download of genuinely newer data wins again on its own.

`get_meta()` takes the same verdict, because reporting the stored copy while the lookup answers from the bundle would put the wrong date and the wrong source on the one screen an admin opens to ask how old their data is.

## Why a constant rather than `filemtime()`

The bundled meta derived its date from `filemtime()`, which an unzip sets to the moment WordPress installed the update. That answers "when was this file written here", not "how old is this data" — and it was being shown to admins as the age of their definitions. `BUNDLED_DATA_DATE` now carries the real capture date, taken from the commit that last regenerated the snapshot.

A hand-maintained constant that can drift from the file it describes is a future bug, so the pairing is enforced: the test hashes the JSON and fails if it changes without the date being bumped, printing the new hash and the fix.

## What the end-to-end run caught and the unit tests could not

After deploying, the date still read the old mtime-derived value, because `get_bundled_meta()` caches on mtime+size and rsync had changed neither — so every existing site would have kept serving the value computed by the previous code. The declared date is now part of the cache key, so editing it invalidates the cache by construction. The unit tests seed that cache themselves and could never have found this.

## Tests

`tests/unit/test-definitions-bundle-supersedes-php.php`, 8 assertions.

Mutation-proved in **both** directions, which matters because the two failure modes are opposite: removing the comparison (pre-fix behaviour) turns 4 assertions red, and `return true` — the naive "always prefer the bundle", which throws away genuinely fresher data — turns the newer-download assertion red. A test checking only one direction would have passed both mistakes.

Verified on a real install rather than asserted: the July copy stops winning, the lookup table holds 5,862 exact entries from the bundle, and a probe cookie present only in the stale copy no longer resolves. Whole PHP unit suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Miglioramenti**
  - Le definizioni integrate nell’applicazione vengono ora utilizzate automaticamente quando risultano più aggiornate delle copie scaricate.
  - Le copie scaricate più recenti continuano a essere mantenute e utilizzate.
  - La data di aggiornamento visualizzata per i dati integrati riflette la data effettiva della loro acquisizione.

- **Test**
  - Aggiunti controlli per verificare la gestione di copie obsolete, mancanti, non datate o con date non valide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->