### PR TITLE
fix(e2e): give the login a budget, and actually call the baseline reset (#262)

### DIFF
--- a/tests/e2e/fixtures/wp-fixture.ts
+++ b/tests/e2e/fixtures/wp-fixture.ts
@@ -48,20 +48,52 @@ const TECHNICAL_COOKIE_RE = [
 
 const isTechnicalCookie = (name: string): boolean => TECHNICAL_COOKIE_RE.some((re) => re.test(name));
 
-async function gotoResilient(page: Page, url: string): Promise<void> {
+/**
+ * How long the whole login is allowed to take, and the slice each attempt gets.
+ *
+ * These used to be independent of the test budget, and that made the retry loops
+ * decorative: one page.goto was allowed 60s plus a 60s load wait — 120s — inside
+ * a 90s test. The outer budget killed the run before a second attempt could
+ * start, so a slow login never retried; it just died, and reported
+ * "Test timeout exceeded" pointing at whatever line happened to be awaiting.
+ *
+ * Measured cost of that: a release-verification run produced 14 red tests across
+ * six specs that have nothing to do with authentication. The first failure was a
+ * login (`#wpadminbar` never appeared); everything after it was a spec operating
+ * on a page it believed was wp-admin — saves that silently did nothing, reads
+ * that returned pre-existing values. Hours to attribute, and nothing wrong with
+ * the product.
+ *
+ * A shared deadline fixes the shape rather than the number: several fast
+ * attempts now fit where one slow attempt used to consume everything, and when
+ * the budget really is exhausted the error names the login instead of a timeout
+ * on an unrelated locator.
+ */
+const LOGIN_TOTAL_BUDGET_MS = 60_000;
+const LOGIN_ATTEMPT_MS = 12_000;
+
+/** Milliseconds left before `deadline`, floored at 1 so callers never pass 0 (= no timeout). */
+function remaining(deadline: number, cap = LOGIN_ATTEMPT_MS): number {
+  return Math.max(1, Math.min(cap, deadline - Date.now()));
+}
+
+async function gotoResilient(page: Page, url: string, deadline: number): Promise<void> {
   let lastError: unknown;
   for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (Date.now() >= deadline) break;
     try {
-      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60_000 });
-      await page.waitForLoadState('domcontentloaded', { timeout: 60_000 }).catch(() => {
-        // Some WordPress/plugin combinations keep requests open longer than needed.
-      });
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: remaining(deadline) });
+      await page
+        .waitForLoadState('domcontentloaded', { timeout: remaining(deadline, 5_000) })
+        .catch(() => {
+          // Some WordPress/plugin combinations keep requests open longer than needed.
+        });
       return;
     } catch (error) {
       lastError = error;
     }
   }
-  throw lastError;
+  throw lastError ?? new Error(`gotoResilient: budget exhausted before reaching ${url}`);
 }
 
 /**
@@ -71,20 +103,20 @@ async function gotoResilient(page: Page, url: string): Promise<void> {
  * banner_default which the plugin treats as an auth-impacting change).
  * The caller wraps this in a retry that clears cookies between attempts.
  */
