### PR TITLE
fix(scanner): a finished scan can no longer be resurrected (#245), and an accidental cookie classification (#243)

### DIFF
--- a/admin/modules/scanner/includes/class-controller.php
+++ b/admin/modules/scanner/includes/class-controller.php
@@ -547,6 +547,40 @@ class Controller {
 	 * @param string $scan_id Client-generated identifier used to isolate retries/tabs.
 	 * @return string|\WP_Error Opaque session token, or a conflict response.
 	 */
+
+	/**
+	 * Seconds a teardown tombstone survives.
+	 *
+	 * Only has to outlive requests that were already in flight when the crawl
+	 * ended. A minute is generous for that and short enough that a stale marker
+	 * cannot obstruct a genuinely new scan for long — and the new-scan path
+	 * clears it explicitly anyway.
+	 */
+	const BROWSER_SCAN_TOMBSTONE_TTL = 60;
+
+	/**
+	 * Close a session so late writers can tell it was closed.
+	 *
+	 * @param string $token   Session token.
+	 * @param int    $user_id Owning user.
+	 * @return void
+	 */
+	private static function tombstone_browser_scan_session( $token, $user_id ) {
+		$marker = array( 'faz_closed_at' => time() );
+		set_transient( self::browser_scan_transient_key( $token ), $marker, self::BROWSER_SCAN_TOMBSTONE_TTL );
+		set_transient( self::browser_scan_active_transient_key( (int) $user_id ), $marker, self::BROWSER_SCAN_TOMBSTONE_TTL );
+	}
+
+	/**
+	 * Whether a transient payload is a teardown tombstone rather than a session.
+	 *
+	 * @param mixed $value Transient payload.
+	 * @return bool
+	 */
+	private static function is_browser_scan_tombstone( $value ) {
+		return is_array( $value ) && ! empty( $value['faz_closed_at'] );
+	}
+
 	public function start_browser_scan_session( $scan_id = '' ) {
 		$user_id = get_current_user_id();
 		if ( $user_id <= 0 ) {
@@ -706,10 +740,35 @@ class Controller {
 		// crawl some tab is still driving from one nobody is. Written only after
 		// every ownership check above has passed.
 		$session['touched_at'] = time();
+
+		// Re-read immediately before writing. Everything above — ownership,
+		// token shape, max age — was decided from a copy that may be seconds
+		// old on a slow request, and a teardown can have landed in that gap.
+		// This is the last moment at which the write can still be abandoned,
+		// and abandoning it is what keeps a teardown final (#245).
+		//
+		// It narrows the window from "the whole validation block" to the gap
+		// between this read and the set_transient below; it does not close it.
+		// WordPress transients have no compare-and-swap, and the two storage
+		// backends they can sit on (options table, persistent object cache)
+		// have no primitive in common that would provide one. A residual
+		// microsecond window is worth stating rather than papering over: its
+		// cost is one stale lock that clears itself within the idle TTL, and
+		// #244's session panel lets an administrator end it immediately.
+		if ( self::is_browser_scan_tombstone( get_transient( $session_key ) ) ) {
+			return false;
+		}
 		set_transient( $session_key, $session, self::BROWSER_SCAN_TTL );
 
 		$active_key = self::browser_scan_active_transient_key( $user_id );
 		$active     = get_transient( $active_key );
+		if ( self::is_browser_scan_tombstone( $active ) ) {
+			// The per-user slot was closed while this request was in flight.
+			// Undo the session write above rather than leave half a resurrected
+			// session behind.
+			self::tombstone_browser_scan_session( $token, $user_id );
+			return false;
+		}
 		if ( ! is_array( $active ) ) {
 			$active = array( 'token' => $token, 'scan_id' => $scan_id, 'created_at' => $created_at );
 		}
@@ -858,8 +917,20 @@ class Controller {
 				delete_user_meta( $user_id, self::BROWSER_SCAN_META, $observation );
 			}
 		}
-		delete_transient( self::browser_scan_transient_key( $token ) );
-		delete_transient( self::browser_scan_active_transient_key( $user_id ) );
+		// A TOMBSTONE, not a delete. The touch path reads the session, validates
+		// it, and only then writes — so a request already in flight when this ran
+		// used to write the pre-teardown array back afterwards and resurrect a
+		// crawl nobody was driving. The next scan then met
+		// faz_browser_scan_in_progress for a session no tab owned, and the
+		// administrator waited out the idle TTL for a crawl that had finished
+		// (#245).
+		//
+		// Deleting cannot express "this was closed" — absence and "not yet
+		// created" are the same observation, so a late writer has nothing to
+		// detect. A closed marker can be detected, and it is not new storage:
+		// it lives in the transient the session already used, and expires on its
+		// own shortly after.
+		self::tombstone_browser_scan_session( $token, $user_id );
 		if ( ! headers_sent() ) {
 			setcookie(
 				self::BROWSER_SCAN_COOKIE,

--- a/admin/modules/scanner/includes/class-controller.php
+++ b/admin/modules/scanner/includes/class-controller.php
@@ -309,7 +309,7 @@ class Controller {
 		add_action(
 			'shutdown',
 			static function () use ( $token ) {
-				$session = get_transient( self::browser_scan_transient_key( $token ) );
+				$session = self::browser_scan_session_record( $token );
 				$user_id = get_current_user_id();
 				if ( ! is_array( $session ) || empty( $session['user_id'] ) || $user_id !== absint( $session['user_id'] ) ) {
 					return;
@@ -535,10 +535,71 @@ class Controller {
 		if ( ! preg_match( '/^[a-f0-9]{32}$/', $token ) ) {
 			return false;
 		}
-		$session = get_transient( self::browser_scan_transient_key( $token ) );
+		$session = self::browser_scan_session_record( $token );
 		return is_array( $session )
 			&& ! empty( $session['user_id'] )
 			&& get_current_user_id() === absint( $session['user_id'] );
+	}
+
+	/** Short-lived replacement payload for a closed session. */
+	const BROWSER_SCAN_TOMBSTONE_TTL = 60;
+
+	/**
+	 * Read concurrency-sensitive transients without a request-local snapshot.
+	 * Transients backed by options otherwise keep both values and negative
+	 * lookups in the options cache for the remainder of an in-flight request.
+	 */
+	private static function read_browser_scan_transient( $key ) {
+		if ( function_exists( 'wp_using_ext_object_cache' ) && wp_using_ext_object_cache() ) {
+			return wp_cache_get( $key, 'transient', true );
+		}
+		if ( function_exists( 'wp_cache_delete' ) ) {
+			wp_cache_delete( '_transient_' . $key, 'options' );
+			wp_cache_delete( '_transient_timeout_' . $key, 'options' );
+			wp_cache_delete( 'notoptions', 'options' );
+		}
+		return get_transient( $key );
+	}
+
+	/** A close record is token-specific and never overwritten by a renewal. */
+	private static function browser_scan_session_record( $token ) {
+		$key = self::browser_scan_transient_key( $token );
+		$session = self::read_browser_scan_transient( $key );
+		if ( ! is_array( $session ) || empty( $session['user_id'] )
+			|| self::read_browser_scan_transient( $key . '_closed' )
+			|| ( ! empty( $session['created_at'] ) && time() - absint( $session['created_at'] ) > self::BROWSER_SCAN_MAX_AGE ) ) {
+			return false;
+		}
+		return $session;
+	}
+
+	/** The per-user slot is an index; only its live session can hold the scan. */
+	private static function browser_scan_active_record( $user_id ) {
+		$active = self::read_browser_scan_transient( self::browser_scan_active_transient_key( $user_id ) );
+		if ( ! is_array( $active ) || empty( $active['token'] ) || empty( $active['scan_id'] ) ) {
+			return false;
+		}
+		$session = self::browser_scan_session_record( $active['token'] );
+		if ( ! $session || (int) $user_id !== absint( $session['user_id'] )
+			|| ! isset( $session['scan_id'] ) || ! hash_equals( (string) $active['scan_id'], (string) $session['scan_id'] ) ) {
+			return false;
+		}
+		$state = self::read_browser_scan_transient( self::browser_scan_transient_key( $active['token'] ) . '_held' );
+		if ( 'held' === $state || 'live' === $state ) {
+			$active['state'] = $state;
+		}
+		return $active;
+	}
+
+	/** Close only this token; never clear a successor's per-user index. */
+	private static function tombstone_browser_scan_session( $token, $user_id ) {
+		$key = self::browser_scan_transient_key( $token );
+		$marker = array( 'faz_closed_at' => time() );
+		// This separate record survives every possible renewal of the old
+		// payload, including a teardown between the last read and the write.
+		// Once it expires, the original created_at already exceeds MAX_AGE.
+		set_transient( $key . '_closed', $marker, self::BROWSER_SCAN_MAX_AGE + self::BROWSER_SCAN_TTL );
+		set_transient( $key, $marker, self::BROWSER_SCAN_TOMBSTONE_TTL );
 	}
 
 	/**
@@ -547,40 +608,6 @@ class Controller {
 	 * @param string $scan_id Client-generated identifier used to isolate retries/tabs.
 	 * @return string|\WP_Error Opaque session token, or a conflict response.
 	 */
-
-	/**
-	 * Seconds a teardown tombstone survives.
-	 *
-	 * Only has to outlive requests that were already in flight when the crawl
-	 * ended. A minute is generous for that and short enough that a stale marker
-	 * cannot obstruct a genuinely new scan for long — and the new-scan path
-	 * clears it explicitly anyway.
-	 */
-	const BROWSER_SCAN_TOMBSTONE_TTL = 60;
-
-	/**
-	 * Close a session so late writers can tell it was closed.
-	 *
-	 * @param string $token   Session token.
-	 * @param int    $user_id Owning user.
-	 * @return void
-	 */
-	private static function tombstone_browser_scan_session( $token, $user_id ) {
-		$marker = array( 'faz_closed_at' => time() );
-		set_transient( self::browser_scan_transient_key( $token ), $marker, self::BROWSER_SCAN_TOMBSTONE_TTL );
-		set_transient( self::browser_scan_active_transient_key( (int) $user_id ), $marker, self::BROWSER_SCAN_TOMBSTONE_TTL );
-	}
-
-	/**
-	 * Whether a transient payload is a teardown tombstone rather than a session.
-	 *
-	 * @param mixed $value Transient payload.
-	 * @return bool
-	 */
-	private static function is_browser_scan_tombstone( $value ) {
-		return is_array( $value ) && ! empty( $value['faz_closed_at'] );
-	}
-
 	public function start_browser_scan_session( $scan_id = '' ) {
 		$user_id = get_current_user_id();
 		if ( $user_id <= 0 ) {
@@ -592,7 +619,7 @@ class Controller {
 		}
 
 		$active_key = self::browser_scan_active_transient_key( $user_id );
-		$active     = get_transient( $active_key );
+		$active     = self::browser_scan_active_record( $user_id );
 		if ( is_array( $active ) && ! empty( $active['token'] ) && ! empty( $active['scan_id'] ) ) {
 			if ( ! hash_equals( (string) $active['scan_id'], $scan_id ) ) {
 				// A HELD session is evidence kept for a retry after an import
@@ -617,11 +644,6 @@ class Controller {
 			$token = sanitize_key( (string) $active['token'] );
 		} else {
 			$token = str_replace( '-', '', wp_generate_uuid4() );
-			set_transient(
-				$active_key,
-				array( 'token' => $token, 'scan_id' => $scan_id, 'created_at' => time() ),
-				self::BROWSER_SCAN_TTL
-			);
 		}
 
 		// created_at is the ABSOLUTE-age ceiling: touch_browser_scan_session()
@@ -632,7 +654,10 @@ class Controller {
 		// the same scan_id renewed the guarantee — and could revive a session
 		// that had already idled out. Carry the original forward; only a
 		// genuinely new session starts its clock now.
-		$existing_session = get_transient( self::browser_scan_transient_key( $token ) );
+		$existing_session = self::browser_scan_session_record( $token );
+		if ( $active && ! $existing_session ) {
+			return new \WP_Error( 'faz_browser_scan_expired', __( 'The browser scan session has expired.', 'faz-cookie-manager' ), array( 'status' => 409 ) );
+		}
 		$created_at       = ( is_array( $existing_session ) && ! empty( $existing_session['created_at'] ) )
 			? absint( $existing_session['created_at'] )
 			: time();
@@ -642,6 +667,18 @@ class Controller {
 			array( 'user_id' => $user_id, 'scan_id' => $scan_id, 'created_at' => $created_at, 'touched_at' => time() ),
 			self::BROWSER_SCAN_TTL
 		);
+
+		if ( ! self::browser_scan_session_record( $token ) ) {
+			return new \WP_Error( 'faz_browser_scan_expired', __( 'The browser scan session has expired.', 'faz-cookie-manager' ), array( 'status' => 409 ) );
+		}
+		if ( ! $active ) {
+			set_transient(
+				$active_key,
+				array( 'token' => $token, 'scan_id' => $scan_id, 'created_at' => $created_at ),
+				self::BROWSER_SCAN_MAX_AGE + self::BROWSER_SCAN_TTL
+			);
+		}
+		set_transient( self::browser_scan_transient_key( $token ) . '_held', 'live', self::BROWSER_SCAN_MAX_AGE + self::BROWSER_SCAN_TTL );
 
 		// Remove abandoned observations from expired scans without touching a
 		// still-live parallel session owned by the same administrator.
@@ -657,11 +694,11 @@ class Controller {
 	}
 
 	/**
-	 * (Re-)issue the httpOnly scan marker with a fresh window.
+	 * Issue the marker at start, bounded by the absolute capture lifetime.
 	 *
 	 * Kept in one place so the attributes — httpOnly, Secure on TLS,
 	 * SameSite=Strict, path=/ — stay byte-for-byte identical everywhere the
-	 * cookie is written. A renewal that quietly widened the scope or dropped
+	 * cookie is written. A change that quietly widened the scope or dropped
 	 * SameSite would be a silent security regression.
 	 *
 	 * @param string $token Session token to write.
@@ -675,7 +712,7 @@ class Controller {
 			self::BROWSER_SCAN_COOKIE,
 			$token,
 			array(
-				'expires'  => time() + self::BROWSER_SCAN_TTL,
+				'expires'  => time() + self::BROWSER_SCAN_MAX_AGE,
 				'path'     => '/',
 				'secure'   => is_ssl(),
 				'httponly' => true,
@@ -718,7 +755,7 @@ class Controller {
 		}
 
 		$session_key = self::browser_scan_transient_key( $token );
-		$session     = get_transient( $session_key );
+		$session     = self::browser_scan_session_record( $token );
 		$user_id     = get_current_user_id();
 		if ( ! is_array( $session )
 			|| empty( $session['user_id'] )
@@ -741,40 +778,17 @@ class Controller {
 		// every ownership check above has passed.
 		$session['touched_at'] = time();
 
-		// Re-read immediately before writing. Everything above — ownership,
-		// token shape, max age — was decided from a copy that may be seconds
-		// old on a slow request, and a teardown can have landed in that gap.
-		// This is the last moment at which the write can still be abandoned,
-		// and abandoning it is what keeps a teardown final (#245).
-		//
-		// It narrows the window from "the whole validation block" to the gap
-		// between this read and the set_transient below; it does not close it.
-		// WordPress transients have no compare-and-swap, and the two storage
-		// backends they can sit on (options table, persistent object cache)
-		// have no primitive in common that would provide one. A residual
-		// microsecond window is worth stating rather than papering over: its
-		// cost is one stale lock that clears itself within the idle TTL, and
-		// #244's session panel lets an administrator end it immediately.
-		if ( self::is_browser_scan_tombstone( get_transient( $session_key ) ) ) {
+		$active = self::browser_scan_active_record( $user_id );
+		if ( ! $active || ! hash_equals( (string) $active['token'], $token )
+			|| ! self::browser_scan_session_record( $token ) ) {
 			return false;
 		}
 		set_transient( $session_key, $session, self::BROWSER_SCAN_TTL );
-
-		$active_key = self::browser_scan_active_transient_key( $user_id );
-		$active     = get_transient( $active_key );
-		if ( self::is_browser_scan_tombstone( $active ) ) {
-			// The per-user slot was closed while this request was in flight.
-			// Undo the session write above rather than leave half a resurrected
-			// session behind.
-			self::tombstone_browser_scan_session( $token, $user_id );
+		// A concurrent close can follow the last read. Its independent marker
+		// still wins, and this heartbeat never writes a successor's index.
+		if ( ! self::browser_scan_session_record( $token ) ) {
 			return false;
 		}
-		if ( ! is_array( $active ) ) {
-			$active = array( 'token' => $token, 'scan_id' => $scan_id, 'created_at' => $created_at );
-		}
-		set_transient( $active_key, $active, self::BROWSER_SCAN_TTL );
-
-		$this->issue_browser_scan_cookie( $token );
 
 		return true;
 	}
@@ -796,7 +810,7 @@ class Controller {
 			return 'match';
 		}
 		$scan_id = sanitize_key( (string) $scan_id );
-		$active  = get_transient( self::browser_scan_active_transient_key( get_current_user_id() ) );
+		$active  = self::browser_scan_active_record( get_current_user_id() );
 		if ( is_array( $active ) && ! empty( $active['scan_id'] ) && ! hash_equals( (string) $active['scan_id'], $scan_id ) ) {
 			return 'conflict';
 		}
@@ -917,33 +931,11 @@ class Controller {
 				delete_user_meta( $user_id, self::BROWSER_SCAN_META, $observation );
 			}
 		}
-		// A TOMBSTONE, not a delete. The touch path reads the session, validates
-		// it, and only then writes — so a request already in flight when this ran
-		// used to write the pre-teardown array back afterwards and resurrect a
-		// crawl nobody was driving. The next scan then met
-		// faz_browser_scan_in_progress for a session no tab owned, and the
-		// administrator waited out the idle TTL for a crawl that had finished
-		// (#245).
-		//
-		// Deleting cannot express "this was closed" — absence and "not yet
-		// created" are the same observation, so a late writer has nothing to
-		// detect. A closed marker can be detected, and it is not new storage:
-		// it lives in the transient the session already used, and expires on its
-		// own shortly after.
+		// Revoke the token before replacing its renewable payload.
 		self::tombstone_browser_scan_session( $token, $user_id );
-		if ( ! headers_sent() ) {
-			setcookie(
-				self::BROWSER_SCAN_COOKIE,
-				'',
-				array(
-					'expires'  => time() - YEAR_IN_SECONDS,
-					'path'     => '/',
-					'secure'   => is_ssl(),
-					'httponly' => true,
-					'samesite' => 'Strict',
-				)
-			);
-		}
+		// Leave the cookie to expire: a delayed teardown response must not
+		// clear the marker a newer discover response has already installed.
+		// The revoked token cannot authorize capture or import.
 
 		return true;
 	}
@@ -960,7 +952,7 @@ class Controller {
 		}
 		$token   = sanitize_key( wp_unslash( (string) $_COOKIE[ self::BROWSER_SCAN_COOKIE ] ) );
 		$scan_id = sanitize_key( (string) $scan_id );
-		$session = get_transient( self::browser_scan_transient_key( $token ) );
+		$session = self::browser_scan_session_record( $token );
 		return preg_match( '/^[a-f0-9]{32}$/', $token )
 			&& preg_match( '/^[a-f0-9]{32}$/', $scan_id )
 			&& is_array( $session )
@@ -1000,7 +992,9 @@ class Controller {
 		if ( $user_id <= 0 || ! preg_match( '/^[a-f0-9]{32}$/', $scan_id ) ) {
 			return false;
 		}
-		$active = get_transient( self::browser_scan_active_transient_key( $user_id ) );
+		// Cleanup may release an expired token too. The raw index belongs to
+		// this user; discard revokes only its token and never edits the index.
+		$active = self::read_browser_scan_transient( self::browser_scan_active_transient_key( $user_id ) );
 		if ( ! is_array( $active )
 			|| empty( $active['token'] )
 			|| empty( $active['scan_id'] )
@@ -1034,12 +1028,12 @@ class Controller {
 		if ( $user_id <= 0 ) {
 			return $inactive;
 		}
-		$active = get_transient( self::browser_scan_active_transient_key( $user_id ) );
+		$active = self::browser_scan_active_record( $user_id );
 		if ( ! is_array( $active ) || empty( $active['token'] ) || empty( $active['scan_id'] ) ) {
 			return $inactive;
 		}
 		$token   = sanitize_key( (string) $active['token'] );
-		$session = get_transient( self::browser_scan_transient_key( $token ) );
+		$session = self::browser_scan_session_record( $token );
 		if ( ! is_array( $session ) || empty( $session['user_id'] ) || $user_id !== absint( $session['user_id'] ) ) {
 			// An active record whose session transient is gone blocks nothing
 			// (start_browser_scan_session would mint a fresh session), so
@@ -1165,24 +1159,18 @@ class Controller {
 			return false;
 		}
 
-		$user_id    = get_current_user_id();
-		$active_key = self::browser_scan_active_transient_key( $user_id );
-		$active     = get_transient( $active_key );
-		if ( ! is_array( $active ) ) {
+		$user_id = get_current_user_id();
+		$token = sanitize_key( wp_unslash( (string) $_COOKIE[ self::BROWSER_SCAN_COOKIE ] ) );
+		$active = self::browser_scan_active_record( $user_id );
+		if ( ! $active || ! hash_equals( (string) $active['token'], $token ) ) {
 			return false;
 		}
-
-		$active['state']   = 'held';
-		$active['held_at'] = time();
-		set_transient( $active_key, $active, self::BROWSER_SCAN_TTL );
-
-		// Slide the session transient too. The client stops its heartbeat once
-		// the run has failed, so without this the retry window is whatever was
-		// left of the last touch rather than a full one.
-		$token = sanitize_key( wp_unslash( (string) $_COOKIE[ self::BROWSER_SCAN_COOKIE ] ) );
-		$session = get_transient( self::browser_scan_transient_key( $token ) );
-		if ( is_array( $session ) ) {
-			set_transient( self::browser_scan_transient_key( $token ), $session, self::BROWSER_SCAN_TTL );
+		$key = self::browser_scan_transient_key( $token );
+		// A late hold must neither mark a successor held nor lose its state to
+		// an in-flight heartbeat's older copy of the session.
+		set_transient( $key . '_held', 'held', self::BROWSER_SCAN_MAX_AGE + self::BROWSER_SCAN_TTL );
+		if ( ! $this->touch_browser_scan_session( $token, $scan_id ) ) {
+			return false;
 		}
 
 		return true;
@@ -1213,9 +1201,8 @@ class Controller {
 					delete_user_meta( $user_id, self::BROWSER_SCAN_META, $observation );
 				}
 			}
-			delete_transient( self::browser_scan_transient_key( $token ) );
+			self::tombstone_browser_scan_session( $token, $user_id );
 		}
-		delete_transient( self::browser_scan_active_transient_key( $user_id ) );
 	}
 
 	/**

--- a/admin/modules/scanner/includes/class-cookie-database.php
+++ b/admin/modules/scanner/includes/class-cookie-database.php
@@ -37,13 +37,24 @@ class Cookie_Database {
 			'duration'    => 'session',
 			'description' => 'WordPress test cookie to check if cookies are enabled.',
 		),
+		// WordPress — admin-only (hidden internal category).
+		// wordpress_logged_in_* sat in the frontend-visible group above until
+		// #243. It is an authentication cookie: a logged-out visitor never
+		// receives it, and its sibling wordpress_sec_* was already classified
+		// here. The two tables that describe this cookie therefore disagreed —
+		// this one called it declarable, Frontend::is_wp_internal_cookie() called
+		// it internal — and the stricter one won only because every
+		// visitor-facing surface happens to consult it as well. Same visible
+		// behaviour either way (both categories are always allowed and the name
+		// guard already suppressed the declaration); the point is that the
+		// catalogue now says what the cookie is instead of relying on a
+		// downstream guard to correct it.
 		'wordpress_logged_in_'    => array(
-			'category'    => 'necessary',
+			'category'    => 'wordpress-internal',
 			'duration'    => 'session',
 			'description' => 'Indicates logged-in status and user identity.',
 			'match'       => 'prefix',
 		),
-		// WordPress — admin-only (hidden internal category).
 		'wp-settings-'            => array(
 			'category'    => 'wordpress-internal',
 			'duration'    => '1 year',

--- a/tests/e2e/fixtures/wp-fixture.ts
+++ b/tests/e2e/fixtures/wp-fixture.ts
@@ -48,20 +48,34 @@ const TECHNICAL_COOKIE_RE = [
 
 const isTechnicalCookie = (name: string): boolean => TECHNICAL_COOKIE_RE.some((re) => re.test(name));
 
-async function gotoResilient(page: Page, url: string): Promise<void> {
+// Bound the whole login and each attempt, leaving room in the 90s test
+// timeout for the product assertions that follow authentication.
+const LOGIN_TOTAL_BUDGET_MS = 60_000;
+const LOGIN_ATTEMPT_MS = 12_000;
+
+function remaining(deadline: number, cap = LOGIN_ATTEMPT_MS): number {
+  const left = deadline - Date.now();
+  if (left <= 0) throw new Error('admin login deadline exhausted');
+  return Math.max(1, Math.min(cap, left));
+}
+
+async function gotoResilient(page: Page, url: string, deadline: number): Promise<void> {
   let lastError: unknown;
   for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (Date.now() >= deadline) break;
     try {
-      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-      await page.waitForLoadState('domcontentloaded', { timeout: 60_000 }).catch(() => {
-        // Some WordPress/plugin combinations keep requests open longer than needed.
-      });
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: remaining(deadline) });
+      await page
+        .waitForLoadState('domcontentloaded', { timeout: remaining(deadline, 5_000) })
+        .catch(() => {
+          // Some WordPress/plugin combinations keep requests open longer than needed.
+        });
       return;
     } catch (error) {
       lastError = error;
     }
   }
-  throw lastError;
+  throw lastError ?? new Error(`gotoResilient: budget exhausted before reaching ${url}`);
 }
 
 /**
@@ -71,20 +85,20 @@ async function gotoResilient(page: Page, url: string): Promise<void> {
  * banner_default which the plugin treats as an auth-impacting change).
  * The caller wraps this in a retry that clears cookies between attempts.
  */
-async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: string, adminPass: string): Promise<void> {
+async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: string, adminPass: string, deadline: number): Promise<void> {
   const loginPath = getWpLoginPath();
-  await gotoResilient(page, `${wpBaseURL}${loginPath}`);
+  await gotoResilient(page, `${wpBaseURL}${loginPath}`, deadline);
 
   // Lucky path: existing session cookie still valid and WP redirected
   // straight to /wp-admin/. NB: a `reauth=1` URL landing on wp-login.php
   // is NOT this branch — WP keeps the URL on /wp-login.php while the
   // partial cookie is rejected, so we fall through to fill below.
   if (page.url().includes('/wp-admin/') && !page.url().includes('reauth=')) {
-    await expect(page.locator('#wpadminbar')).toBeVisible();
+    await expect(page.locator('#wpadminbar')).toBeVisible({ timeout: remaining(deadline) });
     return;
   }
 
-  await expect(page.locator('#user_login')).toBeVisible({ timeout: 20_000 });
+  await expect(page.locator('#user_login')).toBeVisible({ timeout: remaining(deadline) });
   // The login document may still be settling after a slow reauth redirect.
   // Locator.fill() then repeats actionability checks until the whole test
   // times out even though the fields are already visible. Set the native
@@ -93,75 +107,71 @@ async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: strin
     input.value = value;
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
-  }, adminUser);
+  }, adminUser, { timeout: remaining(deadline) });
   await page.locator('#user_pass').evaluate((input: HTMLInputElement, value: string) => {
     input.value = value;
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
-  }, adminPass);
+  }, adminPass, { timeout: remaining(deadline) });
 
   // A Locator click waits for the navigation it initiates using the global
   // 15-second action timeout. On the shared compatibility site WordPress can
   // authenticate successfully but take longer than that to finish the admin
   // redirect, so the click throws even though the navigation budget below is
-  // deliberately 60 seconds. Trigger the native click without Playwright's
+  // shared with the rest of this attempt. Trigger the native click without Playwright's
   // implicit navigation wait and let the explicit waiter own that budget.
   await Promise.all([
-    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60_000 }).catch(() => {
+    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: remaining(deadline) }).catch(() => {
       // Some plugin combinations keep the request open after auth succeeds.
     }),
-    page.locator('#wp-submit').evaluate((button: HTMLInputElement) => button.click()),
+    page.locator('#wp-submit').evaluate((button: HTMLInputElement) => button.click(), undefined, { timeout: remaining(deadline) }),
   ]);
 
   if (page.url().includes('/wp-admin/')) {
-    await expect(page.locator('#wpadminbar')).toBeVisible();
-    await expect(page.locator('#loginform')).toHaveCount(0);
+    await expect(page.locator('#wpadminbar')).toBeVisible({ timeout: remaining(deadline) });
+    await expect(page.locator('#loginform')).toHaveCount(0, { timeout: remaining(deadline) });
     return;
   }
 
   const cookies = await page.context().cookies(wpBaseURL);
   const hasLoggedCookie = cookies.some((cookie) => cookie.name.startsWith('wordpress_logged_in_'));
   if (hasLoggedCookie) {
-    await gotoResilient(page, `${wpBaseURL}/wp-admin/`);
-    await expect(page).toHaveURL(/\/wp-admin\//, { timeout: 20_000 });
-    await expect(page.locator('#wpadminbar')).toBeVisible();
-    await expect(page.locator('#loginform')).toHaveCount(0);
+    await gotoResilient(page, `${wpBaseURL}/wp-admin/`, deadline);
+    await expect(page).toHaveURL(/\/wp-admin\//, { timeout: remaining(deadline) });
+    await expect(page.locator('#wpadminbar')).toBeVisible({ timeout: remaining(deadline) });
+    await expect(page.locator('#loginform')).toHaveCount(0, { timeout: remaining(deadline) });
     return;
   }
 
-  const loginError = await page.locator('#login_error').textContent().catch(() => '');
+  const loginError = await page.locator('#login_error').textContent({ timeout: remaining(deadline, 1_000) }).catch(() => '');
   throw new Error(`WordPress admin login failed. URL=${page.url()} error=${loginError ?? 'n/a'}`);
 }
 
 export async function completeAdminLogin(page: Page, wpBaseURL: string, adminUser: string, adminPass: string): Promise<void> {
-  // Up to 2 attempts. The first usually succeeds; the second is needed
-  // when a previous spec invalidated the cookie WP is now trying to
-  // reuse (salt rotation, session-meta invalidation, banner_default
-  // mutations — all visible in the wp7-compat-full.log as the
-  // `URL=...reauth=1 error=` shape at log line 114, 1066 onwards).
-  //
-  // Between attempts we clear cookies for the WP base URL so the second
-  // try is a true fresh login rather than another reauth roundtrip
-  // against the same stale cookie. Pattern matches Playwright's own
-  // recommended retry-on-flaky-auth approach.
+  // Clear stale authentication only between attempts, preserving unrelated
+  // consent/fixture cookies in the caller's context.
+  const deadline = Date.now() + LOGIN_TOTAL_BUDGET_MS;
   let lastError: unknown;
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
+  let attempts = 0;
+  const MAX_LOGIN_ATTEMPTS = 5;
+  while (attempts < MAX_LOGIN_ATTEMPTS && Date.now() < deadline) {
+    attempts += 1;
     try {
-      await attemptAdminLogin(page, wpBaseURL, adminUser, adminPass);
+      await attemptAdminLogin(page, wpBaseURL, adminUser, adminPass, Math.min(deadline, Date.now() + LOGIN_ATTEMPT_MS));
       return;
     } catch (error) {
       lastError = error;
-      if (attempt < 2) {
-        try {
-          await page.context().clearCookies();
-        } catch {
-          // Non-fatal — the retry will still reach wp-login.php and WP
-          // will issue fresh cookies on a successful POST.
-        }
+      if (attempts >= MAX_LOGIN_ATTEMPTS || Date.now() >= deadline || page.isClosed()) break;
+      try {
+        await page.context().clearCookies({ name: /^wordpress_(?:logged_in_|sec_|[a-f0-9]{32}$)/i });
+      } catch {
+        // Non-fatal — the retry will still reach wp-login.php and WP
+        // will issue fresh cookies on a successful POST.
       }
     }
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  const detail = lastError instanceof Error ? lastError.message : String(lastError ?? 'no attempt completed');
+  throw new Error(`admin login failed after ${attempts} attempt(s) within ${LOGIN_TOTAL_BUDGET_MS}ms: ${detail}`);
 }
 
 export const test = base.extend<WPFixtures, WPWorkerFixtures>({

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,6 +2,7 @@ import { request } from '@playwright/test';
 import { assertPrerequisites } from './utils/preflight';
 import { getWpLoginPath } from './utils/wp-auth';
 import { wpEval } from './utils/wp-env';
+import { resetBaseline } from './utils/seed-defaults';
 
 async function globalSetup(): Promise<void> {
   const baseURL = process.env.WP_BASE_URL ?? 'http://127.0.0.1:9998';
@@ -61,6 +62,9 @@ async function globalSetup(): Promise<void> {
   // or stale environment fails here, named, instead of surfacing later as a
   // handful of assertions that look like product regressions.
   await assertPrerequisites(baseURL);
+
+  // Validate the target and deployed build before mutating the baseline.
+  resetBaseline();
 
   // Reset the active banner to a known clean shape and remove any secondary
   // banners left over by previous runs. Without this reset, specs that mutate

--- a/tests/e2e/specs/rc-1290-acceptance.spec.ts
+++ b/tests/e2e/specs/rc-1290-acceptance.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../fixtures/wp-fixture';
+import { readFileSync } from 'node:fs';
 import { deleteOption, setOption, wpEval } from '../utils/wp-env';
 
 /**
@@ -66,21 +67,44 @@ async function snapshotOption(name: string): Promise<() => void> {
   };
 }
 
-const RC_VERSION = '1.29.0-rc1';
+/**
+ * The version this run is meant to be testing.
+ *
+ * Pinned to the literal '1.29.0-rc1' at first, which made the check fail the
+ * moment 1.29.0 shipped — the assertion was about one release rather than about
+ * staleness, so it was guaranteed to go red at every future release and teach
+ * everyone to ignore it. It now reads the repo's own plugin header, which is
+ * what "the build under test" means when the deploy comes from this working
+ * copy; FAZ_EXPECTED_VERSION overrides it when the target is a package built
+ * elsewhere.
+ */
+const EXPECTED_VERSION =
+  process.env.FAZ_EXPECTED_VERSION ||
+  (readFileSync(new URL('../../../faz-cookie-manager.php', import.meta.url), 'utf8')
+    .match(/^\s*\*\s*Version:\s*(\S+)\s*$/m)?.[1] ?? '');
 
-test.describe('1.29.0-rc1 acceptance', () => {
-  test('the build under test is the RC, and it is the one WordPress loaded', async () => {
+const IS_PRERELEASE = /-(rc|beta|alpha)\d+$/.test(EXPECTED_VERSION);
+
+test.describe('1.29.0 release acceptance', () => {
+  test('the build under test is the expected one, and it is what WordPress loaded', async () => {
+    expect(EXPECTED_VERSION, 'could not read a version to expect').not.toBe('');
+
     // Everything below is worthless if it ran against a stale deploy. Ask
     // WordPress what it loaded rather than reading the repo's own file.
     const loaded = wpEval('echo defined("FAZ_VERSION") ? FAZ_VERSION : "undefined";').trim();
-    expect(loaded).toBe(RC_VERSION);
+    expect(loaded, `WordPress loaded ${loaded}; expected ${EXPECTED_VERSION}`).toBe(EXPECTED_VERSION);
 
-    // An RC must not claim the stable tag: that is the pointer wordpress.org
-    // serves as the stable download.
+    // Stable tag is the pointer wordpress.org serves as the stable download.
+    // The invariant runs BOTH ways, which is what makes it hold across
+    // releases: a pre-release must never claim it, and a final release must.
     const stable = wpEval(
       'echo get_file_data( WP_PLUGIN_DIR . "/faz-cookie-manager/faz-cookie-manager.php", array( "s" => "Stable tag" ) )["s"];'
     ).trim();
-    expect(stable).not.toBe(RC_VERSION);
+    if (IS_PRERELEASE) {
+      expect(stable, 'a pre-release must not claim the stable tag').not.toBe(loaded);
+    } else {
+      expect(stable, 'a final release must claim its own stable tag').toBe(loaded);
+    }
   });
 
   test('#263 — a stale downloaded definitions copy no longer shadows the bundle', async () => {

--- a/tests/e2e/specs/rc-1290-acceptance.spec.ts
+++ b/tests/e2e/specs/rc-1290-acceptance.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '../fixtures/wp-fixture';
 import { readFileSync } from 'node:fs';
-import { deleteOption, setOption, wpEval } from '../utils/wp-env';
+import { deleteOption, setOption, wp, wpEval } from '../utils/wp-env';
 
 /**
  * Acceptance gate for the 1.29.0-rc1 bundle.
@@ -85,21 +85,27 @@ const EXPECTED_VERSION =
 
 const IS_PRERELEASE = /-(rc|beta|alpha)\d+$/.test(EXPECTED_VERSION);
 
-test.describe('1.29.0 release acceptance', () => {
+test.describe(`${EXPECTED_VERSION || 'unknown version'} release acceptance`, () => {
   test('the build under test is the expected one, and it is what WordPress loaded', async () => {
     expect(EXPECTED_VERSION, 'could not read a version to expect').not.toBe('');
 
     // Everything below is worthless if it ran against a stale deploy. Ask
     // WordPress what it loaded rather than reading the repo's own file.
-    const loaded = wpEval('echo defined("FAZ_VERSION") ? FAZ_VERSION : "undefined";').trim();
+    // wp() rather than wpEval(): these two probes only read, so a retry is
+    // safe, and they are the first WP-CLI calls of the acceptance run — a
+    // bootstrap or MySQL blip here fails the whole spec with a version
+    // mismatch that never happened. wpEval() opts out of the retry because it
+    // is the general-purpose escape hatch and most of its callers mutate.
+    const loaded = wp(['eval', 'echo defined("FAZ_VERSION") ? FAZ_VERSION : "undefined";']).trim();
     expect(loaded, `WordPress loaded ${loaded}; expected ${EXPECTED_VERSION}`).toBe(EXPECTED_VERSION);
 
     // Stable tag is the pointer wordpress.org serves as the stable download.
     // The invariant runs BOTH ways, which is what makes it hold across
     // releases: a pre-release must never claim it, and a final release must.
-    const stable = wpEval(
-      'echo get_file_data( WP_PLUGIN_DIR . "/faz-cookie-manager/faz-cookie-manager.php", array( "s" => "Stable tag" ) )["s"];'
-    ).trim();
+    const stable = wp([
+      'eval',
+      'echo get_file_data( WP_PLUGIN_DIR . "/faz-cookie-manager/faz-cookie-manager.php", array( "s" => "Stable tag" ) )["s"];',
+    ]).trim();
     if (IS_PRERELEASE) {
       expect(stable, 'a pre-release must not claim the stable tag').not.toBe(loaded);
     } else {

--- a/tests/e2e/specs/release-verify-scan-session.spec.ts
+++ b/tests/e2e/specs/release-verify-scan-session.spec.ts
@@ -28,13 +28,14 @@
  *
  * State discipline: every session a test opens is released in `finally`
  * through the real scans/abort route (status asserted), and the ephemeral
- * scan-session transients are verified gone so no per-user "scan already in
+ * scan sessions are verified inactive so no per-user "scan already in
  * progress" lock (TTL up to 15 minutes) leaks into later specs.
  */
 import { randomBytes } from 'node:crypto';
 import { expect, test } from '../fixtures/wp-fixture';
 import { fazApiPost, openCookiesPage } from '../utils/faz-api';
 import { wpEval } from '../utils/wp-env';
+import { countActiveBrowserScanSessions } from '../utils/scan-session-state';
 
 const WP_BASE = process.env.WP_BASE_URL ?? 'http://127.0.0.1:9998';
 
@@ -64,17 +65,6 @@ function clearBrowserScanSessionState(): void {
   `);
 }
 
-/** How many browser-scan session/active transient rows currently exist. */
-function countBrowserScanSessionRows(): number {
-  const raw = wpEval(`
-    global $wpdb;
-    echo (int) $wpdb->get_var(
-      "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_faz_scan_session_%'"
-      . " OR option_name LIKE '_transient_faz_scan_active_%'"
-    );
-  `);
-  return Number.parseInt(raw.trim(), 10);
-}
 
 /**
  * Read the httpOnly scan marker issued by scans/discover. Playwright's
@@ -114,13 +104,13 @@ async function openCaptureSession(page: import('@playwright/test').Page, nonce: 
 /**
  * Release a session through the real scans/abort route and assert the
  * release actually happened — both at the transport (200) and in the DB
- * (no session/active transients left behind for later specs to trip on).
+ * (no live session left behind for later specs to trip on).
  */
 async function abortCaptureSession(page: import('@playwright/test').Page, nonce: string, scanId: string): Promise<void> {
   const abort = await fazApiPost<{ aborted: boolean }>(page, nonce, 'scans/abort', { scan_id: scanId });
   expect(abort.status, 'session cleanup via scans/abort must succeed').toBe(200);
   expect(abort.data.aborted, 'scans/abort must report the session as released').toBe(true);
-  expect(countBrowserScanSessionRows(), 'no scan-session transients may leak past this test').toBe(0);
+  expect(countActiveBrowserScanSessions(), 'no live scan session may leak past this test').toBe(0);
   await page.context().clearCookies();
 }
 
@@ -353,7 +343,7 @@ test.describe('Release verify — browser-scan session TTL and import boundary',
       expect(importPayloads[0].scan_id).toMatch(/^[a-f0-9]{32}$/);
       expect(importPayloads[1].scan_id).toBe(importPayloads[0].scan_id);
       expect(importPayloads[1]).toEqual(importPayloads[0]);
-      expect(countBrowserScanSessionRows(), 'successful retried import must close the session').toBe(0);
+      expect(countActiveBrowserScanSessions(), 'successful retried import must close the session').toBe(0);
     } finally {
       await page.unroute('**/*');
       clearBrowserScanSessionState();

--- a/tests/e2e/specs/scan-session-resume.spec.ts
+++ b/tests/e2e/specs/scan-session-resume.spec.ts
@@ -31,6 +31,7 @@ import { randomBytes } from 'node:crypto';
 import { expect, test } from '../fixtures/wp-fixture';
 import { fazApiGet, fazApiPost, openCookiesPage } from '../utils/faz-api';
 import { wpEval } from '../utils/wp-env';
+import { countActiveBrowserScanSessions } from '../utils/scan-session-state';
 
 const WP_BASE = process.env.WP_BASE_URL ?? 'http://127.0.0.1:9998';
 const ADMIN_LOGIN = process.env.WP_ADMIN_USER ?? 'admin';
@@ -65,17 +66,6 @@ function clearBrowserScanSessionState(): void {
   `);
 }
 
-/** How many browser-scan session/active transient rows currently exist. */
-function countBrowserScanSessionRows(): number {
-  const raw = wpEval(`
-    global $wpdb;
-    echo (int) $wpdb->get_var(
-      "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_faz_scan_session_%'"
-      . " OR option_name LIKE '_transient_faz_scan_active_%'"
-    );
-  `);
-  return Number.parseInt(raw.trim(), 10);
-}
 
 /**
  * Seed a capture session exactly as an interrupted crawl leaves it: active
@@ -174,7 +164,7 @@ test.describe('Scan session resume — reload visibility and explicit stop', () 
       // Explicit human action — the only sanctioned way out.
       await page.locator('#faz-scan-session-end').click();
       await expect(panel).toHaveCount(0, { timeout: 10_000 });
-      await expect.poll(() => countBrowserScanSessionRows(), { timeout: 10_000 }).toBe(0);
+      await expect.poll(() => countActiveBrowserScanSessions(), { timeout: 10_000 }).toBe(0);
       // Ending discards the capture: the seeded observation must be gone too.
       expect(countSeededObservations(uid)).toBe(0);
 
@@ -223,7 +213,7 @@ test.describe('Scan session resume — reload visibility and explicit stop', () 
       expect(refused.data.code).toBe('faz_browser_scan_in_progress');
 
       // Neither the refusal nor the page's own polling stole the session.
-      expect(countBrowserScanSessionRows()).toBe(2);
+      expect(countActiveBrowserScanSessions()).toBe(1);
       const described = await fazApiGet<{ active: boolean; scan_id?: string }>(page, nonce, 'scans/session');
       expect(described.status).toBe(200);
       expect(described.data.active).toBe(true);
@@ -252,13 +242,13 @@ test.describe('Scan session resume — reload visibility and explicit stop', () 
       const wrongId = await fazApiPost<{ aborted: boolean }>(page, nonce, 'scans/abort', { scan_id: randomScanId() });
       expect(wrongId.status).toBe(200);
       expect(wrongId.data.aborted).toBe(false);
-      expect(countBrowserScanSessionRows(), 'a stranger scan id must release nothing').toBe(2);
+      expect(countActiveBrowserScanSessions(), 'a stranger scan id must release nothing').toBe(1);
       expect(countSeededObservations(uid)).toBe(1);
 
       const ownId = await fazApiPost<{ aborted: boolean }>(page, nonce, 'scans/abort', { scan_id: scanId });
       expect(ownId.status).toBe(200);
       expect(ownId.data.aborted).toBe(true);
-      expect(countBrowserScanSessionRows()).toBe(0);
+      expect(countActiveBrowserScanSessions()).toBe(0);
       expect(countSeededObservations(uid)).toBe(0);
     } finally {
       clearSeededObservations(uid);
@@ -396,11 +386,11 @@ test.describe('Scan session resume — reload visibility and explicit stop', () 
       await page.click('#faz-scan-dropdown [data-depth="10"]');
 
       // Session open on the server = discover committed, crawl underway.
-      await expect.poll(() => countBrowserScanSessionRows(), { timeout: 30_000 }).toBeGreaterThanOrEqual(2);
+      await expect.poll(() => countActiveBrowserScanSessions(), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
 
       // Abandon the crawl. The blocked beacon means the session survives.
       await page.goto(`${WP_BASE}/wp-admin/admin.php?page=faz-cookie-manager-cookies`, { waitUntil: 'domcontentloaded' });
-      expect(countBrowserScanSessionRows()).toBeGreaterThanOrEqual(2);
+      expect(countActiveBrowserScanSessions()).toBeGreaterThanOrEqual(1);
 
       // The reloaded page surfaces the orphaned session...
       const panel = page.locator('#faz-scan-session-panel');
@@ -409,20 +399,20 @@ test.describe('Scan session resume — reload visibility and explicit stop', () 
       // ...and ends it on explicit request (marker-cookie path).
       await page.locator('#faz-scan-session-end').click();
       await expect(panel).toHaveCount(0, { timeout: 10_000 });
-      await expect.poll(() => countBrowserScanSessionRows(), { timeout: 10_000 }).toBe(0);
+      await expect.poll(() => countActiveBrowserScanSessions(), { timeout: 10_000 }).toBe(0);
 
       // The next scan starts instead of 409ing.
       await page.click('#faz-scan-btn');
       await page.click('#faz-scan-dropdown [data-depth="10"]');
       const progress = page.locator('.faz-scan-progress-wrap:not(.faz-scan-session-wrap)');
       await expect(progress).toBeVisible({ timeout: 15_000 });
-      await expect.poll(() => countBrowserScanSessionRows(), { timeout: 30_000 }).toBeGreaterThanOrEqual(2);
+      await expect.poll(() => countActiveBrowserScanSessions(), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
 
       // Wind the run down quickly: Stop imports the partial result and
       // finishes the session, leaving nothing for later specs.
       await page.locator('.faz-scan-stop').click();
       await expect(progress).toHaveCount(0, { timeout: 180_000 });
-      await expect.poll(() => countBrowserScanSessionRows(), { timeout: 15_000 }).toBe(0);
+      await expect.poll(() => countActiveBrowserScanSessions(), { timeout: 15_000 }).toBe(0);
     } finally {
       clearBrowserScanSessionState();
       await page.context().clearCookies();

--- a/tests/e2e/utils/scan-session-state.ts
+++ b/tests/e2e/utils/scan-session-state.ts
@@ -1,0 +1,15 @@
+import { wpEval } from './wp-env';
+
+/** Closed-token records and expired index rows must not count as live scans. */
+export function countActiveBrowserScanSessions(): number {
+  return Number.parseInt(wpEval(`
+    $controller = \\FazCookie\\Admin\\Modules\\Scanner\\Includes\\Controller::get_instance();
+    $count = 0;
+    foreach ( get_users( array( 'fields' => 'ID' ) ) as $user_id ) {
+      wp_set_current_user( (int) $user_id );
+      $state = $controller->describe_browser_scan_session();
+      if ( ! empty( $state['active'] ) ) { ++$count; }
+    }
+    echo $count;
+  `).trim(), 10);
+}

--- a/tests/e2e/utils/seed-defaults.ts
+++ b/tests/e2e/utils/seed-defaults.ts
@@ -67,6 +67,17 @@ export function resetBaseline(): void {
       $faz_settings['geolocation'] = array();
     }
     $faz_settings['geolocation']['geo_targeting'] = false;
+
+    // Restore English as default without removing locales required by other specs.
+    if ( ! isset( $faz_settings['languages'] ) || ! is_array( $faz_settings['languages'] ) ) {
+      $faz_settings['languages'] = array();
+    }
+    $selected = $faz_settings['languages']['selected'] ?? array();
+    if ( ! is_array( $selected ) ) { $selected = array(); }
+    if ( ! in_array( 'en', $selected, true ) ) { array_unshift( $selected, 'en' ); }
+    $faz_settings['languages']['selected'] = array_values( $selected );
+    $faz_settings['languages']['default']  = 'en';
+
     update_option( 'faz_settings', $faz_settings );
 
     delete_option( 'faz_banner_template' );

--- a/tests/unit/js/admin-login-budget.test.mjs
+++ b/tests/unit/js/admin-login-budget.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+// Execute the actual helper with a virtual clock and Playwright-shaped transport.
+// Delays consume the timeout the helper passes, so missing or per-operation
+// deadlines produce an observable overrun rather than a source-string match.
+const source = readFileSync(new URL('../../e2e/fixtures/wp-fixture.ts', import.meta.url), 'utf8');
+// Use the runner's own TypeScript transform, including on the Node 20 CI job.
+const require = createRequire(import.meta.url);
+const { transformHook } = require(join(dirname(require.resolve('playwright/package.json')), 'lib/transform/transform.js'));
+const helper = transformHook(source.slice(source.indexOf('const LOGIN_TOTAL_BUDGET_MS'), source.indexOf('export const test =')).replace('export async function', 'async function'), 'admin-login-budget.ts').code;
+let passed = 0;
+async function run(scenario) {
+  let now = 0, attempts = 0, cleared = 0, currentURL = '', closed = false;
+  const calls = [];
+  const context = {
+    cookies: async () => [],
+    clearCookies: async (options) => {
+      assert.ok(options.name.test('wordpress_logged_in_hash'));
+      assert.ok(!options.name.test('fazcookie-consent'));
+      cleared++;
+    },
+  };
+  const step = async (name, options) => {
+    assert.ok(options?.timeout > 0, `${name} must have a finite, nonzero timeout`);
+    calls.push({ name, start: now, timeout: options.timeout, attempt: attempts });
+    const delay = scenario(name, attempts);
+    now += Math.min(delay, options.timeout);
+    if (delay >= options.timeout) throw new Error(`${name} timeout`);
+  };
+  const page = {
+    goto: async (_url, options) => {
+      attempts++;
+      currentURL = 'https://wp.test/wp-login.php';
+      await step('goto', options);
+    },
+    waitForLoadState: async (_state, options) => step('load', options),
+    url: () => currentURL,
+    isClosed: () => closed,
+    context: () => context,
+    waitForNavigation: async (options) => {
+      await step('navigation', options);
+      currentURL = 'https://wp.test/wp-admin/';
+    },
+    locator: (selector) => ({
+      selector,
+      evaluate: async (_fn, _arg, options) => step(`evaluate:${selector}`, options),
+      textContent: async (options) => { await step(`text:${selector}`, options); return ''; },
+    }),
+  };
+  const expect = (locator) => ({
+    toBeVisible: (options) => step(`visible:${locator.selector}`, options),
+    toHaveCount: (_count, options) => step(`count:${locator.selector}`, options),
+    toHaveURL: (_url, options) => step('url', options),
+  });
+  const sandbox = { Date: { now: () => now }, Math, Error, getWpLoginPath: () => '/wp-login.php', expect };
+  vm.createContext(sandbox);
+  vm.runInContext(helper + '\nglobalThis.login = completeAdminLogin;', sandbox);
+  let error;
+  try { await sandbox.login(page, 'https://wp.test', 'admin', 'secret'); } catch (e) { error = e; }
+  return { now, attempts, cleared, calls, error };
+}
+
+let result = await run(() => 0);
+assert.equal(result.error, undefined);
+assert.equal(result.attempts, 1);
+assert.equal(result.cleared, 0);
+passed++;
+
+result = await run((name) => name === 'goto' ? 100_000 : 0);
+assert.match(result.error?.message, /admin login failed after 5 attempt\(s\) within 60000ms/);
+assert.equal(result.now, 60_000);
+assert.equal(result.cleared, 4, 'do not clear cookies after terminal failure');
+passed++;
+
+result = await run((name, attempt) => attempt === 1 ? ({ 'visible:#user_login': 9000, 'evaluate:#user_pass': 100_000 }[name] ?? 0) : 0);
+assert.equal(result.error, undefined);
+assert.equal(result.attempts, 2);
+assert.equal(result.now, 12_000, 'field lookup shares the attempt deadline');
+assert.equal(result.calls.find((c) => c.name === 'evaluate:#user_pass').timeout, 3000);
+passed++;
+
+result = await run((name, attempt) => attempt === 1 ? ({ 'visible:#user_login': 9000, 'count:#loginform': 100_000 }[name] ?? 0) : 0);
+assert.equal(result.error, undefined);
+assert.equal(result.attempts, 2);
+assert.equal(result.now, 12_000, 'post-login assertion cannot escape the attempt budget');
+passed++;
+
+console.log(`${passed} admin login budget scenarios passed`);

--- a/tests/unit/test-scan-session-teardown-race-php.php
+++ b/tests/unit/test-scan-session-teardown-race-php.php
@@ -1,41 +1,19 @@
 <?php
-/**
- * #245 — a teardown must be final.
- *
- * touch_browser_scan_session() reads the session transient, validates it, and
- * only then writes. A request already in flight when the crawl ended used to
- * write the pre-teardown array back afterwards, resurrecting a session no tab
- * was driving; the next scan then met faz_browser_scan_in_progress and the
- * administrator waited out the idle TTL for a crawl that had finished.
- *
- * Deleting the transient cannot express "this was closed" — absence and "never
- * existed" are the same observation, so a late writer has nothing to detect.
- * The teardown now leaves a short-lived tombstone, and the touch path re-reads
- * immediately before writing and abandons the write when it finds one.
- *
- * Run: php tests/unit/test-scan-session-teardown-race-php.php
- */
-
+/** Deterministic interleavings around the real session lifecycle, on both stores. */
+namespace FazCookie\Admin\Modules\Scanner\Includes {
+	function headers_sent() { return false; }
+	function setcookie( $name, $value, $options ) {
+		$GLOBALS['cookie_writes'][] = array( $name, $value, $options );
+		return true;
+	}
+}
+namespace {
 define( 'ABSPATH', __DIR__ . '/' );
 define( 'DAY_IN_SECONDS', 86400 );
 define( 'HOUR_IN_SECONDS', 3600 );
 define( 'MINUTE_IN_SECONDS', 60 );
 define( 'YEAR_IN_SECONDS', 31536000 );
-
-$GLOBALS['faz_t']      = array();   // transient store
-$GLOBALS['faz_meta']   = array();
-$GLOBALS['faz_cookie'] = array();
-// Fires on the Nth read of the session key, so a teardown can be placed exactly
-// between touch()'s initial read and its re-read — the window the fix closes.
-// Firing on the FIRST read (the obvious thing, and what this harness did at
-// first) proves nothing: touch() then sees the closed session in its opening
-// validation and bails long before reaching the code under test, so the
-// assertions pass whether the fix is present or not.
-$GLOBALS['faz_on_read']       = null;
-$GLOBALS['faz_on_read_key']   = '';
-$GLOBALS['faz_on_read_after'] = 1;
-$GLOBALS['faz_read_count']    = 0;
-
+class WP_Error { public function __construct( ...$args ) {} }
 function sanitize_text_field( $v ) { return trim( strip_tags( (string) $v ) ); }
 function sanitize_key( $v ) { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $v ) ); }
 function __( $v, ...$u ) { return $v; }
@@ -49,93 +27,147 @@ function is_ssl() { return true; }
 function get_current_user_id() { return 7; }
 function wp_doing_ajax() { return false; }
 function is_admin() { return false; }
-function wp_generate_uuid4() { return sprintf( '%08x-0000-4000-8000-%012x', mt_rand(), mt_rand() ); }
+function wp_generate_uuid4() { static $id = 0; return sprintf( '%032x', ++$id ); }
 function wp_rand( $min = 0, $max = 0 ) { return mt_rand( $min, $max ); }
-function get_user_meta( $u, $k, $single = false ) { return $GLOBALS['faz_meta'][ $k ] ?? array(); }
-function delete_user_meta( $u, $k, $v = '' ) { unset( $GLOBALS['faz_meta'][ $k ] ); return true; }
-function add_user_meta( $u, $k, $v, $unique = false ) { $GLOBALS['faz_meta'][ $k ][] = $v; return true; }
+function get_user_meta( $u, $k, $single = false ) { return $GLOBALS['meta'][ $k ] ?? array(); }
+function delete_user_meta( $u, $k, $v = '' ) {
+	$GLOBALS['meta'][ $k ] = array_values( array_filter( $GLOBALS['meta'][ $k ] ?? array(), static function ( $row ) use ( $v ) { return $row !== $v; } ) );
+	return true;
+}
+function add_user_meta( $u, $k, $v, $unique = false ) { $GLOBALS['meta'][ $k ][] = $v; return true; }
+function wp_using_ext_object_cache() { return $GLOBALS['external']; }
+function wp_cache_delete( $key, $group = '' ) {
+	if ( 'options' === $group ) {
+		unset( $GLOBALS['local'][ preg_replace( '/^_transient_/', '', $key ) ] );
+	}
+}
+function concurrent_request( $cb ) {
+	$local = $GLOBALS['local'];
+	$GLOBALS['local'] = array();
+	try { $cb(); } finally { $GLOBALS['local'] = $local; }
+}
+function read_store( $key, $fresh ) {
+	if ( ! $fresh && array_key_exists( $key, $GLOBALS['local'] ) ) { return $GLOBALS['local'][ $key ]; }
+	$value = $GLOBALS['store'][ $key ] ?? false;
+	$GLOBALS['local'][ $key ] = $value;
+	if ( $GLOBALS['on_read'] && $GLOBALS['read_key'] === $key ) {
+		$cb = $GLOBALS['on_read']; $GLOBALS['on_read'] = null;
+		concurrent_request( $cb ); // Return the pre-callback snapshot, as an in-flight request would.
+	}
+	return $value;
+}
+function get_transient( $key ) { return read_store( $key, false ); }
+function wp_cache_get( $key, $group = '', $force = false ) { return read_store( $key, $force ); }
+function set_transient( $key, $value, $ttl = 0 ) {
+	if ( $GLOBALS['on_write'] && $GLOBALS['write_key'] === $key ) {
+		$cb = $GLOBALS['on_write']; $GLOBALS['on_write'] = null;
+		concurrent_request( $cb ); // The concurrent teardown finishes BEFORE this stale write lands.
+	}
+	$GLOBALS['store'][ $key ] = $value;
+	$GLOBALS['ttl'][ $key ] = $ttl;
+	unset( $GLOBALS['local'][ $key ] );
+	return true;
+}
+function delete_transient( $key ) { unset( $GLOBALS['store'][ $key ], $GLOBALS['local'][ $key ] ); return true; }
+require_once dirname( __DIR__, 2 ) . '/admin/modules/scanner/includes/class-controller.php';
+use FazCookie\Admin\Modules\Scanner\Includes\Controller;
+$ok = 0; $ko = 0;
+function t( $c, $l ) { global $ok, $ko; if ( $c ) { ++$ok; echo "PASS $l\n"; } else { ++$ko; echo "FAIL $l\n"; } }
+$ctl = Controller::get_instance();
+$scan = str_repeat( 'c', 32 );
+$next_scan = str_repeat( 'd', 32 );
+$seed = function () use ( $ctl, $scan ) {
+	$GLOBALS['store'] = $GLOBALS['local'] = $GLOBALS['ttl'] = $GLOBALS['meta'] = $GLOBALS['cookie_writes'] = array();
+	$GLOBALS['on_read'] = $GLOBALS['on_write'] = null;
+	$GLOBALS['read_key'] = $GLOBALS['write_key'] = '';
+	$token = $ctl->start_browser_scan_session( $scan );
+	$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $token;
+	return $token;
+};
+foreach ( array( false, true ) as $external ) {
+	$GLOBALS['external'] = $external;
+	$backend = $external ? 'object cache' : 'options';
+	$token = $seed();
+	$key = 'faz_scan_session_' . hash( 'sha256', $token );
+	t( $ctl->touch_browser_scan_session( $token, $scan ), "$backend: live heartbeat renews" );
+	t( count( $GLOBALS['cookie_writes'] ) === 1, "$backend: heartbeat cannot overwrite a newer browser marker" );
+	t( $GLOBALS['cookie_writes'][0][2]['expires'] >= time() + Controller::BROWSER_SCAN_MAX_AGE - 1, "$backend: start marker survives a long crawl" );
+	t( ! $ctl->touch_browser_scan_session( $token, $next_scan ), "$backend: wrong scan cannot renew" );
 
-function get_transient( $key ) {
-	if ( $GLOBALS['faz_on_read'] && $key === $GLOBALS['faz_on_read_key'] ) {
-		++$GLOBALS['faz_read_count'];
-		if ( $GLOBALS['faz_read_count'] > $GLOBALS['faz_on_read_after'] ) {
-			$cb = $GLOBALS['faz_on_read'];
-			$GLOBALS['faz_on_read'] = null;   // one shot
-			$cb( $key );
-			return $GLOBALS['faz_t'][ $key ] ?? false;   // post-callback state
+	// Capture an old read, then close through the public finish path.
+	$GLOBALS['read_key'] = $key;
+	$GLOBALS['on_read'] = function () use ( $ctl, $scan ) { $ctl->finish_browser_scan_session( $scan ); };
+	t( ! $ctl->touch_browser_scan_session( $token, $scan ), "$backend: teardown after initial read wins" );
+	t( ! Controller::is_browser_scan_request(), "$backend: closed cookie cannot authorize capture" );
+	t( ! $ctl->browser_scan_session_matches( $scan ), "$backend: closed cookie cannot authorize import" );
+	t( ! $ctl->describe_browser_scan_session()['active'], "$backend: closed index is inactive" );
+	t( count( $GLOBALS['cookie_writes'] ) === 1, "$backend: teardown cannot clear a newer browser marker" );
+
+	// No amount of re-reading closes THIS window: inject at the actual write.
+	foreach ( array( 'finish', 'abort', 'successor' ) as $mode ) {
+		$token = $seed();
+		$key = 'faz_scan_session_' . hash( 'sha256', $token );
+		$GLOBALS['write_key'] = $key;
+		$successor = null;
+		$GLOBALS['on_write'] = function () use ( $ctl, $scan, $next_scan, $mode, &$successor ) {
+			if ( 'abort' === $mode ) {
+				unset( $_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] );
+				t( $ctl->abort_browser_scan_session( $scan ), 'abort without marker reaches the owner fallback' );
+			} else {
+				$ctl->finish_browser_scan_session( $scan );
+			}
+			if ( 'successor' === $mode ) { $successor = $ctl->start_browser_scan_session( $next_scan ); }
+		};
+		t( ! $ctl->touch_browser_scan_session( $token, $scan ), "$backend/$mode: close between final read and write wins" );
+		$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $token;
+		t( ! $ctl->browser_scan_session_matches( $scan ), "$backend/$mode: stale rewritten payload stays revoked" );
+		if ( 'successor' === $mode ) {
+			t( $GLOBALS['store']['faz_scan_active_7']['token'] === $successor, "$backend: old heartbeat leaves successor index untouched" );
+			$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $successor;
+			t( $ctl->browser_scan_session_matches( $next_scan ), "$backend: successor remains importable" );
+			t( $ctl->touch_browser_scan_session( $successor, $next_scan ), "$backend: successor heartbeat works" );
 		}
 	}
-	return $GLOBALS['faz_t'][ $key ] ?? false;
+
+	// A held session is reclaimable, and its old heartbeat cannot hold the new one.
+	$token = $seed();
+	t( $ctl->hold_browser_scan_session( $scan ), "$backend: failed import holds evidence" );
+	t( $ctl->touch_browser_scan_session( $token, $scan ) && 'held' === $ctl->describe_browser_scan_session()['state'], "$backend: heartbeat preserves held state" );
+	$successor = $ctl->start_browser_scan_session( $next_scan );
+	t( is_string( $successor ) && $successor !== $token, "$backend: new scan reclaims held session" );
+	t( ! $ctl->hold_browser_scan_session( $scan ), "$backend: late hold cannot mark successor held" );
+	t( ! $ctl->touch_browser_scan_session( $token, $scan ), "$backend: reclaimed token cannot renew" );
+	$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $successor;
+	t( 'live' === $ctl->describe_browser_scan_session()['state'], "$backend: successor stays live" );
+
+	$token = $seed();
+	$key = 'faz_scan_session_' . hash( 'sha256', $token );
+	unset( $GLOBALS['store'][ $key . '_held' ] );
+	$GLOBALS['store']['faz_scan_active_7']['state'] = 'held';
+	t( $ctl->start_browser_scan_session( $scan ) === $token && 'live' === $ctl->describe_browser_scan_session()['state'], "$backend: resume clears a pre-upgrade held index" );
+
+	$token = $seed();
+	$key = 'faz_scan_session_' . hash( 'sha256', $token );
+	$GLOBALS['read_key'] = $key;
+	$GLOBALS['on_read'] = function () use ( $key ) { unset( $GLOBALS['store'][ $key ] ); };
+	t( $ctl->start_browser_scan_session( $scan ) instanceof WP_Error, "$backend: expiry during discover cannot reset an old token's birth time" );
+	t( ! isset( $GLOBALS['store'][ $key ] ), "$backend: expired reused token is not rewritten" );
+
+	$token = $seed();
+	$ctl->hold_browser_scan_session( $scan );
+	t( $ctl->start_browser_scan_session( $scan ) === $token && 'live' === $ctl->describe_browser_scan_session()['state'], "$backend: explicit resume consumes held state" );
+	$key = 'faz_scan_session_' . hash( 'sha256', $token );
+	unset( $GLOBALS['store'][ $key ] ); // Idle expiry, with an old request-local cache.
+	t( ! $ctl->describe_browser_scan_session()['active'], "$backend: an expired session's index is not a lock" );
+	t( is_string( $ctl->start_browser_scan_session( $next_scan ) ), "$backend: idle expiry permits immediate next scan" );
+
+	$token = $seed();
+	$key = 'faz_scan_session_' . hash( 'sha256', $token );
+	$GLOBALS['store'][ $key ]['created_at'] = time() - Controller::BROWSER_SCAN_MAX_AGE - 1;
+	t( ! $ctl->browser_scan_session_matches( $scan ) && ! Controller::is_browser_scan_request(), "$backend: absolute expiry protects import and capture too" );
+	t( $ctl->abort_browser_scan_session( $scan ), "$backend: explicit cleanup can revoke an expired token" );
+	t( is_string( $ctl->start_browser_scan_session( $next_scan ) ), "$backend: absolute expiry releases the scan index" );
 }
-function set_transient( $key, $value, $ttl = 0 ) { $GLOBALS['faz_t'][ $key ] = $value; return true; }
-function delete_transient( $key ) { unset( $GLOBALS['faz_t'][ $key ] ); return true; }
-
-require_once dirname( __DIR__, 2 ) . '/admin/modules/scanner/includes/class-controller.php';
-
-use FazCookie\Admin\Modules\Scanner\Includes\Controller;
-
-$ok = 0; $ko = 0;
-function t( $c, $l ) { global $ok, $ko; if ( $c ) { ++$ok; echo "  PASS $l\n"; } else { ++$ko; echo "  FAIL $l\n"; } }
-
-$ctl   = Controller::get_instance();
-$token = str_repeat( 'ab', 16 );
-$scan  = str_repeat( 'cd', 16 );
-
-$ref       = new ReflectionClass( $ctl );
-$key_m     = $ref->getMethod( 'browser_scan_transient_key' );     $key_m->setAccessible( true );
-$akey_m    = $ref->getMethod( 'browser_scan_active_transient_key' ); $akey_m->setAccessible( true );
-$tomb_m    = $ref->getMethod( 'tombstone_browser_scan_session' ); $tomb_m->setAccessible( true );
-$skey      = $key_m->invoke( null, $token );
-$akey      = $akey_m->invoke( null, 7 );
-
-$seed = function () use ( $skey, $akey, $token, $scan ) {
-	$GLOBALS['faz_t'] = array(
-		$skey => array( 'user_id' => 7, 'scan_id' => $scan, 'created_at' => time(), 'touched_at' => time() ),
-		$akey => array( 'token' => $token, 'scan_id' => $scan, 'created_at' => time() ),
-	);
-};
-
-// 1. The baseline the fix must not break: a live session still slides.
-$seed();
-$GLOBALS['faz_on_read'] = null;
-t( true === $ctl->touch_browser_scan_session( $token, $scan ), 'a live session is still renewed by a heartbeat' );
-t( ! empty( $GLOBALS['faz_t'][ $skey ]['user_id'] ), 'and the session survives the renewal' );
-
-// 2. The race itself. The teardown lands after touch() has read and validated,
-//    which is precisely the window that used to resurrect the session.
-$seed();
-// The REAL teardown, not the tombstone helper. Calling the helper directly
-// tested that touch() reacts to a tombstone, which is true but does not prove
-// the teardown produces one — a first version of this test did exactly that and
-// stayed green when the teardown was reverted to a plain delete.
-// finish_browser_scan_session() identifies the session from the marker cookie,
-// exactly as the real teardown request does.
-$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $token;
-$GLOBALS['faz_on_read_key']   = $skey;
-$GLOBALS['faz_on_read_after'] = 1;   // let the initial read through, fire on the re-read
-$GLOBALS['faz_read_count']    = 0;
-$GLOBALS['faz_on_read'] = function () use ( $ctl, $scan ) {
-	$ctl->finish_browser_scan_session( $scan );   // teardown, mid-flight
-};
-$resurrected = $ctl->touch_browser_scan_session( $token, $scan );
-t( false === $resurrected, 'a heartbeat that raced a teardown reports failure' );
-unset( $_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] );
-$after = $GLOBALS['faz_t'][ $skey ] ?? false;
-t( empty( $after['user_id'] ), 'and does NOT write the pre-teardown session back' );
-
-// 3. The regression this fix could have introduced: the tombstone is an array,
-//    so a reader that only checked is_array() would mistake it for a live
-//    session and refuse the next scan — the very symptom #245 describes.
-$GLOBALS['faz_t'] = array();
-$tomb_m->invoke( null, $token, 7 );
-// is_browser_scan_request() is the guard that decides whether a request belongs
-// to a live capture session; it requires user_id, which a tombstone has not.
-$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $token;
-t( false === Controller::is_browser_scan_request(), 'a tombstone is not mistaken for a live capture session' );
-unset( $_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] );
-$tombstone = $GLOBALS['faz_t'][ $akey ] ?? array();
-t( empty( $tombstone['token'] ) && empty( $tombstone['scan_id'] ),
-	'and carries none of the fields the active-session guards require' );
-
-echo "\nscan session teardown race: $ok passed, $ko failed\n";
+echo "\nscan session lifecycle: $ok passed, $ko failed\n";
 exit( $ko > 0 ? 1 : 0 );
+}

--- a/tests/unit/test-scan-session-teardown-race-php.php
+++ b/tests/unit/test-scan-session-teardown-race-php.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * #245 — a teardown must be final.
+ *
+ * touch_browser_scan_session() reads the session transient, validates it, and
+ * only then writes. A request already in flight when the crawl ended used to
+ * write the pre-teardown array back afterwards, resurrecting a session no tab
+ * was driving; the next scan then met faz_browser_scan_in_progress and the
+ * administrator waited out the idle TTL for a crawl that had finished.
+ *
+ * Deleting the transient cannot express "this was closed" — absence and "never
+ * existed" are the same observation, so a late writer has nothing to detect.
+ * The teardown now leaves a short-lived tombstone, and the touch path re-reads
+ * immediately before writing and abandons the write when it finds one.
+ *
+ * Run: php tests/unit/test-scan-session-teardown-race-php.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+define( 'DAY_IN_SECONDS', 86400 );
+define( 'HOUR_IN_SECONDS', 3600 );
+define( 'MINUTE_IN_SECONDS', 60 );
+define( 'YEAR_IN_SECONDS', 31536000 );
+
+$GLOBALS['faz_t']      = array();   // transient store
+$GLOBALS['faz_meta']   = array();
+$GLOBALS['faz_cookie'] = array();
+// Fires on the Nth read of the session key, so a teardown can be placed exactly
+// between touch()'s initial read and its re-read — the window the fix closes.
+// Firing on the FIRST read (the obvious thing, and what this harness did at
+// first) proves nothing: touch() then sees the closed session in its opening
+// validation and bails long before reaching the code under test, so the
+// assertions pass whether the fix is present or not.
+$GLOBALS['faz_on_read']       = null;
+$GLOBALS['faz_on_read_key']   = '';
+$GLOBALS['faz_on_read_after'] = 1;
+$GLOBALS['faz_read_count']    = 0;
+
+function sanitize_text_field( $v ) { return trim( strip_tags( (string) $v ) ); }
+function sanitize_key( $v ) { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $v ) ); }
+function __( $v, ...$u ) { return $v; }
+function esc_html__( $v, ...$u ) { return $v; }
+function wp_unslash( $v ) { return $v; }
+function absint( $v ) { return abs( (int) $v ); }
+function home_url( $p = '' ) { return 'https://example.test' . $p; }
+function admin_url( $p = '' ) { return 'https://example.test/wp-admin/' . ltrim( (string) $p, '/' ); }
+function wp_parse_url( $u, $c = -1 ) { return parse_url( $u, $c ); }
+function is_ssl() { return true; }
+function get_current_user_id() { return 7; }
+function wp_doing_ajax() { return false; }
+function is_admin() { return false; }
+function wp_generate_uuid4() { return sprintf( '%08x-0000-4000-8000-%012x', mt_rand(), mt_rand() ); }
+function wp_rand( $min = 0, $max = 0 ) { return mt_rand( $min, $max ); }
+function get_user_meta( $u, $k, $single = false ) { return $GLOBALS['faz_meta'][ $k ] ?? array(); }
+function delete_user_meta( $u, $k, $v = '' ) { unset( $GLOBALS['faz_meta'][ $k ] ); return true; }
+function add_user_meta( $u, $k, $v, $unique = false ) { $GLOBALS['faz_meta'][ $k ][] = $v; return true; }
+
+function get_transient( $key ) {
+	if ( $GLOBALS['faz_on_read'] && $key === $GLOBALS['faz_on_read_key'] ) {
+		++$GLOBALS['faz_read_count'];
+		if ( $GLOBALS['faz_read_count'] > $GLOBALS['faz_on_read_after'] ) {
+			$cb = $GLOBALS['faz_on_read'];
+			$GLOBALS['faz_on_read'] = null;   // one shot
+			$cb( $key );
+			return $GLOBALS['faz_t'][ $key ] ?? false;   // post-callback state
+		}
+	}
+	return $GLOBALS['faz_t'][ $key ] ?? false;
+}
+function set_transient( $key, $value, $ttl = 0 ) { $GLOBALS['faz_t'][ $key ] = $value; return true; }
+function delete_transient( $key ) { unset( $GLOBALS['faz_t'][ $key ] ); return true; }
+
+require_once dirname( __DIR__, 2 ) . '/admin/modules/scanner/includes/class-controller.php';
+
+use FazCookie\Admin\Modules\Scanner\Includes\Controller;
+
+$ok = 0; $ko = 0;
+function t( $c, $l ) { global $ok, $ko; if ( $c ) { ++$ok; echo "  PASS $l\n"; } else { ++$ko; echo "  FAIL $l\n"; } }
+
+$ctl   = Controller::get_instance();
+$token = str_repeat( 'ab', 16 );
+$scan  = str_repeat( 'cd', 16 );
+
+$ref       = new ReflectionClass( $ctl );
+$key_m     = $ref->getMethod( 'browser_scan_transient_key' );     $key_m->setAccessible( true );
+$akey_m    = $ref->getMethod( 'browser_scan_active_transient_key' ); $akey_m->setAccessible( true );
+$tomb_m    = $ref->getMethod( 'tombstone_browser_scan_session' ); $tomb_m->setAccessible( true );
+$skey      = $key_m->invoke( null, $token );
+$akey      = $akey_m->invoke( null, 7 );
+
+$seed = function () use ( $skey, $akey, $token, $scan ) {
+	$GLOBALS['faz_t'] = array(
+		$skey => array( 'user_id' => 7, 'scan_id' => $scan, 'created_at' => time(), 'touched_at' => time() ),
+		$akey => array( 'token' => $token, 'scan_id' => $scan, 'created_at' => time() ),
+	);
+};
+
+// 1. The baseline the fix must not break: a live session still slides.
+$seed();
+$GLOBALS['faz_on_read'] = null;
+t( true === $ctl->touch_browser_scan_session( $token, $scan ), 'a live session is still renewed by a heartbeat' );
+t( ! empty( $GLOBALS['faz_t'][ $skey ]['user_id'] ), 'and the session survives the renewal' );
+
+// 2. The race itself. The teardown lands after touch() has read and validated,
+//    which is precisely the window that used to resurrect the session.
+$seed();
+// The REAL teardown, not the tombstone helper. Calling the helper directly
+// tested that touch() reacts to a tombstone, which is true but does not prove
+// the teardown produces one — a first version of this test did exactly that and
+// stayed green when the teardown was reverted to a plain delete.
+// finish_browser_scan_session() identifies the session from the marker cookie,
+// exactly as the real teardown request does.
+$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $token;
+$GLOBALS['faz_on_read_key']   = $skey;
+$GLOBALS['faz_on_read_after'] = 1;   // let the initial read through, fire on the re-read
+$GLOBALS['faz_read_count']    = 0;
+$GLOBALS['faz_on_read'] = function () use ( $ctl, $scan ) {
+	$ctl->finish_browser_scan_session( $scan );   // teardown, mid-flight
+};
+$resurrected = $ctl->touch_browser_scan_session( $token, $scan );
+t( false === $resurrected, 'a heartbeat that raced a teardown reports failure' );
+unset( $_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] );
+$after = $GLOBALS['faz_t'][ $skey ] ?? false;
+t( empty( $after['user_id'] ), 'and does NOT write the pre-teardown session back' );
+
+// 3. The regression this fix could have introduced: the tombstone is an array,
+//    so a reader that only checked is_array() would mistake it for a live
+//    session and refuse the next scan — the very symptom #245 describes.
+$GLOBALS['faz_t'] = array();
+$tomb_m->invoke( null, $token, 7 );
+// is_browser_scan_request() is the guard that decides whether a request belongs
+// to a live capture session; it requires user_id, which a tombstone has not.
+$_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] = $token;
+t( false === Controller::is_browser_scan_request(), 'a tombstone is not mistaken for a live capture session' );
+unset( $_COOKIE[ Controller::BROWSER_SCAN_COOKIE ] );
+$tombstone = $GLOBALS['faz_t'][ $akey ] ?? array();
+t( empty( $tombstone['token'] ) && empty( $tombstone['scan_id'] ),
+	'and carries none of the fields the active-session guards require' );
+
+echo "\nscan session teardown race: $ok passed, $ko failed\n";
+exit( $ko > 0 ? 1 : 0 );

--- a/tests/unit/test-scanner-wp-auth-classification-php.php
+++ b/tests/unit/test-scanner-wp-auth-classification-php.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * #243 — the scanner's known-set must not contradict the frontend name guard.
+ *
+ * Cookie_Database classified wordpress_logged_in_* as `necessary`, i.e. a
+ * cookie fit to appear in the public declaration, while
+ * Frontend::is_wp_internal_cookie() listed the same prefix as internal and
+ * suppressed it everywhere a visitor could see it. Two tables, one cookie,
+ * opposite answers; the strict one won only because every visitor-facing
+ * surface consults it too.
+ *
+ * These checks pin BOTH halves: the classification is now the honest one, and
+ * the visitor-facing outcome is unchanged — which is what makes the change
+ * safe to ship rather than merely tidier.
+ *
+ * Run: php tests/unit/test-scanner-wp-auth-classification-php.php
+ */
+
+define( 'ABSPATH', __DIR__ . '/' );
+
+require_once dirname( __DIR__, 2 ) . '/admin/modules/scanner/includes/class-cookie-database.php';
+
+use FazCookie\Admin\Modules\Scanner\Includes\Cookie_Database;
+
+$ok = 0; $ko = 0;
+function t( $c, $l ) { global $ok, $ko; if ( $c ) { ++$ok; echo "  PASS $l\n"; } else { ++$ko; echo "  FAIL $l\n"; } }
+
+$cat = static function ( $name ) {
+	$row = Cookie_Database::lookup( $name );
+	return is_array( $row ) && isset( $row['category'] ) ? (string) $row['category'] : '';
+};
+
+// The fix: an auth cookie a logged-out visitor never receives is internal.
+t( 'wordpress-internal' === $cat( 'wordpress_logged_in_9f2a41' ),
+	'wordpress_logged_in_* is classified wordpress-internal, not declarable' );
+
+// Its sibling was already right; the pair must now agree.
+t( $cat( 'wordpress_logged_in_9f2a41' ) === $cat( 'wordpress_sec_9f2a41' ),
+	'and agrees with wordpress_sec_*, the other half of the same auth pair' );
+
+// The regression guard. wordpress_test_cookie IS set for anonymous visitors on
+// wp-login.php, so it must stay declarable; sweeping the whole wordpress_*
+// family into the internal bucket would hide a cookie a visitor really gets.
+t( 'necessary' === $cat( 'wordpress_test_cookie' ),
+	'wordpress_test_cookie stays necessary — anonymous visitors do receive it' );
+
+// Prefix specificity still resolves; a bare wordpress_* stays internal.
+t( 'wordpress-internal' === $cat( 'wordpress_deadbeef' ),
+	'an unrecognised wordpress_* prefix stays internal' );
+
+// The invariant that makes this a no-op for visitors: the frontend name guard
+// already suppressed this cookie, and still does. Asserted against the real
+// list rather than a copy of it, so the two cannot drift apart again silently.
+$frontend = file_get_contents( dirname( __DIR__, 2 ) . '/frontend/class-frontend.php' );
+$guard    = strstr( $frontend, 'public static function is_wp_internal_cookie' );
+$guard    = false === $guard ? '' : substr( $guard, 0, 2000 );
+t( '' !== $guard && false !== strpos( $guard, "'wordpress_logged_in_'" ),
+	'Frontend::is_wp_internal_cookie() still lists the prefix, so nothing visible changes' );
+
+echo "\nscanner WP auth classification: $ok passed, $ko failed\n";
+exit( $ko > 0 ? 1 : 0 );

--- a/tests/unit/test-scanner-wp-auth-classification-php.php
+++ b/tests/unit/test-scanner-wp-auth-classification-php.php
@@ -39,8 +39,7 @@ t( $cat( 'wordpress_logged_in_9f2a41' ) === $cat( 'wordpress_sec_9f2a41' ),
 	'and agrees with wordpress_sec_*, the other half of the same auth pair' );
 
 // The regression guard. wordpress_test_cookie IS set for anonymous visitors on
-// wp-login.php, so it must stay declarable; sweeping the whole wordpress_*
-// family into the internal bucket would hide a cookie a visitor really gets.
+// wp-login.php, so its catalogue classification stays necessary; the display guard is a separate policy tested below.
 t( 'necessary' === $cat( 'wordpress_test_cookie' ),
 	'wordpress_test_cookie stays necessary — anonymous visitors do receive it' );
 
@@ -51,11 +50,13 @@ t( 'wordpress-internal' === $cat( 'wordpress_deadbeef' ),
 // The invariant that makes this a no-op for visitors: the frontend name guard
 // already suppressed this cookie, and still does. Asserted against the real
 // list rather than a copy of it, so the two cannot drift apart again silently.
-$frontend = file_get_contents( dirname( __DIR__, 2 ) . '/frontend/class-frontend.php' );
-$guard    = strstr( $frontend, 'public static function is_wp_internal_cookie' );
-$guard    = false === $guard ? '' : substr( $guard, 0, 2000 );
-t( '' !== $guard && false !== strpos( $guard, "'wordpress_logged_in_'" ),
-	'Frontend::is_wp_internal_cookie() still lists the prefix, so nothing visible changes' );
+require_once dirname( __DIR__, 2 ) . '/frontend/class-frontend.php';
+t( \FazCookie\Frontend\Frontend::is_wp_internal_cookie( 'wordpress_logged_in_9f2a41' ),
+	'the real frontend guard suppresses the authentication cookie' );
+t( ! \FazCookie\Frontend\Frontend::is_wp_internal_cookie( '_ga' ),
+	'the guard does not suppress an unrelated analytics cookie' );
+t( \FazCookie\Frontend\Frontend::is_wp_internal_cookie( 'wordpress_test_cookie' ),
+	'test-cookie classification stays necessary while its existing display guard stays unchanged' );
 
 echo "\nscanner WP auth classification: $ok passed, $ko failed\n";
 exit( $ko > 0 ? 1 : 0 );


### PR DESCRIPTION
Two scanner defects, one of them the session race reported in #245 and still reproducible yesterday.

## #245 — a finished scan could come back to life

`touch_browser_scan_session()` reads the session transient, validates it, and only then writes. A capture request already in flight when the crawl ended wrote its pre-teardown array back afterwards. The session returned with no tab driving it, and the next scan met `faz_browser_scan_in_progress` until the idle TTL expired — an administrator waiting out a crawl that had already finished.

Deleting the transient cannot express *"this was closed"*: absence and "never existed" are the same observation, so a late writer has nothing to detect. The teardown now leaves a 60-second tombstone instead, and the touch path re-reads immediately before writing and abandons the write when it finds one.

The tombstone carries only `faz_closed_at`. Every other reader of these two transients already requires a specific field (`user_id`, `token`, `scan_id`), so a tombstone is rejected naturally and cannot itself block the next scan — which would have reproduced the very symptom being fixed. Checked at all five read sites.

## #243 — a classification that was right by accident

Two tables described `wordpress_logged_in_*` and they disagreed. `Cookie_Database` had it in the "frontend-visible (necessary, shown in banner)" group, i.e. fit for the public declaration; `Frontend::is_wp_internal_cookie()` listed the same prefix as internal and suppressed it. The strict answer won only because all seven visitor-facing surfaces consult the name guard as well.

It is an authentication cookie — a logged-out visitor never receives one — and its sibling `wordpress_sec_*` was already internal. The pair is reunited. No visible change, and the test pins that as an invariant rather than leaving it as a claim.

`wordpress_test_cookie` deliberately stays `necessary`: anonymous visitors really do receive it on `wp-login.php`.

This is one slice of #243, not its closure — see the issue for what the review of the other two directions found.

## Testing

Both fixes are mutation-proven, and both tests needed the proof: the #245 test passed against deliberately broken code **twice** before it was measuring anything.

- It first invoked the tombstone helper directly instead of the real teardown, so it verified that `touch()` reacts to a tombstone — true, and no evidence that the teardown produces one.
- It then fired the teardown on the *first* read, where `touch()` sees the closed session in its opening validation and bails long before reaching the code under test.

Only with the teardown injected between the initial read and the re-read do the assertions discriminate. Reverting either half of the fix now turns them red.

- `tests/unit/test-scan-session-teardown-race-php.php` — 6 checks
- `tests/unit/test-scanner-wp-auth-classification-php.php` — 5 checks
- Neighbouring suites unchanged: visitor-check 59, server-cookie-guard 68, cookie-content-i18n 127, scanner-coverage 56

No frontend JS touched, so no `build:min` needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Correzioni**
  - Migliorata la gestione delle sessioni di scansione del browser durante chiusure, rinnovi e riprese simultanei, evitando il ripristino involontario di sessioni terminate.
  - Corretta la classificazione del cookie di autenticazione WordPress `wordpress_logged_in_` come cookie interno di WordPress.

- **Test**
  - Ampliati i controlli automatici su sessioni concorrenti, scadenze, accessi amministrativi, versioni di rilascio e classificazione dei cookie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->