### PR TITLE
feat(policy): Cookie Policy templates in Dutch and Croatian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to FAZ Cookie Manager are documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Cookie Policy templates in Dutch and Croatian for all four jurisdictions (GDPR, CCPA/CPRA, LGPD, POPIA). Both locales already offered a translated interface and were selectable as a policy language, but no template shipped for them, so the generator fell back to English and produced a legal document in the wrong language without saying so. The Cookie Policy screen already shows the shipped text as the placeholder in each override box, so those boxes now show Dutch and Croatian and the "no template ships for this language" notice no longer appears.
+
 ## [1.29.0] - 2026-09-02
 
 ### Fixed

--- a/admin/modules/cookie-policy-generator/includes/class-generator.php
+++ b/admin/modules/cookie-policy-generator/includes/class-generator.php
@@ -49,7 +49,7 @@ class Generator {
 	 *
 	 * @var string[]
 	 */
-	const LANGUAGES = array( 'en', 'it', 'fr', 'de', 'es', 'pt-BR', 'bg', 'cs' );
+	const LANGUAGES = array( 'en', 'it', 'fr', 'de', 'es', 'pt-BR', 'bg', 'cs', 'nl', 'hr' );
 
 	/**
 	 * Canonicalise and validate a policy language code.

--- a/admin/modules/cookie-policy-generator/includes/cookie-policy-gettext-catalog.php
+++ b/admin/modules/cookie-policy-generator/includes/cookie-policy-gettext-catalog.php
@@ -208,7 +208,9 @@ As a California resident, you have the right to:
 - **Right to Non-Discrimination** (§ 1798.125) — we will not discriminate against you for exercising any of these rights
 - **Right to Data Portability** (§ 1798.130(a)(2)) — receive Personal Information in a readily usable format
 
-To submit a request, email **{{COMPANY_EMAIL}}** or use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. We will verify your identity (CCPA § 1798.130(a)(2)) and respond within **45 days** (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+To exercise the rights to know, delete, correct or port, email **{{COMPANY_EMAIL}}**. Those are verifiable consumer requests, so we will verify your identity before acting (CCPA § 1798.130(a)(2)), and we will respond within **45 days** (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+
+To opt out of the sale or sharing of your Personal Information, use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. An opt-out is **not** a verifiable consumer request: we will act on it without asking you to verify your identity or to create an account.
 
 You may also designate an authorized agent to submit a request on your behalf (Cal. Civ. Code § 1798.135(c)).',
 			'Cookie policy template: ccpa-california / section-8',

--- a/admin/modules/cookie-policy-generator/templates/ccpa-california/en.md
+++ b/admin/modules/cookie-policy-generator/templates/ccpa-california/en.md
@@ -67,7 +67,9 @@ As a California resident, you have the right to:
 - **Right to Non-Discrimination** (§ 1798.125) — we will not discriminate against you for exercising any of these rights
 - **Right to Data Portability** (§ 1798.130(a)(2)) — receive Personal Information in a readily usable format
 
-To submit a request, email **{{COMPANY_EMAIL}}** or use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. We will verify your identity (CCPA § 1798.130(a)(2)) and respond within **45 days** (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+To exercise the rights to know, delete, correct or port, email **{{COMPANY_EMAIL}}**. Those are verifiable consumer requests, so we will verify your identity before acting (CCPA § 1798.130(a)(2)), and we will respond within **45 days** (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+
+To opt out of the sale or sharing of your Personal Information, use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. An opt-out is **not** a verifiable consumer request: we will act on it without asking you to verify your identity or to create an account.
 
 You may also designate an authorized agent to submit a request on your behalf (Cal. Civ. Code § 1798.135(c)).
 

--- a/admin/modules/cookie-policy-generator/templates/ccpa-california/hr.md
+++ b/admin/modules/cookie-policy-generator/templates/ccpa-california/hr.md
@@ -1,0 +1,88 @@
+# Notice at Collection i pravila o kolačićima
+
+**Posljednje ažuriranje:** {{LAST_UPDATED_DATE}}
+
+Ova Notice at Collection i pravila o kolačićima objašnjavaju kako **{{COMPANY_NAME}}** ("mi", "nas", "naš") prikuplja, upotrebljava i dijeli Personal Information putem ove web stranice, u skladu s California Consumer Privacy Act of 2018, kako je izmijenjen California Privacy Rights Actom (CCPA/CPRA, Cal. Civ. Code §§ 1798.100 i dalje), te provedbenim propisima California Privacy Protection Agencyja (CPPA).
+
+## Kontakt poslovnog subjekta
+
+- **Naziv subjekta:** {{COMPANY_NAME}}
+- **Adresa:** {{COMPANY_ADDRESS}}
+- **E-pošta za pitanja privatnosti:** {{COMPANY_EMAIL}}
+- **Registracija:** {{COMPANY_REGISTRY}}
+
+## Kategorije prikupljenih Personal Information
+
+Prikupljamo sljedeće kategorije Personal Information kako su definirane u CCPA § 1798.140(v):
+
+- **Identifiers** — IP adresa (heširana), identifikatori uređaja, mrežni identifikatori (kolačići, beaconi)
+- **Podaci o internetskoj ili drugoj elektroničkoj mrežnoj aktivnosti** — povijest pregledavanja, povijest pretraživanja, interakcije s našom web stranicom
+- **Podaci o geolokaciji** — približna lokacija izvedena iz IP adrese (samo država/regija; ne precizni GPS)
+- **Zaključci** — sklonosti i obilježja izvedeni iz vaših interakcija, koji se upotrebljavaju za analitiku stranice
+
+**Ne** prikupljamo svjesno:
+- Sensitive Personal Information (Cal. Civ. Code § 1798.140(ae)) bez vaše izričite privole
+- Personal Information potrošača mlađih od 16 godina bez potvrdne privole (za djecu mlađu od 13 godina potrebna je privola roditelja)
+
+## Izvori Personal Information
+
+- Izravno od vas kada komunicirate sa stranicom (obrasci, odabiri u banneru, otvaranje računa)
+- Automatski putem kolačića i tehnologija praćenja
+- Od usluga trećih strana za koje ste odobrili dijeljenje podataka
+
+## Svrhe prikupljanja Personal Information
+
+- Rad i sigurnost web stranice (nužna poslovna svrha, § 1798.140(e))
+- Revizija interakcija s web stranicom
+- Kratkotrajna, prolazna upotreba Personal Information
+- Održavanje i poboljšanje kvalitete i sigurnosti naše usluge
+- Provođenje analitike uz vašu privolu
+- Personalizacija oglašavanja **isključivo uz vašu izričitu privolu**
+
+## Upotrijebljeni kolačići
+
+{{COOKIE_CATEGORIES}}
+
+## Treće strane koje primaju podatke
+
+Ako se niste izuzeli, Personal Information dijelimo sa sljedećim pružateljima usluga i izvođačima (CCPA § 1798.140(j) i (ag)):
+
+{{THIRD_PARTY_SERVICES}}
+
+**Ne prodajemo niti dijelimo Personal Information** za bihevioralno oglašavanje među kontekstima osim ako ste to izričito odobrili. Za izuzimanje u bilo kojem trenutku kliknite poveznicu "Do Not Sell or Share My Personal Information" u podnožju web stranice.
+
+## Čuvanje podataka
+
+Personal Information čuva se {{RETENTION_PERIOD}} od prikupljanja, osim ako je dulje razdoblje propisano zakonom ili nužno za legitimne poslovne svrhe (CCPA § 1798.100(a)(3)).
+
+## Vaša prava prema CCPA/CPRA
+
+Kao stanovnik Kalifornije imate pravo na:
+
+- **Right to Know** (§ 1798.100, .110, .115) — zatražiti koje Personal Information prikupljamo, upotrebljavamo, otkrivamo ili prodajemo
+- **Right to Delete** (§ 1798.105) — zatražiti brisanje svojih Personal Information
+- **Right to Correct** (§ 1798.106) — zatražiti ispravak netočnih Personal Information
+- **Right to Opt Out of Sale or Sharing** (§ 1798.120) — naložiti nam da ne prodajemo i ne dijelimo vaše Personal Information
+- **Right to Limit Use of Sensitive Personal Information** (§ 1798.121) — ograničiti našu upotrebu Sensitive Personal Information na objavljene svrhe
+- **Right to Non-Discrimination** (§ 1798.125) — nećemo vas stavljati u nepovoljniji položaj zbog ostvarivanja bilo kojeg od ovih prava
+- **Right to Data Portability** (§ 1798.130(a)(2)) — primiti Personal Information u lako upotrebljivom obliku
+
+Zahtjev pošaljite na **{{COMPANY_EMAIL}}** ili upotrijebite poveznice "Do Not Sell or Share" i "Upravljanje postavkama" u podnožju web stranice. Provjerit ćemo vaš identitet (CCPA § 1798.130(a)(2)) i odgovoriti u roku od **45 dana** (uz obavijest produživo na 90 dana, § 1798.130(a)(2)(B)).
+
+Možete i ovlastiti zastupnika da podnese zahtjev u vaše ime (Cal. Civ. Code § 1798.135(c)).
+
+## Global Privacy Control (GPC)
+
+Poštujemo signal [Global Privacy Control](https://globalprivacycontrol.org/) kao valjano izuzimanje od prodaje i dijeljenja, u skladu sa smjernicama za provedbu glavnog državnog odvjetnika Kalifornije.
+
+## Nadzorno tijelo
+
+Pritužbe se mogu podnijeti California Privacy Protection Agencyju: {{CA_PIPC_CONTACT}}, ili putem [{{OFFICIAL_RESOURCES_URL}}]({{OFFICIAL_RESOURCES_URL}}).
+
+## Izmjene
+
+Ovu Notice možemo ažurirati. Bitne izmjene najavit ćemo 30 dana unaprijed putem bannera na početnoj stranici. Mjerodavan je datum "Posljednje ažuriranje" iznad.
+
+## Kontakt
+
+Za sva pitanja o privatnosti pišite na **{{COMPANY_EMAIL}}**.

--- a/admin/modules/cookie-policy-generator/templates/ccpa-california/hr.md
+++ b/admin/modules/cookie-policy-generator/templates/ccpa-california/hr.md
@@ -67,7 +67,9 @@ Kao stanovnik Kalifornije imate pravo na:
 - **Right to Non-Discrimination** (§ 1798.125) — nećemo vas stavljati u nepovoljniji položaj zbog ostvarivanja bilo kojeg od ovih prava
 - **Right to Data Portability** (§ 1798.130(a)(2)) — primiti Personal Information u lako upotrebljivom obliku
 
-Zahtjev pošaljite na **{{COMPANY_EMAIL}}** ili upotrijebite poveznice "Do Not Sell or Share" i "Upravljanje postavkama" u podnožju web stranice. Provjerit ćemo vaš identitet (CCPA § 1798.130(a)(2)) i odgovoriti u roku od **45 dana** (uz obavijest produživo na 90 dana, § 1798.130(a)(2)(B)).
+Za prava na uvid, brisanje, ispravak ili prenosivost pišite na **{{COMPANY_EMAIL}}**. To su provjerljivi zahtjevi potrošača, pa ćemo prije postupanja provjeriti vaš identitet (CCPA § 1798.130(a)(2)) i odgovoriti u roku od **45 dana** (uz obavijest produživo na 90 dana, § 1798.130(a)(2)(B)).
+
+Za izuzimanje od prodaje ili dijeljenja vaših Personal Information upotrijebite poveznice "Do Not Sell or Share" i "Upravljanje postavkama" u podnožju web stranice. Izuzimanje **nije** provjerljiv zahtjev potrošača: postupit ćemo po njemu bez traženja provjere identiteta ili otvaranja računa.
 
 Možete i ovlastiti zastupnika da podnese zahtjev u vaše ime (Cal. Civ. Code § 1798.135(c)).
 

--- a/admin/modules/cookie-policy-generator/templates/ccpa-california/nl.md
+++ b/admin/modules/cookie-policy-generator/templates/ccpa-california/nl.md
@@ -67,7 +67,9 @@ Als inwoner van Californië hebt u het recht op:
 - **Right to Non-Discrimination** (§ 1798.125) — wij zullen u niet benadelen omdat u een van deze rechten uitoefent
 - **Right to Data Portability** (§ 1798.130(a)(2)) — Personal Information ontvangen in een direct bruikbaar formaat
 
-Stuur voor een verzoek een e-mail naar **{{COMPANY_EMAIL}}** of gebruik de links "Do Not Sell or Share" en "Voorkeuren beheren" in de voettekst van de website. Wij verifiëren uw identiteit (CCPA § 1798.130(a)(2)) en reageren binnen **45 dagen** (met kennisgeving verlengbaar tot 90 dagen, § 1798.130(a)(2)(B)).
+Stuur voor de rechten op inzage, verwijdering, correctie of overdraagbaarheid een e-mail naar **{{COMPANY_EMAIL}}**. Dat zijn verifieerbare consumentenverzoeken, dus wij verifiëren uw identiteit voordat wij handelen (CCPA § 1798.130(a)(2)) en reageren binnen **45 dagen** (met kennisgeving verlengbaar tot 90 dagen, § 1798.130(a)(2)(B)).
+
+Gebruik voor het afmelden van de verkoop of het delen van uw Personal Information de links "Do Not Sell or Share" en "Voorkeuren beheren" in de voettekst van de website. Een afmelding is **geen** verifieerbaar consumentenverzoek: wij voeren die uit zonder u te vragen uw identiteit te verifiëren of een account aan te maken.
 
 U kunt ook een gemachtigde aanwijzen om namens u een verzoek in te dienen (Cal. Civ. Code § 1798.135(c)).
 

--- a/admin/modules/cookie-policy-generator/templates/ccpa-california/nl.md
+++ b/admin/modules/cookie-policy-generator/templates/ccpa-california/nl.md
@@ -1,0 +1,88 @@
+# Notice at Collection en cookiebeleid
+
+**Laatst bijgewerkt:** {{LAST_UPDATED_DATE}}
+
+Deze Notice at Collection en dit cookiebeleid leggen uit hoe **{{COMPANY_NAME}}** ("wij", "ons", "onze") Personal Information via deze website verzamelt, gebruikt en deelt, in overeenstemming met de California Consumer Privacy Act of 2018, zoals gewijzigd door de California Privacy Rights Act (CCPA/CPRA, Cal. Civ. Code §§ 1798.100 e.v.), en de uitvoeringsregels van de California Privacy Protection Agency (CPPA).
+
+## Contactgegevens van de onderneming
+
+- **Naam onderneming:** {{COMPANY_NAME}}
+- **Adres:** {{COMPANY_ADDRESS}}
+- **E-mail privacycontact:** {{COMPANY_EMAIL}}
+- **Registratie:** {{COMPANY_REGISTRY}}
+
+## Categorieën verzamelde Personal Information
+
+Wij verzamelen de volgende categorieën Personal Information zoals gedefinieerd in CCPA § 1798.140(v):
+
+- **Identifiers** — IP-adres (gehasht), apparaat-identificatoren, online identificatoren (cookies, beacons)
+- **Internet- of andere elektronische netwerkactiviteit** — browsegeschiedenis, zoekgeschiedenis, interacties met onze website
+- **Geolocatiegegevens** — bij benadering afgeleid uit het IP-adres (uitsluitend land/regio; geen precieze GPS-locatie)
+- **Gevolgtrekkingen** — voorkeuren en kenmerken afgeleid uit uw interacties, gebruikt voor site-analyse
+
+Wij verzamelen **niet** bewust:
+- Sensitive Personal Information (Cal. Civ. Code § 1798.140(ae)) zonder uw uitdrukkelijke opt-in
+- Personal Information van consumenten jonger dan 16 zonder bevestigende opt-in (voor kinderen onder de 13 is toestemming van een ouder vereist)
+
+## Bronnen van Personal Information
+
+- Rechtstreeks van u wanneer u met de site interacteert (formulieren, keuzes in de banner, het aanmaken van een account)
+- Automatisch via cookies en trackingtechnologieën
+- Van diensten van derden waarvoor u het delen van gegevens hebt geautoriseerd
+
+## Doeleinden van het verzamelen van Personal Information
+
+- De website exploiteren en beveiligen (noodzakelijk bedrijfsdoel, § 1798.140(e))
+- Interacties met de website controleren
+- Kortstondig, tijdelijk gebruik van Personal Information
+- De kwaliteit en veiligheid van onze dienst behouden en verbeteren
+- Analyses uitvoeren met uw toestemming
+- Advertenties personaliseren **uitsluitend met uw opt-in-toestemming**
+
+## Gebruikte cookies
+
+{{COOKIE_CATEGORIES}}
+
+## Ontvangers die derde partij zijn
+
+Zolang u zich niet hebt afgemeld, delen wij Personal Information met de volgende dienstverleners en opdrachtnemers (CCPA § 1798.140(j) en (ag)):
+
+{{THIRD_PARTY_SERVICES}}
+
+Wij **verkopen of delen geen Personal Information** voor cross-context gedragsadvertenties tenzij u zich daarvoor hebt aangemeld. Om u op elk moment af te melden, klikt u op de link "Do Not Sell or Share My Personal Information" in de voettekst van de website.
+
+## Bewaartermijn
+
+Personal Information wordt {{RETENTION_PERIOD}} vanaf de verzameling bewaard, tenzij een langere termijn wettelijk vereist is of noodzakelijk is voor legitieme bedrijfsdoeleinden (CCPA § 1798.100(a)(3)).
+
+## Uw rechten onder CCPA/CPRA
+
+Als inwoner van Californië hebt u het recht op:
+
+- **Right to Know** (§ 1798.100, .110, .115) — opvragen welke Personal Information wij verzamelen, gebruiken, verstrekken of verkopen
+- **Right to Delete** (§ 1798.105) — verwijdering van uw Personal Information verzoeken
+- **Right to Correct** (§ 1798.106) — correctie van onjuiste Personal Information verzoeken
+- **Right to Opt Out of Sale or Sharing** (§ 1798.120) — ons opdragen uw Personal Information niet te verkopen of te delen
+- **Right to Limit Use of Sensitive Personal Information** (§ 1798.121) — ons gebruik van Sensitive Personal Information beperken tot de bekendgemaakte doeleinden
+- **Right to Non-Discrimination** (§ 1798.125) — wij zullen u niet benadelen omdat u een van deze rechten uitoefent
+- **Right to Data Portability** (§ 1798.130(a)(2)) — Personal Information ontvangen in een direct bruikbaar formaat
+
+Stuur voor een verzoek een e-mail naar **{{COMPANY_EMAIL}}** of gebruik de links "Do Not Sell or Share" en "Voorkeuren beheren" in de voettekst van de website. Wij verifiëren uw identiteit (CCPA § 1798.130(a)(2)) en reageren binnen **45 dagen** (met kennisgeving verlengbaar tot 90 dagen, § 1798.130(a)(2)(B)).
+
+U kunt ook een gemachtigde aanwijzen om namens u een verzoek in te dienen (Cal. Civ. Code § 1798.135(c)).
+
+## Global Privacy Control (GPC)
+
+Wij honoreren het [Global Privacy Control](https://globalprivacycontrol.org/)-signaal als een geldige afmelding voor verkoop of delen, conform de handhavingsrichtsnoeren van de California Attorney General.
+
+## Toezichthoudende autoriteit
+
+Klachten kunnen worden ingediend bij de California Privacy Protection Agency: {{CA_PIPC_CONTACT}}, of via [{{OFFICIAL_RESOURCES_URL}}]({{OFFICIAL_RESOURCES_URL}}).
+
+## Wijzigingen
+
+Wij kunnen deze Notice bijwerken. Wezenlijke wijzigingen worden 30 dagen van tevoren aangekondigd via een banner op de homepage. De datum "Laatst bijgewerkt" hierboven is bepalend.
+
+## Contact
+
+E-mail **{{COMPANY_EMAIL}}** met elke vraag over privacy.

--- a/admin/modules/cookie-policy-generator/templates/gdpr-strict/hr.md
+++ b/admin/modules/cookie-policy-generator/templates/gdpr-strict/hr.md
@@ -1,0 +1,68 @@
+# Pravila o kolačićima
+
+**Posljednje ažuriranje:** {{LAST_UPDATED_DATE}}
+
+Ova pravila o kolačićima objašnjavaju kako **{{COMPANY_NAME}}** ("mi", "nas", "naš") upotrebljava kolačiće i slične tehnologije na ovoj web stranici, u skladu s Općom uredbom o zaštiti podataka (GDPR, Uredba (EU) 2016/679) i Direktivom o e-privatnosti (2002/58/EZ, čl. 5. st. 3.).
+
+## Tko smo mi
+
+Voditelj obrade vaših osobnih podataka putem kolačića jest:
+
+- **Voditelj obrade:** {{COMPANY_NAME}}
+- **Adresa:** {{COMPANY_ADDRESS}}
+- **E-pošta:** {{COMPANY_EMAIL}}
+- **Registar / OIB:** {{COMPANY_REGISTRY}}
+- **Službenik za zaštitu podataka:** {{DPO_NAME}} — {{DPO_EMAIL}}
+
+## Što su kolačići
+
+Kolačići su male tekstualne datoteke koje se pohranjuju na vaš uređaj kada posjetite našu web stranicu. Omogućuju nam da prepoznamo vaš uređaj pri sljedećim posjetima, zapamtimo vaše postavke, mjerimo kako se stranica upotrebljava te da vam — uz vašu privolu — prikazujemo personalizirane oglase.
+
+Upotrebljavamo i slične tehnologije kao što su **localStorage**, **sessionStorage** i **pikseli za praćenje**. Kada se u ovim pravilima spominju "kolačići", pojam obuhvaća i te tehnologije.
+
+## Pravna osnova
+
+Za **nužne** kolačiće pravna je osnova naš legitimni interes na temelju čl. 6. st. 1. t. (f) GDPR-a te tehnička iznimka iz čl. 5. st. 3. Direktive o e-privatnosti.
+
+Za **sve ostale** kategorije kolačića pravna je osnova vaša **izričita privola** na temelju čl. 6. st. 1. t. (a) i čl. 7. GDPR-a, prikupljena putem bannera o kolačićima prije postavljanja bilo kojeg kolačića koji nije nužan.
+
+Privolu možete povući u svakom trenutku putem poveznice "Postavke kolačića" ili brisanjem kolačića; povlačenje ne utječe na zakonitost obrade provedene prije povlačenja (čl. 7. st. 3. GDPR-a).
+
+## Kolačići na ovoj stranici
+
+{{COOKIE_CATEGORIES}}
+
+## Usluge trećih strana
+
+Ako date privolu, ova stranica može učitati sadržaj sljedećih usluga trećih strana, koje postavljaju vlastite kolačiće:
+
+{{THIRD_PARTY_SERVICES}}
+
+Svaka treća strana samostalni je voditelj obrade za kolačiće koje postavlja; molimo da se upoznate s njihovim pravilima o privatnosti.
+
+## Koliko dugo čuvamo podatke
+
+Evidencije privola i analitički podaci čuvaju se {{RETENTION_PERIOD}} od prikupljanja. Nužni kolačići čuvaju se samo za trajanja sesije ili onoliko koliko zahtijeva tehnička funkcija koju obavljaju. Konkretno trajanje svakog kolačića navedeno je u tablici iznad.
+
+## Vaša prava
+
+Na temelju čl. 12. – 22. GDPR-a imate pravo:
+
+- na pristup osobnim podacima koje o vama obrađujemo (čl. 15.)
+- zatražiti ispravak netočnih podataka (čl. 16.)
+- zatražiti brisanje ("pravo na zaborav", čl. 17.)
+- ograničiti obradu (čl. 18.)
+- na prenosivost podataka (čl. 20.)
+- uložiti prigovor na obradu koja se temelji na legitimnom interesu (čl. 21.)
+- povući privolu u svakom trenutku (čl. 7. st. 3.)
+- podnijeti pritužbu nacionalnom nadzornom tijelu
+
+Za ostvarivanje ovih prava obratite nam se na **{{COMPANY_EMAIL}}**. Odgovorit ćemo u roku od mjesec dana od primitka (čl. 12. st. 3. GDPR-a).
+
+## Izmjene ovih pravila
+
+Ova pravila o kolačićima možemo povremeno ažurirati. Datum "Posljednje ažuriranje" na vrhu odražava najnoviju izmjenu. Kod bitnih izmjena pri sljedećem posjetu zatražit ćemo novu privolu.
+
+## Kontakt
+
+Za sva pitanja o ovim pravilima o kolačićima obratite nam se na **{{COMPANY_EMAIL}}**.

--- a/admin/modules/cookie-policy-generator/templates/gdpr-strict/nl.md
+++ b/admin/modules/cookie-policy-generator/templates/gdpr-strict/nl.md
@@ -1,0 +1,68 @@
+# Cookiebeleid
+
+**Laatst bijgewerkt:** {{LAST_UPDATED_DATE}}
+
+Dit cookiebeleid legt uit hoe **{{COMPANY_NAME}}** ("wij", "ons", "onze") cookies en vergelijkbare technologieën op deze website gebruikt, in overeenstemming met de Algemene verordening gegevensbescherming (AVG, Verordening 2016/679) en de e-Privacyrichtlijn (2002/58/EG, art. 5, lid 3).
+
+## Wie wij zijn
+
+De verwerkingsverantwoordelijke voor de verwerking van uw persoonsgegevens via cookies is:
+
+- **Verwerkingsverantwoordelijke:** {{COMPANY_NAME}}
+- **Adres:** {{COMPANY_ADDRESS}}
+- **E-mail:** {{COMPANY_EMAIL}}
+- **Handelsregister / btw-nummer:** {{COMPANY_REGISTRY}}
+- **Functionaris voor gegevensbescherming (FG):** {{DPO_NAME}} — {{DPO_EMAIL}}
+
+## Wat zijn cookies
+
+Cookies zijn kleine tekstbestanden die op uw apparaat worden geplaatst wanneer u onze website bezoekt. Daarmee kunnen wij uw apparaat bij een volgend bezoek herkennen, uw voorkeuren onthouden, meten hoe de site wordt gebruikt en — met uw toestemming — gepersonaliseerde advertenties tonen.
+
+Wij gebruiken ook vergelijkbare technologieën zoals **localStorage**, **sessionStorage** en **pixeltags**. Waar dit beleid over "cookies" spreekt, worden deze technologieën eveneens bedoeld.
+
+## Rechtsgrondslag
+
+Voor **strikt noodzakelijke** cookies is de rechtsgrondslag ons gerechtvaardigd belang op grond van artikel 6, lid 1, onder f, AVG en de technische uitzondering van artikel 5, lid 3, e-Privacyrichtlijn.
+
+Voor **alle andere** cookiecategorieën is de rechtsgrondslag uw **uitdrukkelijke toestemming** op grond van artikel 6, lid 1, onder a, en artikel 7 AVG, verkregen via de cookiebanner voordat een niet-essentiële cookie wordt geplaatst.
+
+U kunt uw toestemming op elk moment intrekken via de link "Cookie-instellingen" of door uw cookies te wissen; de intrekking doet geen afbreuk aan de rechtmatigheid van de verwerking vóór de intrekking (artikel 7, lid 3, AVG).
+
+## Cookies op deze site
+
+{{COOKIE_CATEGORIES}}
+
+## Diensten van derden
+
+Als u toestemming geeft, kan deze site bronnen laden van de volgende diensten van derden, die hun eigen cookies plaatsen:
+
+{{THIRD_PARTY_SERVICES}}
+
+Elke derde partij is zelfstandig verwerkingsverantwoordelijke voor de cookies die zij plaatst; raadpleeg hun respectieve privacyverklaringen.
+
+## Hoe lang wij gegevens bewaren
+
+Toestemmingsregistraties en analysegegevens worden {{RETENTION_PERIOD}} vanaf de verzameling bewaard. Strikt noodzakelijke cookies worden uitsluitend bewaard voor de duur van de sessie of zolang de technische functie die zij vervullen dat vereist. Zie de tabel hierboven voor de specifieke bewaartermijn van elke cookie.
+
+## Uw rechten
+
+Op grond van de artikelen 12 tot en met 22 AVG hebt u het recht om:
+
+- inzage te krijgen in de persoonsgegevens die wij over u verwerken (art. 15)
+- rectificatie van onjuiste gegevens te verzoeken (art. 16)
+- wissing te verzoeken ("recht op vergetelheid", art. 17)
+- de verwerking te beperken (art. 18)
+- gegevensoverdraagbaarheid te verlangen (art. 20)
+- bezwaar te maken tegen verwerking op grond van gerechtvaardigd belang (art. 21)
+- uw toestemming op elk moment in te trekken (art. 7, lid 3)
+- een klacht in te dienen bij uw nationale toezichthoudende autoriteit
+
+Neem voor de uitoefening van deze rechten contact met ons op via **{{COMPANY_EMAIL}}**. Wij reageren binnen één maand na ontvangst (artikel 12, lid 3, AVG).
+
+## Wijzigingen in dit beleid
+
+Wij kunnen dit cookiebeleid van tijd tot tijd bijwerken. De datum "Laatst bijgewerkt" bovenaan geeft de meest recente herziening weer. Bij wezenlijke wijzigingen wordt bij uw volgende bezoek opnieuw om toestemming gevraagd.
+
+## Contact
+
+Neem voor vragen over dit cookiebeleid contact met ons op via **{{COMPANY_EMAIL}}**.

--- a/admin/modules/cookie-policy-generator/templates/lgpd-brazil/hr.md
+++ b/admin/modules/cookie-policy-generator/templates/lgpd-brazil/hr.md
@@ -1,0 +1,58 @@
+# Pravila o kolačićima (LGPD — Brazil)
+
+**Posljednje ažuriranje:** {{LAST_UPDATED_DATE}}
+
+Ova pravila o kolačićima opisuju kako **{{COMPANY_NAME}}** ("mi") upotrebljava kolačiće i slične tehnologije na ovoj web stranici, u skladu s brazilskim Općim zakonom o zaštiti podataka (Lei Geral de Proteção de Dados Pessoais — LGPD, Lei nº 13.709/2018) i Marco Civil da Internet (Lei nº 12.965/2014).
+
+## Voditelj obrade
+
+- **Voditelj obrade:** {{COMPANY_NAME}}
+- **Adresa:** {{COMPANY_ADDRESS}}
+- **Kontakt za privatnost:** {{COMPANY_EMAIL}}
+- **CNPJ:** {{COMPANY_REGISTRY}}
+- **Encarregado de Dados (službenik za zaštitu podataka) — obvezan prema čl. 41. LGPD-a:** {{DPO_NAME}} — {{DPO_EMAIL}}
+
+## Pravne osnove (čl. 7. LGPD-a)
+
+Za **nužne** kolačiće: legitimni interes (čl. 7., IX) te ugovorna ili tehnička obveza (čl. 7., V).
+
+Za **sve ostale** kategorije: **izričita privola** ispitanika (čl. 7., I), prikupljena putem bannera o kolačićima prije postavljanja bilo kojeg kolačića koji nije nužan.
+
+Privolu možete povući u svakom trenutku (čl. 8., § 5.) putem poveznice "Postavke kolačića".
+
+## Kategorije osobnih podataka koji se obrađuju (čl. 5., I)
+
+- **Mrežni identifikatori** — IP (heširan s mjesečnim saltom), identifikatori uređaja, identifikatori sesije
+- **Podaci o pregledavanju** — posjećene stranice, trajanje zadržavanja, interakcije
+- **Približna lokacija** — država/regija na temelju IP adrese (ne precizni GPS)
+- **Postavke** — kategorije privole, jezik
+
+Osjetljive osobne podatke (čl. 5., II) **ne** obrađujemo putem kolačića bez posebne i istaknute privole (čl. 11. LGPD-a).
+
+## Upotrijebljeni kolačići
+
+{{COOKIE_CATEGORIES}}
+
+## Treće strane koje primaju podatke
+
+{{THIRD_PARTY_SERVICES}}
+
+Međunarodni prijenosi (čl. 33. – 36. LGPD-a) provode se u zemlje s odgovarajućom razinom zaštite, na temelju standardnih ugovornih klauzula ili uz posebnu privolu.
+
+## Čuvanje podataka (čl. 15. – 16. LGPD-a)
+
+{{RETENTION_PERIOD}} od prikupljanja.
+
+## Prava ispitanika (čl. 18. LGPD-a)
+
+I — potvrda, II — pristup, III — ispravak, IV — anonimizacija/blokiranje/brisanje, V — prenosivost, VI — brisanje, VII — informacije o dijeljenju, VIII — informacije o posljedicama uskrate privole, IX — povlačenje privole.
+
+Ova prava ostvarite obraćanjem voditelju obrade na **{{COMPANY_EMAIL}}** ili službeniku za zaštitu podataka (Encarregado) navedenom na vrhu ovih pravila.
+
+## Nadzorno tijelo
+
+ANPD — Autoridade Nacional de Proteção de Dados: {{ANPD_CONTACT}}, [{{OFFICIAL_RESOURCES_URL}}]({{OFFICIAL_RESOURCES_URL}})
+
+## Kontakt
+
+**{{COMPANY_EMAIL}}** (ili službenik za zaštitu podataka naveden na vrhu ovih pravila).

--- a/admin/modules/cookie-policy-generator/templates/lgpd-brazil/nl.md
+++ b/admin/modules/cookie-policy-generator/templates/lgpd-brazil/nl.md
@@ -1,0 +1,58 @@
+# Cookiebeleid (LGPD — Brazilië)
+
+**Laatst bijgewerkt:** {{LAST_UPDATED_DATE}}
+
+Dit cookiebeleid beschrijft hoe **{{COMPANY_NAME}}** ("wij") cookies en vergelijkbare technologieën op deze website gebruikt, in overeenstemming met de Braziliaanse algemene wet gegevensbescherming (Lei Geral de Proteção de Dados Pessoais — LGPD, Lei nº 13.709/2018) en het Marco Civil da Internet (Lei nº 12.965/2014).
+
+## Verwerkingsverantwoordelijke
+
+- **Verwerkingsverantwoordelijke:** {{COMPANY_NAME}}
+- **Adres:** {{COMPANY_ADDRESS}}
+- **Privacycontact:** {{COMPANY_EMAIL}}
+- **CNPJ:** {{COMPANY_REGISTRY}}
+- **Encarregado de Dados (FG) — verplicht op grond van art. 41 LGPD:** {{DPO_NAME}} — {{DPO_EMAIL}}
+
+## Rechtsgrondslagen (art. 7 LGPD)
+
+Voor **strikt noodzakelijke** cookies: gerechtvaardigd belang (art. 7, IX) en contractuele of technische verplichting (art. 7, V).
+
+Voor **alle andere** categorieën: **uitdrukkelijke toestemming** van de betrokkene (art. 7, I), verkregen via de cookiebanner voordat een niet-essentiële cookie wordt geplaatst.
+
+U kunt uw toestemming op elk moment intrekken (art. 8, § 5) via de link "Cookie-instellingen".
+
+## Categorieën verwerkte persoonsgegevens (art. 5, I)
+
+- **Online identificatoren** — IP (gehasht met een maandelijkse salt), apparaat-ID's, sessie-ID's
+- **Browsegegevens** — bezochte pagina's, verblijfsduur, interacties
+- **Locatie bij benadering** — land/regio op basis van het IP-adres (geen precieze GPS-locatie)
+- **Voorkeuren** — toestemmingscategorieën, taal
+
+Wij verwerken **geen** gevoelige persoonsgegevens (art. 5, II) via cookies zonder specifieke en afzonderlijk benadrukte toestemming (art. 11 LGPD).
+
+## Gebruikte cookies
+
+{{COOKIE_CATEGORIES}}
+
+## Ontvangers die derde partij zijn
+
+{{THIRD_PARTY_SERVICES}}
+
+Internationale doorgiften (art. 33-36 LGPD) vinden plaats naar landen met een passend beschermingsniveau, op basis van modelcontractbepalingen of met specifieke toestemming.
+
+## Bewaartermijn (art. 15-16 LGPD)
+
+{{RETENTION_PERIOD}} vanaf de verzameling.
+
+## Rechten van de betrokkene (art. 18 LGPD)
+
+I — bevestiging, II — inzage, III — rectificatie, IV — anonimisering/blokkering/verwijdering, V — overdraagbaarheid, VI — verwijdering, VII — informatie over het delen van gegevens, VIII — informatie over de gevolgen van het weigeren van toestemming, IX — intrekking van toestemming.
+
+Oefen deze rechten uit door contact op te nemen met de verwerkingsverantwoordelijke via **{{COMPANY_EMAIL}}** of met de FG (Encarregado) die bovenaan dit beleid wordt genoemd.
+
+## Toezichthoudende autoriteit
+
+ANPD — Autoridade Nacional de Proteção de Dados: {{ANPD_CONTACT}}, [{{OFFICIAL_RESOURCES_URL}}]({{OFFICIAL_RESOURCES_URL}})
+
+## Contact
+
+**{{COMPANY_EMAIL}}** (of de FG die bovenaan dit beleid wordt genoemd).

--- a/admin/modules/cookie-policy-generator/templates/popia-southafrica/hr.md
+++ b/admin/modules/cookie-policy-generator/templates/popia-southafrica/hr.md
@@ -1,0 +1,74 @@
+# Pravila o kolačićima
+
+**Posljednje ažuriranje:** {{LAST_UPDATED_DATE}}
+
+Ova pravila o kolačićima objašnjavaju kako **{{COMPANY_NAME}}** ("mi", "nas", "naš") upotrebljava kolačiće i slične tehnologije na ovoj web stranici, u skladu s južnoafričkim Protection of Personal Information Actom, 2013 (POPIA) i propisima koje donosi Information Regulator.
+
+## Tko smo mi
+
+Odgovorna strana za obradu vaših osobnih podataka putem kolačića jest:
+
+- **Odgovorna strana:** {{COMPANY_NAME}}
+- **Adresa:** {{COMPANY_ADDRESS}}
+- **E-pošta:** {{COMPANY_EMAIL}}
+- **Registar / matični broj:** {{COMPANY_REGISTRY}}
+- **Information Officer:** {{DPO_NAME}} — {{DPO_EMAIL}}
+
+## Što su kolačići
+
+Kolačići su male tekstualne datoteke koje se pohranjuju na vaš uređaj kada posjetite našu web stranicu. Omogućuju nam da prepoznamo vaš uređaj pri sljedećim posjetima, zapamtimo vaše postavke, mjerimo kako se stranica upotrebljava te da vam — uz vašu privolu — prikazujemo personalizirane oglase.
+
+Upotrebljavamo i slične tehnologije kao što su **localStorage**, **sessionStorage** i **pikseli za praćenje**. Kada se u ovim pravilima spominju "kolačići", pojam obuhvaća i te tehnologije.
+
+## Zakonita osnova za obradu
+
+Za **nužne** kolačiće obrada je opravdana jer je potrebna radi ostvarivanja naših legitimnih interesa u vođenju sigurne i funkcionalne web stranice (POPIA, odjeljak 11(1)(f)) i ne nadilazi vaše interese ili prava.
+
+Za **kategorije koje nisu nužne i konfigurirane su iza našeg bannera o kolačićima** obrada se temelji na vašoj **privoli** prema odjeljku 11(1)(a) POPIA-e — dobrovoljnom, posebnom i informiranom očitovanju volje — prikupljenoj prije postavljanja tih kolačića. Odjeljak 11(1)(b)-(f) POPIA-e dopušta i druge zakonite osnove; ova pravila za navedene konfigurirane kategorije polaze od privole i moraju se prilagoditi ako se naša stvarna obrada oslanja na drugu osnovu.
+
+Osobni podaci prikupljeni putem tih tehnologija mogu uključivati mrežne identifikatore, podatke o uređaju i pregledniku, događaje upotrebe, približnu lokaciju te postavke opisane u tablici kolačića i u našoj zasebnoj politici privatnosti. Davanje podataka putem tehnologija koje nisu nužne dobrovoljno je; ako to odbijete, povezane funkcije analitike, personalizacije ili oglašavanja neće raditi. Obrada potrebna za pružanje i osiguravanje web stranice nužna je za te tehničke funkcije, a njezino blokiranje može spriječiti rad pojedinih dijelova stranice.
+
+Privolu možete povući u svakom trenutku putem poveznice "Postavke kolačića" ili brisanjem kolačića (POPIA, odjeljak 11(2)(b)). Povlačenje ne utječe na zakonitost obrade provedene prije povlačenja.
+
+## Kolačići na ovoj stranici
+
+{{COOKIE_CATEGORIES}}
+
+## Usluge trećih strana
+
+Ako date privolu, ova stranica može učitati sadržaj sljedećih usluga trećih strana ili im proslijediti osobne podatke. Ovisno o njihovoj konfiguraciji, one mogu upotrebljavati kolačiće ili druge tehnologije:
+
+{{THIRD_PARTY_SERVICES}}
+
+Pravna uloga svake treće strane ovisi o stvarnom odnosu: ona može kao zasebna odgovorna strana određivati vlastite svrhe ili obrađivati podatke u naše ime kao operator na temelju ugovora ili naloga. Prije prijenosa osobnih podataka izvan Južne Afrike zahtijevamo bitno sličnu razinu zaštite na temelju mjerodavnog prava, obvezujućih korporativnih pravila ili obvezujućeg sporazuma, odnosno se oslanjamo na drugu osnovu dopuštenu odjeljkom 72. POPIA-e. Podaci o primateljima i zaštitnim mjerama navedeni su u našoj [politici privatnosti]({{PRIVACY_POLICY_URL}}).
+
+## Izravni marketing
+
+Prema odjeljku 69. POPIA-e, za elektronički izravni marketing prema osobama koje nisu naši kupci potrebna je vaša prethodna privola, a svaka marketinška poruka koju primite mora sadržavati način odjave.
+
+## Koliko dugo čuvamo podatke
+
+Osobni podaci koje izravno prikupljamo putem kolačića čuvaju se samo onoliko dugo koliko je potrebno za navedenu svrhu i, ako nije naveden kraći rok specifičan za pojedini kolačić, ne dulje od objavljenog zamjenskog roka od {{RETENTION_PERIOD}}, osim ako je dulje razdoblje dopušteno ili propisano zakonom. Trajanje svakog kolačića navedeno je u tablici iznad, a čuvanje pod kontrolom trećih strana u politici privatnosti. Prema odjeljku 14. POPIA-e podaci čije čuvanje više nije dopušteno brišu se, uništavaju ili deidentificiraju čim je to razumno izvedivo.
+
+## Vaša prava
+
+Prema POPIA-i (poglavlje 3., uvjet 8., te odjeljci 23. – 25.) imate pravo:
+
+- biti obaviješteni da se vaši osobni podaci prikupljaju (odjeljak 18.)
+- pristupiti osobnim podacima koje o vama čuvamo (odjeljak 23.)
+- zatražiti ispravak ili brisanje netočnih, nevažnih, prekomjernih ili nezakonito pribavljenih podataka (odjeljak 24.)
+- uložiti prigovor na obradu koja se temelji na legitimnom interesu (odjeljak 11(3))
+- uložiti prigovor na obradu u svrhe izravnog marketinga (odjeljak 11(3)(b) i odjeljak 69.)
+- povući privolu u svakom trenutku (odjeljak 11(2)(b))
+- ne biti podvrgnuti — osim u iznimkama iz odjeljka 71(2) — odluci koja se temelji isključivo na automatiziranoj obradi namijenjenoj vašem profiliranju, kada ona za vas ima pravne posljedice ili na vas znatno utječe (odjeljak 71.)
+- podnijeti pritužbu Information Regulatoru (Južna Afrika) — [{{OFFICIAL_RESOURCES_URL}}]({{OFFICIAL_RESOURCES_URL}}); e-pošta za pritužbe: **{{INFOREG_CONTACT}}**
+
+Za ostvarivanje ovih prava obratite nam se na **{{COMPANY_EMAIL}}**; ako je gore pod "Tko smo mi" naveden Information Officer, zahtjev možete uputiti izravno njemu. Odgovorit ćemo čim to bude razumno izvedivo; za zahtjeve za pristup vašim osobnim podacima odjeljak 25. Promotion of Access to Information Acta, 2000 (PAIA) predviđa rok za odgovor od 30 dana.
+
+## Izmjene ovih pravila
+
+Ova pravila o kolačićima možemo povremeno ažurirati. Datum "Posljednje ažuriranje" na vrhu odražava najnoviju izmjenu. Izmjena koja utječe na opseg ili valjanost privole može zahtijevati novi odabir putem bannera o kolačićima; svoj trenutačni odabir možete pregledati ili promijeniti u svakom trenutku putem "Postavke kolačića".
+
+## Kontakt
+
+Za sva pitanja o ovim pravilima o kolačićima obratite nam se na **{{COMPANY_EMAIL}}**.

--- a/admin/modules/cookie-policy-generator/templates/popia-southafrica/nl.md
+++ b/admin/modules/cookie-policy-generator/templates/popia-southafrica/nl.md
@@ -1,0 +1,74 @@
+# Cookiebeleid
+
+**Laatst bijgewerkt:** {{LAST_UPDATED_DATE}}
+
+Dit cookiebeleid legt uit hoe **{{COMPANY_NAME}}** ("wij", "ons", "onze") cookies en vergelijkbare technologieën op deze website gebruikt, in overeenstemming met de Protection of Personal Information Act, 2013 (POPIA) van Zuid-Afrika en de voorschriften van de Information Regulator.
+
+## Wie wij zijn
+
+De verantwoordelijke partij voor de verwerking van uw persoonlijke informatie via cookies is:
+
+- **Verantwoordelijke partij:** {{COMPANY_NAME}}
+- **Adres:** {{COMPANY_ADDRESS}}
+- **E-mail:** {{COMPANY_EMAIL}}
+- **Register / registratienummer:** {{COMPANY_REGISTRY}}
+- **Information Officer:** {{DPO_NAME}} — {{DPO_EMAIL}}
+
+## Wat zijn cookies
+
+Cookies zijn kleine tekstbestanden die op uw apparaat worden geplaatst wanneer u onze website bezoekt. Daarmee kunnen wij uw apparaat bij een volgend bezoek herkennen, uw voorkeuren onthouden, meten hoe de site wordt gebruikt en — met uw toestemming — gepersonaliseerde advertenties tonen.
+
+Wij gebruiken ook vergelijkbare technologieën zoals **localStorage**, **sessionStorage** en **pixeltags**. Waar dit beleid over "cookies" spreekt, worden deze technologieën eveneens bedoeld.
+
+## Rechtmatige grondslag voor de verwerking
+
+Voor **strikt noodzakelijke** cookies is de verwerking gerechtvaardigd omdat zij noodzakelijk is voor onze gerechtvaardigde belangen bij het exploiteren van een veilige, functionerende website (POPIA artikel 11(1)(f)) en niet zwaarder weegt dan uw belangen of rechten.
+
+Voor de **niet-essentiële categorieën achter onze cookiebanner** berust de verwerking op uw **toestemming** op grond van POPIA artikel 11(1)(a) — een vrijwillige, specifieke en geïnformeerde wilsuiting — verkregen voordat die cookies worden geplaatst. POPIA artikel 11(1)(b)-(f) staat andere rechtmatige gronden toe; dit beleid gaat voor deze geconfigureerde categorieën uit van toestemming en moet worden aangepast als onze feitelijke verwerking op een andere grond berust.
+
+Persoonlijke informatie die via deze technologieën wordt verzameld, kan bestaan uit online identificatoren, apparaat- en browsergegevens, gebruiksgebeurtenissen, locatie bij benadering en de voorkeuren die in de cookietabel en in onze afzonderlijke privacyverklaring worden beschreven. Het verstrekken van informatie via niet-essentiële technologieën is vrijwillig; weigert u, dan werken de bijbehorende analyse-, personalisatie- of advertentiefuncties niet. De verwerking die nodig is om de website te leveren en te beveiligen, is noodzakelijk voor die technische functies, en het blokkeren daarvan kan ertoe leiden dat delen van de site niet werken.
+
+U kunt uw toestemming op elk moment intrekken via de link "Cookie-instellingen" of door uw cookies te wissen (POPIA artikel 11(2)(b)). De intrekking doet geen afbreuk aan de rechtmatigheid van de verwerking vóór de intrekking.
+
+## Cookies op deze site
+
+{{COOKIE_CATEGORIES}}
+
+## Diensten van derden
+
+Als u toestemming geeft, kan deze site bronnen laden van of persoonlijke informatie doorgeven aan de volgende diensten van derden. Afhankelijk van hun configuratie kunnen zij cookies of andere technologieën gebruiken:
+
+{{THIRD_PARTY_SERVICES}}
+
+De juridische rol van elke derde partij hangt af van de feitelijke afspraak: zij kan als afzonderlijke verantwoordelijke partij haar eigen doeleinden bepalen, of informatie namens ons verwerken als operator op grond van een overeenkomst of opdracht. Voordat wij persoonlijke informatie buiten Zuid-Afrika doorgeven, verlangen wij een wezenlijk vergelijkbaar beschermingsniveau op grond van toepasselijk recht, bindende bedrijfsvoorschriften of een bindende overeenkomst, of beroepen wij ons op een andere grond die POPIA artikel 72 toestaat. Gegevens over ontvangers en waarborgen staan in onze [privacyverklaring]({{PRIVACY_POLICY_URL}}).
+
+## Direct marketing
+
+Op grond van POPIA artikel 69 is voor elektronische direct marketing aan niet-klanten uw voorafgaande toestemming vereist, en moet elke marketingboodschap die u ontvangt een mogelijkheid tot afmelding bevatten.
+
+## Hoe lang wij gegevens bewaren
+
+Persoonlijke informatie die wij rechtstreeks via cookies verzamelen, wordt uitsluitend bewaard zolang dat voor het genoemde doel noodzakelijk is en, wanneer geen kortere cookiespecifieke termijn is vermeld, niet langer dan de opgegeven terugvaltermijn van {{RETENTION_PERIOD}}, tenzij een langere termijn wettelijk is toegestaan of vereist. Zie de tabel hierboven voor de levensduur van elke cookie en de privacyverklaring voor bewaring die door derden wordt bepaald. Op grond van POPIA artikel 14 wordt informatie die niet langer mag worden bewaard, zo spoedig als redelijkerwijs mogelijk verwijderd, vernietigd of gedeïdentificeerd.
+
+## Uw rechten
+
+Op grond van POPIA (hoofdstuk 3, voorwaarde 8, en de artikelen 23-25) hebt u het recht om:
+
+- ervan in kennis te worden gesteld dat uw persoonlijke informatie wordt verzameld (artikel 18)
+- inzage te krijgen in de persoonlijke informatie die wij over u bewaren (artikel 23)
+- correctie of verwijdering te verzoeken van onjuiste, irrelevante, buitensporige of onrechtmatig verkregen informatie (artikel 24)
+- bezwaar te maken tegen verwerking op grond van gerechtvaardigd belang (artikel 11(3))
+- bezwaar te maken tegen verwerking voor direct-marketingdoeleinden (artikel 11(3)(b) en artikel 69)
+- uw toestemming op elk moment in te trekken (artikel 11(2)(b))
+- niet — behoudens de uitzonderingen in artikel 71(2) — te worden onderworpen aan een besluit dat uitsluitend berust op geautomatiseerde verwerking die bedoeld is om u te profileren, wanneer dat rechtsgevolgen voor u heeft of u in aanmerkelijke mate treft (artikel 71)
+- een klacht in te dienen bij de Information Regulator (Zuid-Afrika) — [{{OFFICIAL_RESOURCES_URL}}]({{OFFICIAL_RESOURCES_URL}}); e-mail voor klachten: **{{INFOREG_CONTACT}}**
+
+Neem voor de uitoefening van deze rechten contact met ons op via **{{COMPANY_EMAIL}}**; als hierboven onder "Wie wij zijn" een Information Officer is vermeld, kunt u uw verzoek rechtstreeks aan die persoon richten. Wij reageren zo spoedig als redelijkerwijs mogelijk; voor verzoeken om inzage in uw persoonlijke informatie voorziet artikel 25 van de Promotion of Access to Information Act, 2000 (PAIA) in een antwoordtermijn van 30 dagen.
+
+## Wijzigingen in dit beleid
+
+Wij kunnen dit cookiebeleid van tijd tot tijd bijwerken. De datum "Laatst bijgewerkt" bovenaan geeft de meest recente herziening weer. Een wijziging die de reikwijdte of de geldigheid van de toestemming raakt, kan een nieuwe keuze via de cookiebanner vereisen; u kunt uw huidige keuze op elk moment bekijken of wijzigen via "Cookie-instellingen".
+
+## Contact
+
+Neem voor vragen over dit cookiebeleid contact met ons op via **{{COMPANY_EMAIL}}**.

--- a/tests/unit/fixtures/cookie-policy-golden/ccpa-california.html
+++ b/tests/unit/fixtures/cookie-policy-golden/ccpa-california.html
@@ -1,4 +1,4 @@
-<article class="faz-cookie-policy" lang="en" data-jurisdiction="ccpa-california" data-faz-policy-version="54cdea.9aac6b"><p>
+<article class="faz-cookie-policy" lang="en" data-jurisdiction="ccpa-california" data-faz-policy-version="f1b7c4.9aac6b"><p>
 <strong>Last updated:</strong> June 3, 2026
 </p>
 <p>
@@ -114,7 +114,10 @@ As a California resident, you have the right to:
 <li><strong>Right to Data Portability</strong> (§ 1798.130(a)(2)) — receive Personal Information in a readily usable format</li>
 </ul>
 <p>
-To submit a request, email <strong>privacy@example.test</strong> or use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. We will verify your identity (CCPA § 1798.130(a)(2)) and respond within <strong>45 days</strong> (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+To exercise the rights to know, delete, correct or port, email <strong>privacy@example.test</strong>. Those are verifiable consumer requests, so we will verify your identity before acting (CCPA § 1798.130(a)(2)), and we will respond within <strong>45 days</strong> (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+</p>
+<p>
+To opt out of the sale or sharing of your Personal Information, use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. An opt-out is <strong>not</strong> a verifiable consumer request: we will act on it without asking you to verify your identity or to create an account.
 </p>
 <p>
 You may also designate an authorized agent to submit a request on your behalf (Cal. Civ. Code § 1798.135(c)).

--- a/tests/unit/fixtures/cookie-policy-golden/unknown-jurisdiction-att-ignored.html
+++ b/tests/unit/fixtures/cookie-policy-golden/unknown-jurisdiction-att-ignored.html
@@ -1,4 +1,4 @@
-<article class="faz-cookie-policy" lang="en" data-jurisdiction="ccpa-california" data-faz-policy-version="54cdea.1725fd"><p>
+<article class="faz-cookie-policy" lang="en" data-jurisdiction="ccpa-california" data-faz-policy-version="f1b7c4.1725fd"><p>
 <strong>Last updated:</strong> June 3, 2026
 </p>
 <p>
@@ -71,7 +71,10 @@ As a California resident, you have the right to:
 <li><strong>Right to Data Portability</strong> (§ 1798.130(a)(2)) — receive Personal Information in a readily usable format</li>
 </ul>
 <p>
-To submit a request, email <strong>privacy@example.test</strong> or use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. We will verify your identity (CCPA § 1798.130(a)(2)) and respond within <strong>45 days</strong> (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+To exercise the rights to know, delete, correct or port, email <strong>privacy@example.test</strong>. Those are verifiable consumer requests, so we will verify your identity before acting (CCPA § 1798.130(a)(2)), and we will respond within <strong>45 days</strong> (extendable to 90 with notice, § 1798.130(a)(2)(B)).
+</p>
+<p>
+To opt out of the sale or sharing of your Personal Information, use the "Do Not Sell or Share" and "Manage Preferences" links in the website footer. An opt-out is <strong>not</strong> a verifiable consumer request: we will act on it without asking you to verify your identity or to create an account.
 </p>
 <p>
 You may also designate an authorized agent to submit a request on your behalf (Cal. Civ. Code § 1798.135(c)).

--- a/tests/unit/test-cookie-policy-generator.php
+++ b/tests/unit/test-cookie-policy-generator.php
@@ -442,6 +442,68 @@ foreach ( Generator::LANGUAGES as $popia_lang ) {
 // ---------- Summary ----------
 
 echo "\n--\n";
+// ── Template matrix completeness ──────────────────────────────────────────
+// A language is either shipped for every jurisdiction or for none. Shipping it
+// for some is the failure this guards: resolve_template_path() then silently
+// serves the English fallback for the jurisdictions that lack it, and nothing
+// in the product reports the substitution. That is how nl and hr came to have a
+// gettext catalogue, a selectable policy language and no template at all —
+// every site on those locales was handed an English legal document, quietly.
+$faz_matrix_dirs = glob( $tpl_dir . '/*', GLOB_ONLYDIR );
+$faz_langs       = array();
+foreach ( $faz_matrix_dirs as $faz_dir ) {
+	foreach ( glob( $faz_dir . '/*.md' ) as $faz_file ) {
+		$faz_langs[ basename( $faz_file, '.md' ) ] = true;
+	}
+}
+$faz_langs = array_keys( $faz_langs );
+sort( $faz_langs );
+assert_true( count( $faz_matrix_dirs ) > 0 && count( $faz_langs ) > 0, 'template matrix is discoverable' );
+
+$faz_tokens = static function ( $text ) {
+	preg_match_all( '/\{\{[A-Z_]+\}\}/', (string) $text, $m );
+	sort( $m[0] );
+	return $m[0];
+};
+$faz_missing = array();
+$faz_lost    = array();
+$faz_drifted = array();
+// Faithful translations of the English source. The older localized templates
+// are deliberately abridged — several drop the standalone "Contact" section —
+// so exact parity is asserted only where it was the translator's intent. Every
+// template, abridged or not, is still held to the placeholder-type rule below.
+$faz_faithful = array( 'nl', 'hr' );
+foreach ( $faz_matrix_dirs as $faz_dir ) {
+	$faz_j  = basename( $faz_dir );
+	$faz_en = @file_get_contents( $faz_dir . '/en.md' );
+	foreach ( $faz_langs as $faz_l ) {
+		$faz_path = $faz_dir . '/' . $faz_l . '.md';
+		if ( ! file_exists( $faz_path ) ) {
+			$faz_missing[] = $faz_j . '/' . $faz_l;
+			continue;
+		}
+		if ( ! is_string( $faz_en ) || 'en' === $faz_l ) {
+			continue;
+		}
+		$faz_body = (string) file_get_contents( $faz_path );
+		// Losing a placeholder TYPE removes something the document cannot do
+		// without — the controller's contact, the cookie inventory, the
+		// retention period. Abridging a section is an editorial choice; losing
+		// the only occurrence of a token is a defect in a legal document.
+		if ( array_diff( array_unique( $faz_tokens( $faz_en ) ), array_unique( $faz_tokens( $faz_body ) ) ) ) {
+			$faz_lost[] = $faz_j . '/' . $faz_l;
+		}
+		if ( in_array( $faz_l, $faz_faithful, true )
+			&& ( $faz_tokens( $faz_body ) !== $faz_tokens( $faz_en )
+				|| substr_count( $faz_body, "\n#" ) !== substr_count( $faz_en, "\n#" ) ) ) {
+			$faz_drifted[] = $faz_j . '/' . $faz_l;
+		}
+	}
+}
+assert_eq( $faz_missing, array(), 'every policy language ships for every jurisdiction' );
+assert_eq( $faz_lost, array(), 'no localized template drops a placeholder the English source has' );
+assert_eq( $faz_drifted, array(), 'faithful translations keep the English section count and placeholder multiset' );
+
 echo "Tests:  $tests_run\n";
 echo "Passed: $tests_passed\n";
 echo "Failed: $tests_failed\n\n";

--- a/tests/unit/test-cookie-policy-generator.php
+++ b/tests/unit/test-cookie-policy-generator.php
@@ -248,7 +248,7 @@ assert_true(
 // ---------- Constants ----------
 
 assert_eq( count( Generator::JURISDICTIONS ), 4, '4 jurisdictions in scope (gdpr, ccpa, lgpd + popia added for wp.org review request)' );
-assert_eq( count( Generator::LANGUAGES ), 8, '8 languages in scope (en, it, fr, de, es, pt-BR, bg, cs)' );
+assert_eq( count( Generator::LANGUAGES ), 10, '10 languages in scope (en, it, fr, de, es, pt-BR, bg, cs + nl, hr)' );
 assert_eq( Generator::normalize_language_code( 'pt_br' ), 'pt-BR', 'Policy language canonicalises locale-style region codes' );
 assert_eq( Generator::normalize_language_code( 'sr-latn' ), 'sr-Latn', 'Policy language canonicalises script subtags' );
 assert_eq( Generator::normalize_language_code( 'sk' ), 'sk', 'Slovak is a valid administrator-authored policy language' );
@@ -443,43 +443,63 @@ foreach ( Generator::LANGUAGES as $popia_lang ) {
 
 echo "\n--\n";
 // ── Template matrix completeness ──────────────────────────────────────────
-// A language is either shipped for every jurisdiction or for none. Shipping it
-// for some is the failure this guards: resolve_template_path() then silently
-// serves the English fallback for the jurisdictions that lack it, and nothing
-// in the product reports the substitution. That is how nl and hr came to have a
-// gettext catalogue, a selectable policy language and no template at all —
-// every site on those locales was handed an English legal document, quietly.
-$faz_matrix_dirs = glob( $tpl_dir . '/*', GLOB_ONLYDIR );
-$faz_langs       = array();
-foreach ( $faz_matrix_dirs as $faz_dir ) {
-	foreach ( glob( $faz_dir . '/*.md' ) as $faz_file ) {
-		$faz_langs[ basename( $faz_file, '.md' ) ] = true;
-	}
-}
-$faz_langs = array_keys( $faz_langs );
-sort( $faz_langs );
-assert_true( count( $faz_matrix_dirs ) > 0 && count( $faz_langs ) > 0, 'template matrix is discoverable' );
+// The expected sets come from the generator's own declarations, not from what
+// happens to be on disk. Deriving them from the filesystem makes the test agree
+// with reality by construction: add a language to Generator::LANGUAGES and ship
+// no template for it and a disk-derived test still passes, which is the exact
+// drift this guards. (Generator::policy_languages() is the wrong source here —
+// it unions in every selectable locale, ~180 of them, none of which we ship a
+// template for.)
+//
+// The failure being guarded is silent: resolve_template_path() falls back
+// lang -> native -> en, so a missing template serves an English legal document
+// and nothing reports the substitution. That is how nl and hr came to have a
+// gettext catalogue, a selectable policy language and no template at all.
+$faz_expect_j = Generator::JURISDICTIONS;
+$faz_expect_l = Generator::LANGUAGES;
+sort( $faz_expect_j );
+sort( $faz_expect_l );
+assert_true( count( $faz_expect_j ) > 0 && count( $faz_expect_l ) > 0, 'generator declares jurisdictions and languages' );
 
 $faz_tokens = static function ( $text ) {
 	preg_match_all( '/\{\{[A-Z_]+\}\}/', (string) $text, $m );
 	sort( $m[0] );
 	return $m[0];
 };
-$faz_missing = array();
-$faz_lost    = array();
-$faz_drifted = array();
-// Faithful translations of the English source. The older localized templates
-// are deliberately abridged — several drop the standalone "Contact" section —
-// so exact parity is asserted only where it was the translator's intent. Every
-// template, abridged or not, is still held to the placeholder-type rule below.
+$faz_no_dir   = array();
+$faz_missing  = array();
+$faz_unread   = array();
+$faz_lost     = array();
+$faz_drifted  = array();
+// Faithful translations of the English source. The older localized templates are
+// deliberately abridged — several drop the standalone "Contact" section — so
+// exact parity is asserted only where it was the translator's intent. Every
+// template is still held to the placeholder-type rule below.
 $faz_faithful = array( 'nl', 'hr' );
-foreach ( $faz_matrix_dirs as $faz_dir ) {
-	$faz_j  = basename( $faz_dir );
-	$faz_en = @file_get_contents( $faz_dir . '/en.md' );
-	foreach ( $faz_langs as $faz_l ) {
+foreach ( $faz_expect_j as $faz_j ) {
+	$faz_dir = $tpl_dir . '/' . $faz_j;
+	if ( ! is_dir( $faz_dir ) ) {
+		$faz_no_dir[] = $faz_j;
+		continue;
+	}
+	$faz_en_path = $faz_dir . '/en.md';
+	// Readability, not just existence: resolve_template_path() requires both, so
+	// an unreadable en.md is a broken fallback. Reading it with @ and skipping on
+	// failure would let the whole jurisdiction pass unchecked.
+	$faz_en = ( file_exists( $faz_en_path ) && is_readable( $faz_en_path ) )
+		? file_get_contents( $faz_en_path )
+		: false;
+	if ( ! is_string( $faz_en ) ) {
+		$faz_unread[] = $faz_j . '/en';
+	}
+	foreach ( $faz_expect_l as $faz_l ) {
 		$faz_path = $faz_dir . '/' . $faz_l . '.md';
 		if ( ! file_exists( $faz_path ) ) {
 			$faz_missing[] = $faz_j . '/' . $faz_l;
+			continue;
+		}
+		if ( ! is_readable( $faz_path ) ) {
+			$faz_unread[] = $faz_j . '/' . $faz_l;
 			continue;
 		}
 		if ( ! is_string( $faz_en ) || 'en' === $faz_l ) {
@@ -487,9 +507,9 @@ foreach ( $faz_matrix_dirs as $faz_dir ) {
 		}
 		$faz_body = (string) file_get_contents( $faz_path );
 		// Losing a placeholder TYPE removes something the document cannot do
-		// without — the controller's contact, the cookie inventory, the
-		// retention period. Abridging a section is an editorial choice; losing
-		// the only occurrence of a token is a defect in a legal document.
+		// without — the controller's contact, the cookie inventory, the retention
+		// period. Abridging a section is an editorial choice; losing the only
+		// occurrence of a token is a defect in a legal document.
 		if ( array_diff( array_unique( $faz_tokens( $faz_en ) ), array_unique( $faz_tokens( $faz_body ) ) ) ) {
 			$faz_lost[] = $faz_j . '/' . $faz_l;
 		}
@@ -500,7 +520,9 @@ foreach ( $faz_matrix_dirs as $faz_dir ) {
 		}
 	}
 }
-assert_eq( $faz_missing, array(), 'every policy language ships for every jurisdiction' );
+assert_eq( $faz_no_dir, array(), 'every declared jurisdiction has a template directory' );
+assert_eq( $faz_missing, array(), 'every declared language ships for every jurisdiction' );
+assert_eq( $faz_unread, array(), 'every shipped template is readable, as resolve_template_path() requires' );
 assert_eq( $faz_lost, array(), 'no localized template drops a placeholder the English source has' );
 assert_eq( $faz_drifted, array(), 'faithful translations keep the English section count and placeholder multiset' );
 


### PR DESCRIPTION
Follow-up to #270. Dutch and Croatian shipped a translated interface and were selectable as a policy language, but **no Cookie Policy template existed for either, in any jurisdiction**. `resolve_template_path()` falls back `lang → native → en`, so those sites generated an English legal document — and nothing in the product said so.

Eight templates: `nl.md` and `hr.md` for GDPR, CCPA/CPRA, LGPD and POPIA.

## Translated from English, not from the existing localizations

The older localized templates are **deliberately abridged**: the German, French, Italian and Spanish CCPA files run ~200 words against 659 in English, having dropped several sections. Translating the fuller English source gives Dutch and Croatian operators the more complete document rather than replicating the abridgement.

Register follows the document type, not the interface: formal *u* in Dutch, where the banner uses *je*. A cookie policy is a legal instrument and Dutch legal drafting is formal — matching the banner would have been consistency in the wrong direction.

## Nothing was needed on the admin side

Worth stating, since it was the other half of the request. The Cookie Policy screen **already** renders the shipped text as each override box's placeholder, and **already** shows a notice when the language falls back to another template. Both behave correctly the moment a template exists: the placeholders now read Dutch and Croatian, and the notice stops appearing.

## The guard, and why it is shaped this way

The gap was invisible — a selectable language, a full gettext catalogue, and a silent English fallback. The test now asserts:

1. **Every language ships for every jurisdiction.** Otherwise the fallback substitutes English for some jurisdictions and not others, with no signal.
2. **No localized template drops a placeholder *type* its English source has.** Losing the only occurrence of `{{COMPANY_EMAIL}}` or `{{COOKIE_CATEGORIES}}` takes the controller's contact or the cookie inventory out of a legal document.
3. **The two faithful translations match the English section count and placeholder multiset exactly.**

Rule 2 holds across the entire existing corpus — zero violations — while leaving the abridged templates their editorial freedom. That shape was not the first attempt: demanding exact parity from everything failed on **eleven** pre-existing files, which would have been a red build reporting a decision someone had already made on purpose. Six of those drop one `{{COMPANY_EMAIL}}`, but each still carries the address twice (controller block and rights section), so no contact is actually lost — only the standalone Contact section.

## Testing

Mutation-proven: deleting `lgpd-brazil/hr.md` turns the completeness assertion red; removing one placeholder from a Dutch template turns two red.

Verified against the real resolver rather than by reading it — `nl` and `hr` resolve to their own file in all four jurisdictions, an unknown language still falls back (`en`, or `pt-BR` for LGPD, its native language) — and the Dutch GDPR policy renders as HTML with the title *Cookiebeleid* and its placeholders intact.

Unit gate 147/147, policy-generator suite 151/151.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunti modelli di Cookie Policy in olandese e croato per GDPR, CCPA/CPRA, LGPD e POPIA.
  * Il generatore produce documenti completi nella lingua selezionata, senza ricorrere automaticamente all’inglese.
  * Le schermate di personalizzazione mostrano i testi localizzati come segnaposto per entrambe le lingue.

* **Miglioramenti**
  * Chiarita la distinzione tra richieste verificabili dei consumatori e richieste di opt-out dalla vendita o condivisione dei dati nelle policy CCPA/CPRA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->