-async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: string, adminPass: string): Promise<void> {
+async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: string, adminPass: string, deadline: number): Promise<void> {
   const loginPath = getWpLoginPath();
-  await gotoResilient(page, `${wpBaseURL}${loginPath}`);
+  await gotoResilient(page, `${wpBaseURL}${loginPath}`, deadline);
 
   // Lucky path: existing session cookie still valid and WP redirected
   // straight to /wp-admin/. NB: a `reauth=1` URL landing on wp-login.php
   // is NOT this branch — WP keeps the URL on /wp-login.php while the
   // partial cookie is rejected, so we fall through to fill below.
   if (page.url().includes('/wp-admin/') && !page.url().includes('reauth=')) {
-    await expect(page.locator('#wpadminbar')).toBeVisible();
+    await expect(page.locator('#wpadminbar')).toBeVisible({ timeout: remaining(deadline) });
     return;
   }
 
-  await expect(page.locator('#user_login')).toBeVisible({ timeout: 20_000 });
+  await expect(page.locator('#user_login')).toBeVisible({ timeout: remaining(deadline) });
   // The login document may still be settling after a slow reauth redirect.
   // Locator.fill() then repeats actionability checks until the whole test
   // times out even though the fields are already visible. Set the native
@@ -107,14 +139,14 @@ async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: strin
   // deliberately 60 seconds. Trigger the native click without Playwright's
   // implicit navigation wait and let the explicit waiter own that budget.
   await Promise.all([
-    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: 60_000 }).catch(() => {
+    page.waitForNavigation({ waitUntil: 'domcontentloaded', timeout: remaining(deadline) }).catch(() => {
       // Some plugin combinations keep the request open after auth succeeds.
     }),
     page.locator('#wp-submit').evaluate((button: HTMLInputElement) => button.click()),
   ]);
 
   if (page.url().includes('/wp-admin/')) {
-    await expect(page.locator('#wpadminbar')).toBeVisible();
+    await expect(page.locator('#wpadminbar')).toBeVisible({ timeout: remaining(deadline) });
     await expect(page.locator('#loginform')).toHaveCount(0);
     return;
   }
@@ -122,9 +154,9 @@ async function attemptAdminLogin(page: Page, wpBaseURL: string, adminUser: strin
   const cookies = await page.context().cookies(wpBaseURL);
   const hasLoggedCookie = cookies.some((cookie) => cookie.name.startsWith('wordpress_logged_in_'));
   if (hasLoggedCookie) {
-    await gotoResilient(page, `${wpBaseURL}/wp-admin/`);
-    await expect(page).toHaveURL(/\/wp-admin\//, { timeout: 20_000 });
-    await expect(page.locator('#wpadminbar')).toBeVisible();
+    await gotoResilient(page, `${wpBaseURL}/wp-admin/`, deadline);
+    await expect(page).toHaveURL(/\/wp-admin\//, { timeout: remaining(deadline) });
+    await expect(page.locator('#wpadminbar')).toBeVisible({ timeout: remaining(deadline) });
     await expect(page.locator('#loginform')).toHaveCount(0);
     return;
   }
@@ -144,24 +176,36 @@ export async function completeAdminLogin(page: Page, wpBaseURL: string, adminUse
   // try is a true fresh login rather than another reauth roundtrip
   // against the same stale cookie. Pattern matches Playwright's own
   // recommended retry-on-flaky-auth approach.
+  // One budget for the whole login, shared by every attempt below.
+  const deadline = Date.now() + LOGIN_TOTAL_BUDGET_MS;
   let lastError: unknown;
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
+  let attempts = 0;
+  // Bounded by the DEADLINE, not by a fixed count. Two was the old cap, and with
+  // 12s attempts inside a 60s budget it would leave most of the budget unused —
+  // the opposite of the original bug but the same mistake: a number picked
+  // without reference to the one that governs it. MAX_LOGIN_ATTEMPTS is only a
+  // runaway guard.
+  const MAX_LOGIN_ATTEMPTS = 4;
+  while (attempts < MAX_LOGIN_ATTEMPTS && Date.now() < deadline) {
+    attempts += 1;
     try {
-      await attemptAdminLogin(page, wpBaseURL, adminUser, adminPass);
+      await attemptAdminLogin(page, wpBaseURL, adminUser, adminPass, deadline);
       return;
     } catch (error) {
       lastError = error;
-      if (attempt < 2) {
-        try {
-          await page.context().clearCookies();
-        } catch {
-          // Non-fatal — the retry will still reach wp-login.php and WP
-          // will issue fresh cookies on a successful POST.
-        }
+      try {
+        await page.context().clearCookies();
+      } catch {
+        // Non-fatal — the retry will still reach wp-login.php and WP
+        // will issue fresh cookies on a successful POST.
       }
     }
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  // Name the login. The whole point of a budget is that an exhausted one reports
+  // itself, instead of surfacing later as a timeout on whatever locator the spec
+  // happened to be awaiting when the page was never wp-admin.
+  const detail = lastError instanceof Error ? lastError.message : String(lastError ?? 'no attempt completed');
+  throw new Error(`admin login failed after ${attempts} attempt(s) within ${LOGIN_TOTAL_BUDGET_MS}ms: ${detail}`);
 }
 
 export const test = base.extend<WPFixtures, WPWorkerFixtures>({

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -2,8 +2,17 @@ import { request } from '@playwright/test';
 import { assertPrerequisites } from './utils/preflight';
 import { getWpLoginPath } from './utils/wp-auth';
 import { wpEval } from './utils/wp-env';
+import { resetBaseline } from './utils/seed-defaults';
 
 async function globalSetup(): Promise<void> {
+  // Put the site on a known baseline before anything runs. resetBaseline() has
+  // existed in utils/seed-defaults.ts and was called by NOBODY — a reset written
+  // and never wired in, so every run inherited whatever the previous one left
+  // behind. That is how a release-verification run produced twelve reds across
+  // specs that assert banner copy: the site was still on the Italian default a
+  // prior, interrupted run had set.
+  resetBaseline();
+
   const baseURL = process.env.WP_BASE_URL ?? 'http://127.0.0.1:9998';
   const adminUser = process.env.WP_ADMIN_USER ?? 'admin';
   const adminPass = process.env.WP_ADMIN_PASS ?? 'admin';

--- a/tests/e2e/specs/rc-1290-acceptance.spec.ts
+++ b/tests/e2e/specs/rc-1290-acceptance.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../fixtures/wp-fixture';
+import { readFileSync } from 'node:fs';
 import { deleteOption, setOption, wpEval } from '../utils/wp-env';
 
 /**
@@ -66,21 +67,44 @@ async function snapshotOption(name: string): Promise<() => void> {
   };
 }
 
-const RC_VERSION = '1.29.0-rc1';
+/**
+ * The version this run is meant to be testing.
+ *
+ * Pinned to the literal '1.29.0-rc1' at first, which made the check fail the
+ * moment 1.29.0 shipped — the assertion was about one release rather than about
+ * staleness, so it was guaranteed to go red at every future release and teach
+ * everyone to ignore it. It now reads the repo's own plugin header, which is
+ * what "the build under test" means when the deploy comes from this working
+ * copy; FAZ_EXPECTED_VERSION overrides it when the target is a package built
+ * elsewhere.
+ */
+const EXPECTED_VERSION =
+  process.env.FAZ_EXPECTED_VERSION ||
+  (readFileSync(new URL('../../../faz-cookie-manager.php', import.meta.url), 'utf8')
+    .match(/^\s*\*\s*Version:\s*(\S+)\s*$/m)?.[1] ?? '');
 
-test.describe('1.29.0-rc1 acceptance', () => {
-  test('the build under test is the RC, and it is the one WordPress loaded', async () => {
+const IS_PRERELEASE = /-(rc|beta|alpha)\d+$/.test(EXPECTED_VERSION);
+
+test.describe('1.29.0 release acceptance', () => {
+  test('the build under test is the expected one, and it is what WordPress loaded', async () => {
+    expect(EXPECTED_VERSION, 'could not read a version to expect').not.toBe('');
+
     // Everything below is worthless if it ran against a stale deploy. Ask
     // WordPress what it loaded rather than reading the repo's own file.
     const loaded = wpEval('echo defined("FAZ_VERSION") ? FAZ_VERSION : "undefined";').trim();
-    expect(loaded).toBe(RC_VERSION);
+    expect(loaded, `WordPress loaded ${loaded}; expected ${EXPECTED_VERSION}`).toBe(EXPECTED_VERSION);
 
-    // An RC must not claim the stable tag: that is the pointer wordpress.org
-    // serves as the stable download.
+    // Stable tag is the pointer wordpress.org serves as the stable download.
+    // The invariant runs BOTH ways, which is what makes it hold across
+    // releases: a pre-release must never claim it, and a final release must.
     const stable = wpEval(
       'echo get_file_data( WP_PLUGIN_DIR . "/faz-cookie-manager/faz-cookie-manager.php", array( "s" => "Stable tag" ) )["s"];'
     ).trim();
-    expect(stable).not.toBe(RC_VERSION);
+    if (IS_PRERELEASE) {
+      expect(stable, 'a pre-release must not claim the stable tag').not.toBe(loaded);
+    } else {
+      expect(stable, 'a final release must claim its own stable tag').toBe(loaded);
+    }
   });
 
   test('#263 — a stale downloaded definitions copy no longer shadows the bundle', async () => {

--- a/tests/e2e/utils/seed-defaults.ts
+++ b/tests/e2e/utils/seed-defaults.ts
@@ -67,6 +67,29 @@ export function resetBaseline(): void {
       $faz_settings['geolocation'] = array();
     }
     $faz_settings['geolocation']['geo_targeting'] = false;
+
+    // Language baseline. Specs that need another language set their own and
+    // restore it (banner-i18n-non-english, multilingual-edge), but a run that is
+    // interrupted — or a spec that fails before its afterAll — leaves the site
+    // on whatever it had configured. Everything that asserts banner COPY then
+    // reads Italian where it expects English, and reports it as a content bug:
+    // reads the Italian banner title on a test that never mentions language.
+    // Normalising here costs nothing for the specs that override it.
+    // Only the DEFAULT is normalised, and 'en' is ensured present in the
+    // selection. Replacing the whole languages block with English-only was the
+    // first attempt and was too blunt: specs assert the settings payload and
+    // several need other locales selected, so dropping them traded one class of
+    // failure for another. The polluting axis is the default — it decides which
+    // copy the banner renders — not the size of the selection.
+    if ( ! isset( $faz_settings['languages'] ) || ! is_array( $faz_settings['languages'] ) ) {
+      $faz_settings['languages'] = array();
+    }
+    $selected = $faz_settings['languages']['selected'] ?? array();
+    if ( ! is_array( $selected ) ) { $selected = array(); }
+    if ( ! in_array( 'en', $selected, true ) ) { array_unshift( $selected, 'en' ); }
+    $faz_settings['languages']['selected'] = array_values( $selected );
+    $faz_settings['languages']['default']  = 'en';
+
     update_option( 'faz_settings', $faz_settings );
 
     delete_option( 'faz_banner_template' );


### PR DESCRIPTION
Two harness defects found while working out why the full suite showed 14 reds. Neither was a product regression — all three suspect specs pass in isolation — but both make the suite lie about what it measured.

## The login had no budget

`loginAsAdmin()` retried on a fixed per-attempt timeout with no overall ceiling, so a slow or wedged login could burn minutes before failing, and the failure surfaced as whatever assertion came next rather than as a login problem. It now runs against a shared 60-second deadline: each attempt gets what remains, capped at 12 seconds, and the loop is bounded by the deadline rather than by a retry count (`MAX_LOGIN_ATTEMPTS = 4` stays only as a runaway guard). A failure now says so plainly — `admin login failed after N attempt(s) within 60000ms: …`.

This matters beyond tidiness. A login failure mid-suite looks exactly like a product bug in whichever spec inherited the broken session, and that is how it wasted time: I first blamed language contamination, dismissed it because a language-aware spec passed, and only later found the real first cause. In a cascade only the first error informs; everything after it describes the world after the break.

## The baseline reset existed and nothing called it

`resetBaseline()` was written, exported, and invoked by nobody — so every run started from whatever the previous one left behind. `global-setup.ts` now calls it first.

It is deliberately gentle. It normalises `languages.default` to `en` and ensures `en` is in `selected`; it does **not** prune other locales. A first, more aggressive version that forced `selected: ['en']` took the suite from 12 reds to 16 — a reset that destroys state other specs legitimately rely on is worse than no reset.

## Testing

The full suite has not run to completion against this branch: the machine hit a load average of 395 mid-run and nginx started returning upstream timeouts, which produces reds that say nothing about the code. The three specs these changes were meant to stabilise pass in isolation. I would rather say that than present an interrupted run as a green one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Test**
  * Migliorata l’affidabilità dei test end-to-end, con gestione più robusta dei tentativi di accesso amministrativo e dei tempi massimi.
  * L’ambiente di test viene ora ripristinato automaticamente a una configurazione di base coerente, inclusa la lingua predefinita inglese.
  * Aggiornati i controlli di accettazione per verificare dinamicamente la versione del plugin e la coerenza del relativo tag di stabilità.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->