### PR TITLE
refactor(admin-js): name the i18n helper fazI18n, not __

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to FAZ Cookie Manager are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- The admin JavaScript translation helper is named `fazI18n()` instead of `__()`. It never was gettext — it looks up a dotted key in the PHP-provided `fazConfig.i18n` map — but under the gettext name the string extractor on translate.wordpress.org harvested 285 of those keys as if they were translatable English text, which capped every locale's completion at 84.8% and blocked language-pack generation. No runtime behaviour changes: the keys, the English fallbacks and the lookup are untouched.
+
 ## [1.29.0] - 2026-09-02
 
 ### Fixed

--- a/admin/assets/js/modules/scan-engine.js
+++ b/admin/assets/js/modules/scan-engine.js
@@ -23,7 +23,10 @@
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back
 	// to the provided string. Mirrors the per-page helper so the engine carries
 	// no dependency on whichever page happens to load it.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -463,7 +466,7 @@
 				return FAZ.post('scans/discover', discoverPayload).catch(function (err) {
 					if (attempt < 2 && err && err.code === 'fetch_error') {
 						var delay = attempt === 0 ? 1000 : 3000;
-						emit.status(__('cookies.serverBusyRetrying', 'Server busy, retrying in %ds...').replace('%d', delay / 1000));
+						emit.status(fazI18n('cookies.serverBusyRetrying', 'Server busy, retrying in %ds...').replace('%d', delay / 1000));
 						console.warn('[FAZ Scanner] Discover attempt ' + (attempt + 1) + ' failed, retrying...', err.message);
 						return new Promise(function (r) { setTimeout(r, delay); })
 							.then(function () { return discoverWithRetry(attempt + 1); });
@@ -494,11 +497,11 @@
 				scanMetrics.urlsDiscovered = urls.length;
 
 				if (!urls.length) {
-					rejectAndAbort(new Error(__('cookies.noPagesFound', 'No pages found to scan.')));
+					rejectAndAbort(new Error(fazI18n('cookies.noPagesFound', 'No pages found to scan.')));
 					return;
 				}
 
-				emit.status(__('cookies.scanningPages', 'Scanning 0/%d pages...').replace('%d', urls.length));
+				emit.status(fazI18n('cookies.scanningPages', 'Scanning 0/%d pages...').replace('%d', urls.length));
 				emit.pages('0/' + urls.length + ' pages');
 				emit.progress(0);
 
@@ -516,7 +519,7 @@
 						collectedScripts
 					)) {
 						var browserError = new Error(
-							__('cookies.browserScanUnavailable', 'The browser scan could not inspect any page. Make sure the public site is reachable through the WordPress admin origin and that framing is not blocked.')
+							fazI18n('cookies.browserScanUnavailable', 'The browser scan could not inspect any page. Make sure the public site is reachable through the WordPress admin origin and that framing is not blocked.')
 							+ buildScanDiagnosticsHint(diagnostics, 0)
 						);
 						browserError.stage = 'browser';
@@ -528,7 +531,7 @@
 					// scripts an iframe never requests. Site root, not urls[0],
 					// which may be a WooCommerce page after priority prepending.
 					if (urls.length > 0) {
-						emit.status(__('cookies.enrichingServer', 'Enriching with server scan...'));
+						emit.status(fazI18n('cookies.enrichingServer', 'Enriching with server scan...'));
 						var homepageUrl = result.home_url || urls[0];
 						FAZ.post('scans/server-scan', { url: homepageUrl }).then(function (serverResult) {
 							var existingScripts = {};
@@ -570,7 +573,7 @@
 
 					function doImport() {
 						emit.progress(100);
-						emit.status(__('cookies.savingResults', 'Saving results...'));
+						emit.status(fazI18n('cookies.savingResults', 'Saving results...'));
 
 						var importStart = Date.now();
 						var metricsToSend = {
@@ -643,7 +646,7 @@
 									throw err;
 								}
 								var delay = IMPORT_RETRY_DELAYS_MS[attempt];
-								emit.status(__('cookies.serverBusyRetrying', 'Server busy, retrying in %ds...').replace('%d', delay / 1000));
+								emit.status(fazI18n('cookies.serverBusyRetrying', 'Server busy, retrying in %ds...').replace('%d', delay / 1000));
 								console.warn('[FAZ Scanner] Import attempt ' + (attempt + 1) + ' failed, retrying the same scan...', err.message);
 								return new Promise(function (retry) { setTimeout(retry, delay); })
 									.then(function () { return importWithRetry(attempt + 1); });
@@ -684,7 +687,7 @@
 						// One shape for every import failure, so the first attempt and
 						// a later manual retry are indistinguishable to the caller.
 						function buildImportError(err) {
-							var failure = new Error(__('cookies.scanSaveFailed', 'Scan finished but failed to save results.') + buildScanApiErrorDetail(err));
+							var failure = new Error(fazI18n('cookies.scanSaveFailed', 'Scan finished but failed to save results.') + buildScanApiErrorDetail(err));
 							failure.stage = 'import';
 							failure.scanId = scanId;
 							// Only what the SERVER said. See getApiErrorSessionHeld().
@@ -716,7 +719,7 @@
 				}, emit, scanMetrics, scanOptions);
 			}).catch(function (err) {
 				console.error('[FAZ Scanner] Discover failed:', err);
-				var e1 = new Error(__('cookies.discoverFailed', 'Failed to discover pages.') + buildScanApiErrorDetail(err));
+				var e1 = new Error(fazI18n('cookies.discoverFailed', 'Failed to discover pages.') + buildScanApiErrorDetail(err));
 				e1.stage = 'discover';
 				// The server's error code already travels in the MESSAGE above,
 				// which is for humans. Carry it as data too, so a caller can

--- a/admin/assets/js/pages/banner.js
+++ b/admin/assets/js/pages/banner.js
@@ -7,7 +7,10 @@
 	'use strict';
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		// Read-only dot-path lookup via reduce (not a mutating for-loop) — a
 		// pure traversal that returns the localized string or the fallback.
@@ -53,17 +56,17 @@
 	// ── Colour-contrast checker (WCAG AA) — hoisted to module scope so
 	// loadBanner()'s on-load check (outside FAZ.ready) can reach it; the
 	// in-FAZ.ready colour-change handlers call it too. Self-contained:
-	// only dependency is the module-level __() i18n helper.
+	// only dependency is the module-level fazI18n() i18n helper.
 	var FAZ_CONTRAST_PAIRS = [
-		{ fg: 'faz-b-title-color',       bg: 'faz-b-notice-bg',       min: 4.5, label: __('banner.cTitle', 'Title vs banner background') },
-		{ fg: 'faz-b-desc-color',        bg: 'faz-b-notice-bg',       min: 4.5, label: __('banner.cDesc', 'Description vs banner background') },
-		{ fg: 'faz-b-link-color',        bg: 'faz-b-notice-bg',       min: 4.5, label: __('banner.cLink', 'Link vs banner background') },
-		{ fg: 'faz-b-accept-text',       bg: 'faz-b-accept-bg',       min: 4.5, label: __('banner.cAccept', 'Accept button text vs its background') },
-		{ fg: 'faz-b-reject-text',       bg: 'faz-b-reject-bg',       min: 4.5, label: __('banner.cReject', 'Reject button text vs its background') },
-		{ fg: 'faz-b-settings-text',     bg: 'faz-b-settings-bg',      min: 4.5, label: __('banner.cSettings', 'Settings button text vs its background'), fallbackBg: 'faz-b-notice-bg' },
-		{ fg: 'faz-b-catprev-save-text', bg: 'faz-b-catprev-save-bg',  min: 4.5, label: __('banner.cSave', 'Save button text vs its background') },
-		{ fg: 'faz-b-catprev-label',     bg: 'faz-b-notice-bg',        min: 4.5, label: __('banner.cCatLabel', 'Category label vs banner background') },
-		{ fg: 'faz-b-donotsell-text',    bg: 'faz-b-notice-bg',        min: 4.5, label: __('banner.cDoNotSell', 'Do Not Sell text vs banner background') }
+		{ fg: 'faz-b-title-color',       bg: 'faz-b-notice-bg',       min: 4.5, label: fazI18n('banner.cTitle', 'Title vs banner background') },
+		{ fg: 'faz-b-desc-color',        bg: 'faz-b-notice-bg',       min: 4.5, label: fazI18n('banner.cDesc', 'Description vs banner background') },
+		{ fg: 'faz-b-link-color',        bg: 'faz-b-notice-bg',       min: 4.5, label: fazI18n('banner.cLink', 'Link vs banner background') },
+		{ fg: 'faz-b-accept-text',       bg: 'faz-b-accept-bg',       min: 4.5, label: fazI18n('banner.cAccept', 'Accept button text vs its background') },
+		{ fg: 'faz-b-reject-text',       bg: 'faz-b-reject-bg',       min: 4.5, label: fazI18n('banner.cReject', 'Reject button text vs its background') },
+		{ fg: 'faz-b-settings-text',     bg: 'faz-b-settings-bg',      min: 4.5, label: fazI18n('banner.cSettings', 'Settings button text vs its background'), fallbackBg: 'faz-b-notice-bg' },
+		{ fg: 'faz-b-catprev-save-text', bg: 'faz-b-catprev-save-bg',  min: 4.5, label: fazI18n('banner.cSave', 'Save button text vs its background') },
+		{ fg: 'faz-b-catprev-label',     bg: 'faz-b-notice-bg',        min: 4.5, label: fazI18n('banner.cCatLabel', 'Category label vs banner background') },
+		{ fg: 'faz-b-donotsell-text',    bg: 'faz-b-notice-bg',        min: 4.5, label: fazI18n('banner.cDoNotSell', 'Do Not Sell text vs banner background') }
 	];
 	function fazReadColor(id) {
 		// The -hex text input is the canonical value (can hold "transparent"
@@ -125,10 +128,10 @@
 		var card = document.createElement('div');
 		card.style.cssText = 'border-left:4px solid var(--faz-warning,#b86900);background:#fff8e6;padding:10px 14px;border-radius:4px;font-size:13px';
 		var h = document.createElement('strong');
-		h.textContent = __('banner.contrastTitle', 'Accessibility: low colour contrast');
+		h.textContent = fazI18n('banner.contrastTitle', 'Accessibility: low colour contrast');
 		var p = document.createElement('p');
 		p.style.margin = '6px 0 4px';
-		p.textContent = __('banner.contrastIntro', 'These colour pairs fall below the WCAG AA 4.5:1 minimum and may be hard to read:');
+		p.textContent = fazI18n('banner.contrastIntro', 'These colour pairs fall below the WCAG AA 4.5:1 minimum and may be hard to read:');
 		var ul = document.createElement('ul');
 		ul.style.cssText = 'margin:0;padding-left:18px';
 		issues.forEach(function (i) {
@@ -200,7 +203,7 @@
 			var stored = parseInt(expiryEl.value, 10);
 			var served = isFinite(stored) ? Math.max(min, Math.min(max, stored)) : stored;
 			if (isFinite(stored) && served !== stored) {
-				hint.textContent = __('banner.expiryRuntimeBounded', 'This banner stores %1$d days, but visitors are served %2$d days: the selected regulation bounds the lifetime when the banner is served.')
+				hint.textContent = fazI18n('banner.expiryRuntimeBounded', 'This banner stores %1$d days, but visitors are served %2$d days: the selected regulation bounds the lifetime when the banner is served.')
 					.replace('%1$d', String(stored))
 					.replace('%2$d', String(served));
 				hint.style.display = '';
@@ -494,7 +497,7 @@
 			migrated = true;
 		}
 		if (migrated && typeof FAZ !== 'undefined' && FAZ.notify) {
-			FAZ.notify(__('banner.layoutMigrated', 'Classic / Pushdown has no opt-out popup, which a CCPA "Do Not Sell" banner requires — switched to a compatible layout.'), 'warning');
+			FAZ.notify(fazI18n('banner.layoutMigrated', 'Classic / Pushdown has no opt-out popup, which a CCPA "Do Not Sell" banner requires — switched to a compatible layout.'), 'warning');
 		}
 		var hint = document.getElementById('faz-b-type-ccpa-hint');
 		if (hint) hint.style.display = lawShowsDoNotSell ? '' : 'none';
@@ -506,7 +509,7 @@
 		if (!opt) return;
 		if (!opt.dataset.baseLabel) opt.dataset.baseLabel = opt.textContent;
 		opt.textContent = unavailable
-			? opt.dataset.baseLabel + ' — ' + __('banner.notAvailCcpa', 'not available for CCPA / US State Laws')
+			? opt.dataset.baseLabel + ' — ' + fazI18n('banner.notAvailCcpa', 'not available for CCPA / US State Laws')
 			: opt.dataset.baseLabel;
 	}
 
@@ -813,7 +816,7 @@
 				showMissingBannerNotice(bannerId);
 				return;
 			}
-			FAZ.notify(__('banner.loadFailed', 'Failed to load banner settings.'), 'error');
+			FAZ.notify(fazI18n('banner.loadFailed', 'Failed to load banner settings.'), 'error');
 		});
 	}
 
@@ -882,7 +885,7 @@
 			btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
 			var label = b.name || ('Banner #' + b.id);
 			if (Number(b['default']) === 1) label = '★ ' + label;
-			if (Number(b.status) !== 1) label += ' (' + __('banner.inactive', 'inactive') + ')';
+			if (Number(b.status) !== 1) label += ' (' + fazI18n('banner.inactive', 'inactive') + ')';
 			btn.textContent = label;
 			if (!isActive) {
 				btn.addEventListener('click', function () {
@@ -924,11 +927,11 @@
 					contents: bannerData.contents
 				}).then(function () {
 					bannerData.name = next;
-					FAZ.notify(__('banner.renamed', 'Banner renamed.'));
+					FAZ.notify(fazI18n('banner.renamed', 'Banner renamed.'));
 					// Re-render the chip row so the new name is reflected.
 					populateSwitcher();
 				}).catch(function () {
-					FAZ.notify(__('banner.renameFailed', 'Failed to save the new name.'), 'error');
+					FAZ.notify(fazI18n('banner.renameFailed', 'Failed to save the new name.'), 'error');
 					nameIn.value = bannerData.name || '';
 				});
 			};
@@ -949,7 +952,7 @@
 		}
 		if (delBtn && !delBtn.dataset.fazSwitcherBound) {
 			delBtn.addEventListener('click', function () {
-				if (!window.confirm(__('banner.deleteConfirm', 'Delete this banner permanently? This cannot be undone.'))) return;
+				if (!window.confirm(fazI18n('banner.deleteConfirm', 'Delete this banner permanently? This cannot be undone.'))) return;
 				delBtn.disabled = true;
 				// Helper: navigate back to the page-without-banner-id so the
 				// editor mounts on the default banner. Used by both the
@@ -992,7 +995,7 @@
 					// it as "already deleted" rather than a hard failure.
 					var n = (typeof resp === 'number') ? resp : (resp && typeof resp.deleted === 'number' ? resp.deleted : 1);
 					if (!n) {
-						FAZ.notify(__('banner.alreadyDeleted', 'This banner was already removed. Reloading…'));
+						FAZ.notify(fazI18n('banner.alreadyDeleted', 'This banner was already removed. Reloading…'));
 						redirectWithGrace();
 						return;
 					}
@@ -1002,10 +1005,10 @@
 						var still = Array.isArray(rows) && rows.some(function (b) { return Number(b.id) === Number(bannerId); });
 						if (still) {
 							delBtn.disabled = false;
-							FAZ.notify(__('banner.deleteFailed', 'Failed to delete banner.') + ' (server still lists id=' + bannerId + ')', 'error');
+							FAZ.notify(fazI18n('banner.deleteFailed', 'Failed to delete banner.') + ' (server still lists id=' + bannerId + ')', 'error');
 							return;
 						}
-						FAZ.notify(__('banner.deleted', 'Banner deleted.'));
+						FAZ.notify(fazI18n('banner.deleted', 'Banner deleted.'));
 						redirectToDefault();
 					});
 				}).catch(function (err) {
@@ -1022,7 +1025,7 @@
 						|| (err.data && err.data.status === 404)
 					);
 					if ( alreadyGone ) {
-						FAZ.notify(__('banner.alreadyDeleted', 'This banner was already removed. Reloading…'));
+						FAZ.notify(fazI18n('banner.alreadyDeleted', 'This banner was already removed. Reloading…'));
 						redirectWithGrace();
 						return;
 					}
@@ -1030,7 +1033,7 @@
 					var detail = '';
 					if (err && err.code) detail = ' [' + err.code + ']';
 					else if (err && err.message) detail = ' [' + err.message + ']';
-					FAZ.notify(__('banner.deleteFailed', 'Failed to delete banner.') + detail, 'error');
+					FAZ.notify(fazI18n('banner.deleteFailed', 'Failed to delete banner.') + detail, 'error');
 					if (window.console && console.error) console.error('FAZ delete banner failed', err);
 				});
 			});
@@ -1050,14 +1053,14 @@
 		// Name
 		var nameWrap = document.createElement('div');
 		var nameLabel = document.createElement('label');
-		nameLabel.textContent = __('banner.new.name', 'Banner name');
+		nameLabel.textContent = fazI18n('banner.new.name', 'Banner name');
 		nameLabel.style.cssText = 'display:block;font-weight:500;margin-bottom:.25rem;';
 		var nameInput = document.createElement('input');
 		nameInput.type = 'text';
 		nameInput.className = 'faz-input';
 		nameInput.style.width = '100%';
-		nameInput.placeholder = __('banner.new.namePlaceholder', 'e.g. CCPA US visitors');
-		nameInput.value = __('banner.new.defaultName', 'New banner');
+		nameInput.placeholder = fazI18n('banner.new.namePlaceholder', 'e.g. CCPA US visitors');
+		nameInput.value = fazI18n('banner.new.defaultName', 'New banner');
 		nameWrap.appendChild(nameLabel);
 		nameWrap.appendChild(nameInput);
 		form.appendChild(nameWrap);
@@ -1065,12 +1068,12 @@
 		// Law
 		var lawWrap = document.createElement('div');
 		var lawLabel = document.createElement('label');
-		lawLabel.textContent = __('banner.new.law', 'Consent model');
+		lawLabel.textContent = fazI18n('banner.new.law', 'Consent model');
 		lawLabel.style.cssText = 'display:block;font-weight:500;margin-bottom:.25rem;';
 		var lawHelp = document.createElement('div');
 		lawHelp.className = 'faz-help';
 		lawHelp.style.cssText = 'margin-bottom:.4rem;';
-		lawHelp.innerHTML = __(
+		lawHelp.innerHTML = fazI18n(
 			'banner.new.lawHelp',
 			'Pick the legal paradigm, not the country — language, "Do not sell" copy and country targeting live in the Content + Geo Targeting tabs after creation.<br><strong>Opt-in</strong> covers GDPR, UK-GDPR, ePrivacy, LGPD (Brazil), Swiss nFADP, PIPEDA (Canada), KVKK (Turkey) and similar consent-first regimes. <strong>Opt-out</strong> covers CCPA/CPRA (California), Virginia CDPA, Colorado CPA, Connecticut CTDPA, Utah UCPA and other US state laws.'
 		);
@@ -1078,8 +1081,8 @@
 		lawSelect.className = 'faz-input';
 		lawSelect.style.width = '100%';
 		[
-			{ value: 'gdpr', label: __('banner.new.lawOptionGdpr', 'Opt-in — GDPR, UK-GDPR, ePrivacy, LGPD, nFADP, PIPEDA, …') },
-			{ value: 'ccpa', label: __('banner.new.lawOptionCcpa', 'Opt-out — CCPA/CPRA, Virginia, Colorado, Connecticut, Utah, …') }
+			{ value: 'gdpr', label: fazI18n('banner.new.lawOptionGdpr', 'Opt-in — GDPR, UK-GDPR, ePrivacy, LGPD, nFADP, PIPEDA, …') },
+			{ value: 'ccpa', label: fazI18n('banner.new.lawOptionCcpa', 'Opt-out — CCPA/CPRA, Virginia, Colorado, Connecticut, Utah, …') }
 		].forEach(function (opt) {
 			var o = document.createElement('option');
 			o.value = opt.value;
@@ -1096,23 +1099,23 @@
 		// "EU/EEA" here produces the same target_countries the tab does.
 		var regWrap = document.createElement('div');
 		var regLabel = document.createElement('label');
-		regLabel.textContent = __('banner.new.regions', 'Target regions (optional)');
+		regLabel.textContent = fazI18n('banner.new.regions', 'Target regions (optional)');
 		regLabel.style.cssText = 'display:block;font-weight:500;margin-bottom:.25rem;';
 		var regHelp = document.createElement('div');
 		regHelp.className = 'faz-help';
 		regHelp.style.cssText = 'margin-bottom:.4rem;';
-		regHelp.textContent = __('banner.new.regionsHelp', 'Tick the regions this banner should target. Leave all unchecked to make this a match-all / fallback banner.');
+		regHelp.textContent = fazI18n('banner.new.regionsHelp', 'Tick the regions this banner should target. Leave all unchecked to make this a match-all / fallback banner.');
 		var regGrid = document.createElement('div');
 		regGrid.style.cssText = 'display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:.4rem;';
 		var REGION_LABELS = {
-			EU: __('banner.new.regionEu', 'EU / EEA (27 + IS, LI, NO)'),
-			UK: __('banner.new.regionUk', 'United Kingdom (UK-GDPR)'),
-			US: __('banner.new.regionUs', 'United States'),
-			CA: __('banner.new.regionCa', 'Canada'),
-			BR: __('banner.new.regionBr', 'Brazil (LGPD)'),
-			AU: __('banner.new.regionAu', 'Australia'),
-			JP: __('banner.new.regionJp', 'Japan'),
-			CH: __('banner.new.regionCh', 'Switzerland (nFADP)')
+			EU: fazI18n('banner.new.regionEu', 'EU / EEA (27 + IS, LI, NO)'),
+			UK: fazI18n('banner.new.regionUk', 'United Kingdom (UK-GDPR)'),
+			US: fazI18n('banner.new.regionUs', 'United States'),
+			CA: fazI18n('banner.new.regionCa', 'Canada'),
+			BR: fazI18n('banner.new.regionBr', 'Brazil (LGPD)'),
+			AU: fazI18n('banner.new.regionAu', 'Australia'),
+			JP: fazI18n('banner.new.regionJp', 'Japan'),
+			CH: fazI18n('banner.new.regionCh', 'Switzerland (nFADP)')
 		};
 		Object.keys(REGION_PRESETS).forEach(function (key) {
 			var lbl = document.createElement('label');
@@ -1139,13 +1142,13 @@
 		// Custom country codes
 		var customWrap = document.createElement('div');
 		var customLabel = document.createElement('label');
-		customLabel.textContent = __('banner.new.customCountries', 'Additional country codes (optional)');
+		customLabel.textContent = fazI18n('banner.new.customCountries', 'Additional country codes (optional)');
 		customLabel.style.cssText = 'display:block;font-weight:500;margin-bottom:.25rem;';
 		var customInput = document.createElement('input');
 		customInput.type = 'text';
 		customInput.className = 'faz-input';
 		customInput.style.width = '100%';
-		customInput.placeholder = __('banner.new.customCountriesPlaceholder', 'NZ, SG, KR');
+		customInput.placeholder = fazI18n('banner.new.customCountriesPlaceholder', 'NZ, SG, KR');
 		customWrap.appendChild(customLabel);
 		customWrap.appendChild(customInput);
 		form.appendChild(customWrap);
@@ -1155,7 +1158,7 @@
 		rowWrap.style.cssText = 'display:flex;gap:1rem;align-items:flex-end;';
 		var prioWrap = document.createElement('div');
 		var prioLabel = document.createElement('label');
-		prioLabel.textContent = __('banner.new.priority', 'Priority');
+		prioLabel.textContent = fazI18n('banner.new.priority', 'Priority');
 		prioLabel.style.cssText = 'display:block;font-weight:500;margin-bottom:.25rem;font-size:13px;';
 		var prioInput = document.createElement('input');
 		prioInput.type = 'number';
@@ -1173,7 +1176,7 @@
 		var defTrack = document.createElement('span');
 		defTrack.className = 'faz-toggle-track';
 		var defText = document.createElement('span');
-		defText.textContent = __('banner.new.useAsDefault', 'Use as default fallback');
+		defText.textContent = fazI18n('banner.new.useAsDefault', 'Use as default fallback');
 		defLbl.appendChild(defInput);
 		defLbl.appendChild(defTrack);
 		defLbl.appendChild(defText);
@@ -1187,16 +1190,16 @@
 		var cancelBtn = document.createElement('button');
 		cancelBtn.type = 'button';
 		cancelBtn.className = 'faz-btn faz-btn-secondary';
-		cancelBtn.textContent = __('banner.new.cancel', 'Cancel');
+		cancelBtn.textContent = fazI18n('banner.new.cancel', 'Cancel');
 		var createBtn = document.createElement('button');
 		createBtn.type = 'button';
 		createBtn.className = 'faz-btn faz-btn-primary';
-		createBtn.textContent = __('banner.new.create', 'Create banner');
+		createBtn.textContent = fazI18n('banner.new.create', 'Create banner');
 		footer.appendChild(cancelBtn);
 		footer.appendChild(createBtn);
 
 		var m = FAZ.modal({
-			title: __('banner.new.title', 'Create a new banner'),
+			title: fazI18n('banner.new.title', 'Create a new banner'),
 			body: form,
 			footer: footer,
 			size: 'lg'
@@ -1225,7 +1228,7 @@
 
 			createBtn.disabled = true;
 			cancelBtn.disabled = true;
-			createBtn.textContent = __('banner.new.creating', 'Creating…');
+			createBtn.textContent = fazI18n('banner.new.creating', 'Creating…');
 
 			// Pull the law-appropriate default config so the new banner
 			// starts with sane content/translations/colours instead of an
@@ -1244,20 +1247,20 @@
 			}).then(function (created) {
 				var newId = created && created.id ? Number(created.id) : 0;
 				if (newId <= 0) {
-					FAZ.notify(__('banner.new.failed', 'Failed to create banner.'), 'error');
+					FAZ.notify(fazI18n('banner.new.failed', 'Failed to create banner.'), 'error');
 					createBtn.disabled = false;
 					cancelBtn.disabled = false;
-					createBtn.textContent = __('banner.new.create', 'Create banner');
+					createBtn.textContent = fazI18n('banner.new.create', 'Create banner');
 					return;
 				}
 				var base = window.location.href.split('?')[0];
 				var page = (window.location.search.match(/page=([^&]+)/) || [null, 'faz-cookie-manager-banner'])[1];
 				window.location.href = base + '?page=' + encodeURIComponent(page) + '&banner_id=' + newId;
 			}).catch(function () {
-				FAZ.notify(__('banner.new.failed', 'Failed to create banner.'), 'error');
+				FAZ.notify(fazI18n('banner.new.failed', 'Failed to create banner.'), 'error');
 				createBtn.disabled = false;
 				cancelBtn.disabled = false;
-				createBtn.textContent = __('banner.new.create', 'Create banner');
+				createBtn.textContent = fazI18n('banner.new.create', 'Create banner');
 			});
 		});
 	}
@@ -1370,7 +1373,7 @@
 						impact.textContent = '';
 						return;
 					}
-					impact.textContent = __(
+					impact.textContent = fazI18n(
 						'banner.defaultImpact',
 						'Saving will clear the default flag on: '
 					) + others.join(', ') + '.';
@@ -1434,11 +1437,11 @@
 					banner_control: { status: newValue }
 				}).then(function () {
 					FAZ.notify(newValue
-						? __('banner.enabled', 'Cookie banner enabled.')
-						: __('banner.disabled', 'Cookie banner disabled.'));
+						? fazI18n('banner.enabled', 'Cookie banner enabled.')
+						: fazI18n('banner.disabled', 'Cookie banner disabled.'));
 				}).catch(function () {
 					toggle.checked = !newValue;
-					FAZ.notify(__('banner.toggleFailed', 'Failed to update banner status.'), 'error');
+					FAZ.notify(fazI18n('banner.toggleFailed', 'Failed to update banner status.'), 'error');
 				});
 			});
 		}).catch(function () {
@@ -2016,7 +2019,7 @@
 		syncFormToBannerData();
 		refreshPreview();
 
-		FAZ.notify(__('banner.presetApplied', 'Preset applied: %s').replace('%s', preset.name), 'success');
+		FAZ.notify(fazI18n('banner.presetApplied', 'Preset applied: %s').replace('%s', preset.name), 'success');
 	}
 
 	function setColorPair(baseId, value) {
@@ -2298,7 +2301,7 @@
 			var dnsHint = document.getElementById('faz-b-law-content-hint');
 			if (dnsHint) dnsHint.style.display = '';
 			FAZ.notify(
-				__('banner.dnsMismatch', 'Heads up: the banner text still promises the "Do Not Sell" link under a law that no longer shows it (languages: %s). Saved anyway — update the Content tab to match.').replace('%s', dnsMismatch.join(', ')),
+				fazI18n('banner.dnsMismatch', 'Heads up: the banner text still promises the "Do Not Sell" link under a law that no longer shows it (languages: %s). Saved anyway — update the Content tab to match.').replace('%s', dnsMismatch.join(', ')),
 				'warning'
 			);
 		}
@@ -2322,11 +2325,11 @@
 				bannerData = updated;
 				normalizeBannerConfig(bannerData.properties);
 				FAZ.btnLoading(btn, false);
-				FAZ.notify(__('banner.saved', 'Banner settings saved.'));
+				FAZ.notify(fazI18n('banner.saved', 'Banner settings saved.'));
 			refreshPreview();
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('banner.saveFailed', 'Failed to save banner settings.'), 'error');
+			FAZ.notify(fazI18n('banner.saveFailed', 'Failed to save banner settings.'), 'error');
 		});
 	}
 

--- a/admin/assets/js/pages/consent-logs.js
+++ b/admin/assets/js/pages/consent-logs.js
@@ -6,7 +6,10 @@
 	'use strict';
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -92,7 +95,7 @@
 			td.colSpan = 6;
 			td.className = 'faz-text-center faz-text-muted';
 			td.style.padding = '40px';
-			td.textContent = __('consentLogs.loadFailed', 'Failed to load consent logs.');
+			td.textContent = fazI18n('consentLogs.loadFailed', 'Failed to load consent logs.');
 			tr.appendChild(td);
 			tbody.appendChild(tr);
 		});
@@ -108,7 +111,7 @@
 			td.colSpan = 6;
 			td.className = 'faz-text-center faz-text-muted';
 			td.style.padding = '40px';
-			td.textContent = __('consentLogs.noLogs', 'No consent logs found.');
+			td.textContent = fazI18n('consentLogs.noLogs', 'No consent logs found.');
 			tr.appendChild(td);
 			tbody.appendChild(tr);
 			document.getElementById('faz-log-footer').style.display = 'none';
@@ -169,7 +172,7 @@
 						// auto-humanized label.
 						var metaKey = k.slice(5);
 						var metaLabel = metaKey === 'age_affirmed'
-							? __('consentLogs.metaAgeAffirmed', 'Age affirmed')
+							? fazI18n('consentLogs.metaAgeAffirmed', 'Age affirmed')
 							: metaKey.replace(/_/g, ' ').replace(/\b\w/g, function (c) { return c.toUpperCase(); });
 						catBadge.className = 'faz-cat-pill faz-cat-audit';
 						catBadge.textContent = metaLabel;
@@ -222,14 +225,14 @@
 		// Info text
 		var start = (page - 1) * perPage + 1;
 		var end = Math.min(page * perPage, totalItems);
-		info.textContent = __('consentLogs.showing', 'Showing %1$s\u2013%2$s of %3$s').replace('%1$s', start).replace('%2$s', end).replace('%3$s', totalItems);
+		info.textContent = fazI18n('consentLogs.showing', 'Showing %1$s\u2013%2$s of %3$s').replace('%1$s', start).replace('%2$s', end).replace('%3$s', totalItems);
 
 		if (totalPages <= 1) return;
 
 		// Prev button
 		var prev = document.createElement('button');
 		prev.className = 'faz-btn faz-btn-sm faz-btn-outline';
-		prev.textContent = __('consentLogs.prev', '← Prev');
+		prev.textContent = fazI18n('consentLogs.prev', '← Prev');
 		prev.disabled = page <= 1;
 		prev.addEventListener('click', function () { page--; loadLogs(); });
 		container.appendChild(prev);
@@ -256,7 +259,7 @@
 		// Next button
 		var next = document.createElement('button');
 		next.className = 'faz-btn faz-btn-sm faz-btn-outline';
-		next.textContent = __('consentLogs.next', 'Next →');
+		next.textContent = fazI18n('consentLogs.next', 'Next →');
 		next.disabled = page >= totalPages;
 		next.addEventListener('click', function () { page++; loadLogs(); });
 		container.appendChild(next);
@@ -302,10 +305,10 @@
 				link.click();
 				document.body.removeChild(link);
 				URL.revokeObjectURL(link.href);
-				FAZ.notify(__('consentLogs.exportOk', 'CSV exported successfully.'));
+				FAZ.notify(fazI18n('consentLogs.exportOk', 'CSV exported successfully.'));
 			})
 			.catch(function () {
-				FAZ.notify(__('consentLogs.exportFailed', 'Failed to export CSV.'), 'error');
+				FAZ.notify(fazI18n('consentLogs.exportFailed', 'Failed to export CSV.'), 'error');
 			});
 	}
 

--- a/admin/assets/js/pages/cookies.js
+++ b/admin/assets/js/pages/cookies.js
@@ -10,7 +10,10 @@
 	window.fazCookiesBooted = true;
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -110,7 +113,7 @@
 				svcSelect.innerHTML = '';
 				var placeholder = document.createElement('option');
 				placeholder.value = '';
-				placeholder.textContent = __('cookies.selectService', 'Select a service…');
+				placeholder.textContent = fazI18n('cookies.selectService', 'Select a service…');
 				svcSelect.appendChild(placeholder);
 				services.forEach(function (s) {
 					var opt = document.createElement('option');
@@ -124,7 +127,7 @@
 				svcSelect.innerHTML = '';
 				var failOpt = document.createElement('option');
 				failOpt.value = '';
-				failOpt.textContent = __('cookies.servicesLoadFailed', 'Could not load services');
+				failOpt.textContent = fazI18n('cookies.servicesLoadFailed', 'Could not load services');
 				svcSelect.appendChild(failOpt);
 			}).then(function () {
 				catalogueRequest = null;
@@ -151,7 +154,7 @@
 					// One i18n key for the whole sentence so translators can reorder
 					// the service label, count and text and handle plural forms.
 					FAZ.notify(
-						__('cookies.serviceRegistered', '%1$s: %2$d cookie(s) registered')
+						fazI18n('cookies.serviceRegistered', '%1$s: %2$d cookie(s) registered')
 							.replace('%1$s', function () { return label; })
 							.replace('%2$d', function () { return String(added); }),
 						'success'
@@ -161,7 +164,7 @@
 					loadCookies();
 					loadCategories();
 				}).catch(function () {
-					FAZ.notify(__('cookies.registerFailed', 'Could not register service.'), 'error');
+					FAZ.notify(fazI18n('cookies.registerFailed', 'Could not register service.'), 'error');
 				}).then(function () {
 					registerSvcBtn.disabled = false;
 				});
@@ -186,11 +189,11 @@
 			var ids = [];
 			document.querySelectorAll('.faz-cookie-check:checked').forEach(function (cb) { ids.push(parseInt(cb.value, 10)); });
 			if (!ids.length) return;
-			FAZ.confirm(__('cookies.bulkDeleteConfirm', 'Delete selected cookie(s)?') + ' (' + ids.length + ')').then(function (ok) {
+			FAZ.confirm(fazI18n('cookies.bulkDeleteConfirm', 'Delete selected cookie(s)?') + ' (' + ids.length + ')').then(function (ok) {
 				if (!ok) return;
 				FAZ.post('cookies/bulk-delete', { ids: ids }).then(function (res) {
 					var deletedCount = (res && typeof res.deleted === 'number') ? res.deleted : ids.length;
-					FAZ.notify(deletedCount + ' ' + __('cookies.cookieDeleted', 'Cookie deleted.'));
+					FAZ.notify(deletedCount + ' ' + fazI18n('cookies.cookieDeleted', 'Cookie deleted.'));
 					loadCookies();
 					loadCategories();
 					// `restorable` is what makes the undo affordance appear; the
@@ -204,8 +207,8 @@
 					var snapshotFailed = !!(err && err.code === 'faz_recycle_bin_write_failed');
 					FAZ.notify(
 						snapshotFailed
-							? __('cookies.bulkDeleteSnapshotFailed', 'Nothing was deleted: the undo snapshot could not be saved, so the cookies were left in place.')
-							: __('cookies.bulkDeleteFailed', 'Bulk delete failed.'),
+							? fazI18n('cookies.bulkDeleteSnapshotFailed', 'Nothing was deleted: the undo snapshot could not be saved, so the cookies were left in place.')
+							: fazI18n('cookies.bulkDeleteFailed', 'Bulk delete failed.'),
 						'error'
 					);
 				});
@@ -322,7 +325,7 @@
 			if (cat.slug === 'necessary') {
 				var naSpan = document.createElement('span');
 				naSpan.style.color = 'var(--faz-text-muted)';
-				naSpan.textContent = __('cookies.notApplicable', '—');
+				naSpan.textContent = fazI18n('cookies.notApplicable', '—');
 				tdSaleShare.appendChild(naSpan);
 			} else {
 				var mkToggle = function (kind, label, checked) {
@@ -340,8 +343,8 @@
 				// the schema default.
 				var sellOn = (cat.sell_personal_data === undefined) ? true : !!cat.sell_personal_data;
 				var shareOn = (cat.share_personal_data === undefined) ? true : !!cat.share_personal_data;
-				tdSaleShare.appendChild(mkToggle('sell', __('cookies.sell', 'Sell'), sellOn));
-				tdSaleShare.appendChild(mkToggle('share', __('cookies.share', 'Share'), shareOn));
+				tdSaleShare.appendChild(mkToggle('sell', fazI18n('cookies.sell', 'Sell'), sellOn));
+				tdSaleShare.appendChild(mkToggle('share', fazI18n('cookies.share', 'Share'), shareOn));
 			}
 			tr.appendChild(tdSaleShare);
 
@@ -410,7 +413,7 @@
 		Promise.allSettled(promises).then(function (results) {
 			var failed = results.filter(function (r) { return r.status === 'rejected'; }).length;
 			if (failed === 0) {
-				FAZ.notify(__('cookies.categoriesSaved', 'Categories saved.'), 'success');
+				FAZ.notify(fazI18n('cookies.categoriesSaved', 'Categories saved.'), 'success');
 			} else {
 				FAZ.notify((results.length - failed) + ' saved, ' + failed + ' failed.', 'error');
 			}
@@ -568,7 +571,7 @@
 		var deleteAllBtn = document.createElement('button');
 		deleteAllBtn.type = 'button';
 		deleteAllBtn.className = 'faz-btn faz-btn-sm faz-stale-delete-all';
-		deleteAllBtn.textContent = __('cookies.deleteAllStale', 'Delete all stale');
+		deleteAllBtn.textContent = fazI18n('cookies.deleteAllStale', 'Delete all stale');
 		deleteAllBtn.addEventListener('click', deleteAllStaleCookies);
 		staleBar.appendChild(deleteAllBtn);
 	}
@@ -638,18 +641,18 @@
 		bar.style.display = '';
 
 		var msg = document.createElement('span');
-		msg.textContent = __('cookies.jarOnlyHint', '%d cookie(s) were already in your browser when the scan started, so they could not be attributed to any page and were not imported.')
+		msg.textContent = fazI18n('cookies.jarOnlyHint', '%d cookie(s) were already in your browser when the scan started, so they could not be attributed to any page and were not imported.')
 			.replace('%d', function () { return String(names.length); });
 		bar.appendChild(msg);
 
 		var details = document.createElement('details');
 		details.className = 'faz-jar-details';
 		var summary = document.createElement('summary');
-		summary.textContent = __('cookies.jarOnlyToggle', 'Show the names');
+		summary.textContent = fazI18n('cookies.jarOnlyToggle', 'Show the names');
 		details.appendChild(summary);
 
 		var explain = document.createElement('p');
-		explain.textContent = __('cookies.jarOnlyExplain', 'If you recognise one as a cookie your site really sets, add it manually with Add Cookie.');
+		explain.textContent = fazI18n('cookies.jarOnlyExplain', 'If you recognise one as a cookie your site really sets, add it manually with Add Cookie.');
 		details.appendChild(explain);
 
 		var list = document.createElement('ul');
@@ -695,7 +698,7 @@
 			bar.style.display = '';
 
 			var title = document.createElement('strong');
-			title.textContent = __('cookies.visitorCheckTitle', 'Server-side visitor check (headers only) — scan #%s:')
+			title.textContent = fazI18n('cookies.visitorCheckTitle', 'Server-side visitor check (headers only) — scan #%s:')
 				.replace('%s', function () { return String(check.scan_id || ''); });
 			bar.appendChild(title);
 
@@ -705,7 +708,7 @@
 				var li = document.createElement('li');
 				// textContent, never innerHTML: cookie names are content a
 				// scanned page (or a third party it embeds) controls.
-				li.textContent = __(key, fallback)
+				li.textContent = fazI18n(key, fallback)
 					.replace('%1$d', function () { return String(names.length); })
 					.replace('%2$s', function () { return names.join(', '); });
 				list.appendChild(li);
@@ -717,13 +720,13 @@
 				bar.appendChild(list);
 			} else {
 				var none = document.createElement('p');
-				none.textContent = __('cookies.visitorCheckNoDiff', 'The anonymous check found no cookie differences against the browser scan.');
+				none.textContent = fazI18n('cookies.visitorCheckNoDiff', 'The anonymous check found no cookie differences against the browser scan.');
 				bar.appendChild(none);
 			}
 
 			var disclaimer = document.createElement('p');
 			disclaimer.className = 'faz-help';
-			disclaimer.textContent = __('cookies.visitorCheckDisclaimer', 'This check re-fetches the scanned pages without a login and compares Set-Cookie headers only. It cannot see cookies that JavaScript sets for anonymous visitors, nor cookies set only after an interaction (for example an add-to-cart request), so a clean result does not mean the visitor view is fully verified.');
+			disclaimer.textContent = fazI18n('cookies.visitorCheckDisclaimer', 'This check re-fetches the scanned pages without a login and compares Set-Cookie headers only. It cannot see cookies that JavaScript sets for anonymous visitors, nor cookies set only after an interaction (for example an add-to-cart request), so a clean result does not mean the visitor view is fully verified.');
 			bar.appendChild(disclaimer);
 		}).catch(function () {
 			bar.style.display = 'none';
@@ -768,17 +771,17 @@
 			var msg = document.createElement('span');
 			msg.textContent = age
 				/* translators: 1: number of cookies, 2: human-readable age such as "3 hours". */
-				? __('cookies.restoreDeletedHintAged', '%1$d deleted cookie(s) can still be restored (deleted %2$s ago).')
+				? fazI18n('cookies.restoreDeletedHintAged', '%1$d deleted cookie(s) can still be restored (deleted %2$s ago).')
 					.replace('%1$d', function () { return String(count); })
 					.replace('%2$s', function () { return age; })
-				: __('cookies.restoreDeletedHint', '%d recently deleted cookie(s) can still be restored.')
+				: fazI18n('cookies.restoreDeletedHint', '%d recently deleted cookie(s) can still be restored.')
 					.replace('%d', function () { return String(count); });
 			bar.appendChild(msg);
 
 			var restoreBtn = document.createElement('button');
 			restoreBtn.type = 'button';
 			restoreBtn.className = 'faz-btn faz-btn-sm faz-restore-deleted';
-			restoreBtn.textContent = __('cookies.restoreDeleted', 'Undo delete');
+			restoreBtn.textContent = fazI18n('cookies.restoreDeleted', 'Undo delete');
 			restoreBtn.addEventListener('click', function () {
 				restoreBtn.disabled = true;
 				FAZ.post('cookies/restore-deleted', {}).then(function (res) {
@@ -793,19 +796,19 @@
 					if (0 === restored) {
 						FAZ.notify(
 							skipped > 0
-								? __('cookies.restoreAllPresent', 'Nothing to restore: those cookies are already in the list again.')
-								: __('cookies.restoreNoneRestored', 'No cookies were restored.'),
+								? fazI18n('cookies.restoreAllPresent', 'Nothing to restore: those cookies are already in the list again.')
+								: fazI18n('cookies.restoreNoneRestored', 'No cookies were restored.'),
 							'info'
 						);
 					} else if (skipped > 0) {
 						FAZ.notify(
-							__('cookies.restoreSucceededPartial', '%1$d cookie(s) restored. %2$d were already in the list.')
+							fazI18n('cookies.restoreSucceededPartial', '%1$d cookie(s) restored. %2$d were already in the list.')
 								.replace('%1$d', String(restored))
 								.replace('%2$d', String(skipped)),
 							'success'
 						);
 					} else {
-						FAZ.notify(__('cookies.restoreSucceeded', '%d cookie(s) restored.')
+						FAZ.notify(fazI18n('cookies.restoreSucceeded', '%d cookie(s) restored.')
 							.replace('%d', function () { return String(restored); }), 'success');
 					}
 					loadCookies();
@@ -827,10 +830,10 @@
 					var serverMessage = (err && typeof err.message === 'string' && err.message) ? err.message : '';
 					FAZ.notify(
 						emptied
-							? __('cookies.nothingToRestore', 'There is nothing left to restore.')
+							? fazI18n('cookies.nothingToRestore', 'There is nothing left to restore.')
 							: (needsCap && serverMessage
 								? serverMessage
-								: __('cookies.restoreFailed', 'Could not restore the deleted cookies.')),
+								: fazI18n('cookies.restoreFailed', 'Could not restore the deleted cookies.')),
 						emptied ? 'info' : (needsCap ? 'warning' : 'error')
 					);
 				}).then(function () {
@@ -861,7 +864,7 @@
 		var allBtn = document.createElement('button');
 		allBtn.className = activeCat === 'all' ? 'active' : '';
 		var allName = document.createElement('span');
-		allName.textContent = __('cookies.allCookies', 'All Cookies');
+		allName.textContent = fazI18n('cookies.allCookies', 'All Cookies');
 		allBtn.appendChild(allName);
 		var allCount = document.createElement('span');
 		allCount.className = 'faz-count';
@@ -886,8 +889,8 @@
 			if (cat.visibility !== undefined && !cat.visibility) {
 				var badge = document.createElement('span');
 				badge.className = 'faz-badge faz-badge-muted';
-				badge.textContent = __('cookies.hidden', 'hidden');
-				badge.title = __('cookies.hiddenFromFrontend', 'Hidden from frontend');
+				badge.textContent = fazI18n('cookies.hidden', 'hidden');
+				badge.title = fazI18n('cookies.hiddenFromFrontend', 'Hidden from frontend');
 				badge.style.cssText = 'font-size:10px;margin-left:6px;padding:1px 6px;border-radius:3px;background:#e2e8f0;color:#64748b;vertical-align:middle;';
 				btn.appendChild(badge);
 			}
@@ -926,7 +929,7 @@
 			td.colSpan = 6;
 			td.className = 'faz-empty';
 			var p = document.createElement('p');
-			p.textContent = __('cookies.noCookiesFound', 'No cookies found.');
+			p.textContent = fazI18n('cookies.noCookiesFound', 'No cookies found.');
 			td.appendChild(p);
 			tr.appendChild(td);
 			tbody.appendChild(tr);
@@ -962,8 +965,8 @@
 			if (cookie.transfer && cookie.transfer.enabled) {
 				var transferBadge = document.createElement('span');
 				transferBadge.className = 'faz-cookie-transfer-badge';
-				transferBadge.textContent = __('cookies.transferBadge', '3rd country');
-				transferBadge.title = __('cookies.transferBadgeTitle', 'Transfers personal data to a third country (Schrems II)');
+				transferBadge.textContent = fazI18n('cookies.transferBadge', '3rd country');
+				transferBadge.title = fazI18n('cookies.transferBadgeTitle', 'Transfers personal data to a third country (Schrems II)');
 				tdName.appendChild(transferBadge);
 			}
 			tr.appendChild(tdName);
@@ -990,7 +993,7 @@
 
 			var editBtn = document.createElement('button');
 			editBtn.className = 'faz-btn faz-btn-outline faz-btn-sm';
-			editBtn.textContent = __('cookies.edit', 'Edit');
+			editBtn.textContent = fazI18n('cookies.edit', 'Edit');
 			editBtn.addEventListener('click', function () {
 				var cookieId = getCookieId(cookie);
 				if (!cookieId) {
@@ -1002,7 +1005,7 @@
 				FAZ.get('cookies/' + cookieId, { context: 'edit' }).then(function (fullCookie) {
 					openCookieModal(fullCookie || cookie);
 				}).catch(function () {
-					FAZ.notify(__('cookies.cookieLoadFailed', 'Failed to load cookie details.'), 'error');
+					FAZ.notify(fazI18n('cookies.cookieLoadFailed', 'Failed to load cookie details.'), 'error');
 				}).then(function () {
 					editBtn.disabled = false;
 				});
@@ -1011,7 +1014,7 @@
 
 			var delBtn = document.createElement('button');
 			delBtn.className = 'faz-btn faz-btn-outline faz-btn-sm';
-			delBtn.textContent = __('cookies.delete', 'Delete');
+			delBtn.textContent = fazI18n('cookies.delete', 'Delete');
 			delBtn.style.color = 'var(--faz-danger)';
 			delBtn.addEventListener('click', function () { deleteCookie(cookie); });
 			tdActions.appendChild(delBtn);
@@ -1019,7 +1022,7 @@
 			if (isStale) {
 				var staleBtn = document.createElement('button');
 				staleBtn.className = 'faz-btn faz-btn-sm';
-				staleBtn.textContent = __('cookies.deleteStale', 'Delete stale');
+				staleBtn.textContent = fazI18n('cookies.deleteStale', 'Delete stale');
 				staleBtn.style.background = '#fee2e2';
 				staleBtn.style.color = '#991b1b';
 				staleBtn.style.border = '1px solid #fecaca';
@@ -1059,10 +1062,10 @@
 		var canEditScripts = !!(window.fazConfig && window.fazConfig.canEditScripts);
 
 		var fields = [
-			{ label: __('cookies.nameLabel', 'Cookie Name'), path: 'name', type: 'text' },
-			{ label: __('cookies.domainLabel', 'Domain'), path: 'domain', type: 'text' },
-			{ label: __('cookies.durationLabel', 'Duration'), path: 'duration', type: 'text', placeholder: __('cookies.durationPlaceholder', 'e.g. 1 year') },
-			{ label: __('cookies.descriptionLabel', 'Description'), path: 'description', type: 'textarea' },
+			{ label: fazI18n('cookies.nameLabel', 'Cookie Name'), path: 'name', type: 'text' },
+			{ label: fazI18n('cookies.domainLabel', 'Domain'), path: 'domain', type: 'text' },
+			{ label: fazI18n('cookies.durationLabel', 'Duration'), path: 'duration', type: 'text', placeholder: fazI18n('cookies.durationPlaceholder', 'e.g. 1 year') },
+			{ label: fazI18n('cookies.descriptionLabel', 'Description'), path: 'description', type: 'textarea' },
 		];
 
 		// Only expose opt-in/opt-out script fields to users with the
@@ -1070,8 +1073,8 @@
 		// always POST these fields (even empty), tripping the REST sanitize
 		// callback's 403 for multisite site-admins who lack the capability.
 		if (canEditScripts) {
-			fields.push({ label: __('cookies.optInScriptLabel', 'Opt-in Script (runs when category is accepted)'), path: 'opt_in_script', type: 'textarea', placeholder: __('cookies.optInScriptPlaceholder', '// JS executed on consent accept\n// e.g. gtag("event", "consent_granted");') });
-			fields.push({ label: __('cookies.optOutScriptLabel', 'Opt-out Script (runs when category is rejected/revoked)'), path: 'opt_out_script', type: 'textarea', placeholder: __('cookies.optOutScriptPlaceholder', '// JS executed on consent reject or revoke') });
+			fields.push({ label: fazI18n('cookies.optInScriptLabel', 'Opt-in Script (runs when category is accepted)'), path: 'opt_in_script', type: 'textarea', placeholder: fazI18n('cookies.optInScriptPlaceholder', '// JS executed on consent accept\n// e.g. gtag("event", "consent_granted");') });
+			fields.push({ label: fazI18n('cookies.optOutScriptLabel', 'Opt-out Script (runs when category is rejected/revoked)'), path: 'opt_out_script', type: 'textarea', placeholder: fazI18n('cookies.optOutScriptPlaceholder', '// JS executed on consent reject or revoke') });
 		}
 
 		fields.forEach(function (f) {
@@ -1106,7 +1109,7 @@
 				// text some breathing room without breaking the compact form
 				// layout.
 				scriptNotice.style.cssText = 'font-size:12px;color:#767676;margin:4px 0 0;';
-				scriptNotice.textContent = __('cookies.scriptNotice', 'Note: code entered here is included in the page source and visible to all visitors.');
+				scriptNotice.textContent = fazI18n('cookies.scriptNotice', 'Note: code entered here is included in the page source and visible to all visitors.');
 				group.appendChild(scriptNotice);
 			}
 			form.appendChild(group);
@@ -1121,7 +1124,7 @@
 		transferGroup.className = 'faz-form-group faz-transfer-fieldset';
 
 		var transferTitle = document.createElement('label');
-		transferTitle.textContent = __('cookies.transferTitle', 'International data transfers (Schrems II)');
+		transferTitle.textContent = fazI18n('cookies.transferTitle', 'International data transfers (Schrems II)');
 		transferGroup.appendChild(transferTitle);
 
 		var transferEnabledLabel = document.createElement('label');
@@ -1131,34 +1134,34 @@
 		transferEnabled.className = 'faz-transfer-enabled';
 		transferEnabled.checked = !!existingTransfer.enabled;
 		transferEnabledLabel.appendChild(transferEnabled);
-		transferEnabledLabel.appendChild(document.createTextNode(__('cookies.transferEnabledLabel', 'This cookie may transfer personal data to a country without an EU adequacy decision')));
+		transferEnabledLabel.appendChild(document.createTextNode(fazI18n('cookies.transferEnabledLabel', 'This cookie may transfer personal data to a country without an EU adequacy decision')));
 		transferGroup.appendChild(transferEnabledLabel);
 
 		var countryLabel = document.createElement('label');
 		countryLabel.style.cssText = 'font-weight:400;font-size:12px;';
-		countryLabel.textContent = __('cookies.transferCountryLabel', 'Recipient country / countries');
+		countryLabel.textContent = fazI18n('cookies.transferCountryLabel', 'Recipient country / countries');
 		transferGroup.appendChild(countryLabel);
 		var countryInput = document.createElement('input');
 		countryInput.type = 'text';
 		countryInput.className = 'faz-input faz-transfer-country';
-		countryInput.placeholder = __('cookies.transferCountryPlaceholder', 'e.g. United States');
+		countryInput.placeholder = fazI18n('cookies.transferCountryPlaceholder', 'e.g. United States');
 		countryInput.value = textVal(existingTransfer.countries) || '';
 		transferGroup.appendChild(countryInput);
 
 		var safeguardLabel = document.createElement('label');
 		safeguardLabel.style.cssText = 'font-weight:400;font-size:12px;margin-top:8px;';
-		safeguardLabel.textContent = __('cookies.transferSafeguardLabel', 'Safeguard (optional)');
+		safeguardLabel.textContent = fazI18n('cookies.transferSafeguardLabel', 'Safeguard (optional)');
 		transferGroup.appendChild(safeguardLabel);
 		var safeguardInput = document.createElement('textarea');
 		safeguardInput.className = 'faz-textarea faz-transfer-safeguard';
 		safeguardInput.rows = 2;
-		safeguardInput.placeholder = __('cookies.transferSafeguardPlaceholder', 'e.g. Standard Contractual Clauses, EU-US Data Privacy Framework, or explicit consent (Art. 49(1)(a))');
+		safeguardInput.placeholder = fazI18n('cookies.transferSafeguardPlaceholder', 'e.g. Standard Contractual Clauses, EU-US Data Privacy Framework, or explicit consent (Art. 49(1)(a))');
 		safeguardInput.value = textVal(existingTransfer.safeguard) || '';
 		transferGroup.appendChild(safeguardInput);
 
 		var transferHelp = document.createElement('p');
 		transferHelp.style.cssText = 'font-size:12px;color:#767676;margin:4px 0 0;';
-		transferHelp.textContent = __('cookies.transferHelp', 'Naming a third-country transfer helps you obtain informed consent. This plugin does not provide legal advice — describe the safeguard your provider relies on.');
+		transferHelp.textContent = fazI18n('cookies.transferHelp', 'Naming a third-country transfer helps you obtain informed consent. This plugin does not provide legal advice — describe the safeguard your provider relies on.');
 		transferGroup.appendChild(transferHelp);
 
 		form.appendChild(transferGroup);
@@ -1190,7 +1193,7 @@
 		var catGroup = document.createElement('div');
 		catGroup.className = 'faz-form-group';
 		var catLabel = document.createElement('label');
-		catLabel.textContent = __('cookies.category', 'Category');
+		catLabel.textContent = fazI18n('cookies.category', 'Category');
 		catGroup.appendChild(catLabel);
 		var catSelect = document.createElement('select');
 		catSelect.className = 'faz-select';
@@ -1209,7 +1212,7 @@
 		footer.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;width:100%';
 		var cancelBtn = document.createElement('button');
 		cancelBtn.className = 'faz-btn faz-btn-outline';
-		cancelBtn.textContent = __('cookies.cancel', 'Cancel');
+		cancelBtn.textContent = fazI18n('cookies.cancel', 'Cancel');
 		cancelBtn.type = 'button';
 		var saveBtn = document.createElement('button');
 		saveBtn.className = 'faz-btn faz-btn-primary';
@@ -1278,25 +1281,25 @@
 
 			promise.then(function () {
 				m.close();
-				FAZ.notify(isEdit ? __('cookies.cookieUpdated', 'Cookie updated.') : __('cookies.cookieAdded', 'Cookie added.'));
+				FAZ.notify(isEdit ? fazI18n('cookies.cookieUpdated', 'Cookie updated.') : fazI18n('cookies.cookieAdded', 'Cookie added.'));
 				loadCookies();
 				loadCategories();
 			}).catch(function () {
 				FAZ.btnLoading(saveBtn, false);
-				FAZ.notify(__('cookies.cookieSaveFailed', 'Failed to save cookie.'), 'error');
+				FAZ.notify(fazI18n('cookies.cookieSaveFailed', 'Failed to save cookie.'), 'error');
 			});
 		});
 	}
 
 	function deleteCookie(cookie) {
-		FAZ.confirm(__('cookies.cookieDeleteConfirm', 'Delete cookie "%s"?').replace('%s', cookie.name || '')).then(function (ok) {
+		FAZ.confirm(fazI18n('cookies.cookieDeleteConfirm', 'Delete cookie "%s"?').replace('%s', cookie.name || '')).then(function (ok) {
 			if (!ok) return;
 			FAZ.del('cookies/' + getCookieId(cookie)).then(function () {
-				FAZ.notify(__('cookies.cookieDeleted', 'Cookie deleted.'));
+				FAZ.notify(fazI18n('cookies.cookieDeleted', 'Cookie deleted.'));
 				loadCookies();
 				loadCategories();
 			}).catch(function () {
-				FAZ.notify(__('cookies.cookieDeleteFailed', 'Failed to delete cookie.'), 'error');
+				FAZ.notify(fazI18n('cookies.cookieDeleteFailed', 'Failed to delete cookie.'), 'error');
 			});
 		});
 	}
@@ -1308,17 +1311,17 @@
 				delete staleCookieNames[staleKey];
 				staleCookieCount = Math.max(0, staleCookieCount - 1);
 			}
-			FAZ.notify(__('cookies.staleDeleted', 'Stale cookie deleted.'));
+			FAZ.notify(fazI18n('cookies.staleDeleted', 'Stale cookie deleted.'));
 			loadCookies();
 			loadCategories();
 		}).catch(function () {
-			FAZ.notify(__('cookies.staleDeleteFailed', 'Failed to delete stale cookie.'), 'error');
+			FAZ.notify(fazI18n('cookies.staleDeleteFailed', 'Failed to delete stale cookie.'), 'error');
 		});
 	}
 
 	function deleteAllStaleCookies() {
 		if (!staleCookieCount) return;
-		FAZ.confirm(__('cookies.staleAllConfirm', 'Remove these cookie-policy entries? Cookies that load only after an interaction, during a flow, or as httpOnly cookies may still be present even if the scan did not observe them.')).then(function (ok) {
+		FAZ.confirm(fazI18n('cookies.staleAllConfirm', 'Remove these cookie-policy entries? Cookies that load only after an interaction, during a flow, or as httpOnly cookies may still be present even if the scan did not observe them.')).then(function (ok) {
 			if (!ok) return;
 			FAZ.get('cookies').then(function (data) {
 				var list = Array.isArray(data) ? data : (data.items || []);
@@ -1331,7 +1334,7 @@
 					}
 				});
 				if (!ids.length) {
-					FAZ.notify(__('cookies.staleNone', 'No stale cookies to delete.'));
+					FAZ.notify(fazI18n('cookies.staleNone', 'No stale cookies to delete.'));
 					return;
 				}
 				// `reason: 'stale'` opts this call into the server-side threshold
@@ -1343,9 +1346,9 @@
 					var refusedCount = (res && typeof res.refused === 'number') ? res.refused : 0;
 					staleCookieNames = {};
 					staleCookieCount = 0;
-					var message = deletedCount + ' ' + __('cookies.staleDeleted', 'stale cookie(s) deleted.');
+					var message = deletedCount + ' ' + fazI18n('cookies.staleDeleted', 'stale cookie(s) deleted.');
 					if (refusedCount > 0) {
-						message += ' ' + __('cookies.staleRefusedNotEarned', '%d entry(ies) were kept: they have not yet been missing from enough complete scans.')
+						message += ' ' + fazI18n('cookies.staleRefusedNotEarned', '%d entry(ies) were kept: they have not yet been missing from enough complete scans.')
 							.replace('%d', function () { return String(refusedCount); });
 					}
 					FAZ.notify(message);
@@ -1356,13 +1359,13 @@
 					var snapshotFailed = !!(err && err.code === 'faz_recycle_bin_write_failed');
 					FAZ.notify(
 						snapshotFailed
-							? __('cookies.bulkDeleteSnapshotFailed', 'Nothing was deleted: the undo snapshot could not be saved, so the cookies were left in place.')
-							: __('cookies.staleDeleteAllFailed', 'Failed to delete stale cookies.'),
+							? fazI18n('cookies.bulkDeleteSnapshotFailed', 'Nothing was deleted: the undo snapshot could not be saved, so the cookies were left in place.')
+							: fazI18n('cookies.staleDeleteAllFailed', 'Failed to delete stale cookies.'),
 						'error'
 					);
 				});
 			}).catch(function () {
-				FAZ.notify(__('cookies.staleLoadFailed', 'Failed to load cookies for stale cleanup.'), 'error');
+				FAZ.notify(fazI18n('cookies.staleLoadFailed', 'Failed to load cookies for stale cleanup.'), 'error');
 			});
 		});
 	}
@@ -1487,7 +1490,7 @@
 		endBtn.type = 'button';
 		endBtn.id = 'faz-scan-session-end';
 		endBtn.className = 'faz-btn faz-btn-sm faz-btn-danger';
-		endBtn.textContent = __('cookies.endActiveScan', 'End this scan and discard its capture');
+		endBtn.textContent = fazI18n('cookies.endActiveScan', 'End this scan and discard its capture');
 		actions.appendChild(endBtn);
 		box.appendChild(notice);
 		box.appendChild(detail);
@@ -1502,10 +1505,10 @@
 				// aborted:false means the session lapsed on its own between the
 				// last poll and the click — either way it no longer exists.
 				removeActiveSessionPanel();
-				FAZ.notify(__('cookies.activeScanEnded', 'Scan session ended — its capture was discarded. You can start a new scan.'), 'success');
+				FAZ.notify(fazI18n('cookies.activeScanEnded', 'Scan session ended — its capture was discarded. You can start a new scan.'), 'success');
 			}, function (err) {
 				endBtn.disabled = false;
-				FAZ.notify((err && err.message) || __('cookies.scanFailed', 'Scan failed.'), 'error');
+				FAZ.notify((err && err.message) || fazI18n('cookies.scanFailed', 'Scan failed.'), 'error');
 			});
 		});
 
@@ -1545,14 +1548,14 @@
 		var isLive = idleFor >= 0 && idleFor <= SESSION_STALL_AFTER_S;
 
 		activeSessionPanel.wrap.classList.toggle('faz-scan-progress-held', !isLive);
-		els.statusEl.textContent = isLive ? __('cookies.scanStarted', 'Scanning...') : '';
-		els.notice.textContent = __('cookies.activeScanNotice', 'A cookie scan session for your account is already open on the server (started at %s). A new scan cannot start until it ends.')
+		els.statusEl.textContent = isLive ? fazI18n('cookies.scanStarted', 'Scanning...') : '';
+		els.notice.textContent = fazI18n('cookies.activeScanNotice', 'A cookie scan session for your account is already open on the server (started at %s). A new scan cannot start until it ends.')
 			.replace('%s', function () { return formatClockTime(info.started_at); });
 		els.detail.textContent = isLive
-			? __('cookies.activeScanLive', 'It is capturing right now — %1$d observation(s) so far, the last at %2$s. If one of your other tabs is running a scan, let it finish. Ending the session discards everything it has captured.')
+			? fazI18n('cookies.activeScanLive', 'It is capturing right now — %1$d observation(s) so far, the last at %2$s. If one of your other tabs is running a scan, let it finish. Ending the session discards everything it has captured.')
 				.replace('%1$d', function () { return String(info.observations || 0); })
 				.replace('%2$s', function () { return formatClockTime(info.last_activity); })
-			: __('cookies.activeScanStalled', 'Nothing has reached the server since %s. If none of your tabs is running a scan, the tab that was driving this one is gone. The session will expire on its own in a few minutes, or you can end it now — ending it discards everything it captured.')
+			: fazI18n('cookies.activeScanStalled', 'Nothing has reached the server since %s. If none of your tabs is running a scan, the tab that was driving this one is gone. The session will expire on its own in a few minutes, or you can end it now — ending it discards everything it captured.')
 				.replace('%s', function () { return formatClockTime(info.last_activity); });
 
 		if (!activeSessionPanel.timer) {
@@ -1567,7 +1570,7 @@
 		var btn = document.getElementById('faz-scan-btn');
 		var dropdown = document.getElementById('faz-scan-dropdown');
 		FAZ.btnLoading(btn, true);
-		btn.textContent = __('cookies.scanStarted', 'Scanning...');
+		btn.textContent = fazI18n('cookies.scanStarted', 'Scanning...');
 
 		// The session panel's poll timer must stop before its wrapper goes: the
 		// sweep below removes the DOM but would leave the interval re-creating
@@ -1593,7 +1596,7 @@
 		bar.className = 'faz-scan-bar';
 		var statusEl = document.createElement('span');
 		statusEl.className = 'faz-scan-status';
-		statusEl.textContent = __('cookies.discoveringPages', 'Discovering pages...');
+		statusEl.textContent = fazI18n('cookies.discoveringPages', 'Discovering pages...');
 		var pagesEl = document.createElement('div');
 		pagesEl.className = 'faz-scan-pages';
 		pagesEl.textContent = '0/0 pages';
@@ -1605,7 +1608,7 @@
 		var stopBtn = document.createElement('button');
 		stopBtn.type = 'button';
 		stopBtn.className = 'faz-btn faz-btn-sm faz-scan-stop';
-		stopBtn.textContent = __('cookies.stopScan', 'Stop scan');
+		stopBtn.textContent = fazI18n('cookies.stopScan', 'Stop scan');
 		progress.appendChild(bar);
 		progress.appendChild(statusEl);
 		progressWrap.appendChild(progress);
@@ -1660,7 +1663,7 @@
 					setStaleCookies(previousDiscoveredSet, currentDetectedSet, getEarnedDeletableSet(res));
 				}
 
-				// Every fragment of this summary goes through __(): a half-translated
+				// Every fragment of this summary goes through fazI18n(): a half-translated
 				// sentence is worse than an untranslated one, and the two clauses
 				// below were already localized. Replacements use callbacks so a
 				// value containing "$&" cannot be read as a replacement pattern.
@@ -1672,26 +1675,26 @@
 				// below are described as what is already on record.
 				var duplicate = !!(res.importResult && res.importResult.duplicate);
 				var msg = duplicate
-					? __('cookies.scanAlreadySaved', 'Already saved — %1$d cookies on %2$d pages were imported by an earlier attempt. Nothing was saved twice.')
+					? fazI18n('cookies.scanAlreadySaved', 'Already saved — %1$d cookies on %2$d pages were imported by an earlier attempt. Nothing was saved twice.')
 						.replace('%1$d', function () { return String(res.total); })
 						.replace('%2$d', function () { return String(res.pagesScanned); })
-					: __('cookies.scanComplete', 'Scan complete — %1$d cookies found on %2$d pages')
+					: fazI18n('cookies.scanComplete', 'Scan complete — %1$d cookies found on %2$d pages')
 						.replace('%1$d', function () { return String(res.total); })
 						.replace('%2$d', function () { return String(res.pagesScanned); });
 				if (res.stoppedReason) {
-					msg += ' ' + __('cookies.scanStopped', '(stopped by you before every page was visited)');
+					msg += ' ' + fazI18n('cookies.scanStopped', '(stopped by you before every page was visited)');
 				} else if (res.earlyStopReason) {
-					msg += ' ' + __('cookies.scanEarlyStop', '(early stop: %s)')
+					msg += ' ' + fazI18n('cookies.scanEarlyStop', '(early stop: %s)')
 						.replace('%s', function () { return String(res.earlyStopReason); });
 				}
 				if (!coverageIsComplete) {
-					msg += ' | ' + __('cookies.scanCoverageIncomplete', 'Scan coverage was incomplete, so no cookie was marked as stale.');
+					msg += ' | ' + fazI18n('cookies.scanCoverageIncomplete', 'Scan coverage was incomplete, so no cookie was marked as stale.');
 				} else if (staleCookieCount > 0) {
-					msg += ' | ' + __('cookies.staleHighlighted', '%d stale cookie(s) highlighted')
+					msg += ' | ' + fazI18n('cookies.staleHighlighted', '%d stale cookie(s) highlighted')
 						.replace('%d', function () { return String(staleCookieCount); });
 				}
 				if (res.importResult && res.importResult.enrichment_pending) {
-					msg += ' | ' + __('cookies.enrichmentPending', 'The browser scan was saved. Server-header enrichment is still running in the background, so a few more cookies may appear shortly.');
+					msg += ' | ' + fazI18n('cookies.enrichmentPending', 'The browser scan was saved. Server-header enrichment is still running in the background, so a few more cookies may appear shortly.');
 				}
 				msg += FAZ.scanEngine.diagnosticsHint(res.diagnostics, res.total);
 				if (res.diagnostics && res.diagnostics.totalIssues > 0) {
@@ -1702,7 +1705,7 @@
 			}
 
 			function terminalFailure(err) {
-				finishScan(btn, progressWrap, (err && err.message) || __('cookies.scanFailed', 'Scan failed.'), true);
+				finishScan(btn, progressWrap, (err && err.message) || fazI18n('cookies.scanFailed', 'Scan failed.'), true);
 			}
 
 			// The import stage is the only failure the administrator can still
@@ -1739,11 +1742,11 @@
 			 */
 			function offerImportRetry(err) {
 				FAZ.btnLoading(btn, false);
-				btn.textContent = __('cookies.scanSite', 'Scan Site') + ' ▾';
+				btn.textContent = fazI18n('cookies.scanSite', 'Scan Site') + ' ▾';
 				if (stopBtn.parentNode) { stopBtn.parentNode.removeChild(stopBtn); }
 				bar.style.width = '100%';
 				progressWrap.classList.add('faz-scan-progress-held');
-				statusEl.textContent = __('cookies.importNotSaved', 'Not saved');
+				statusEl.textContent = fazI18n('cookies.importNotSaved', 'Not saved');
 				pagesEl.textContent = '';
 
 				// The engine hands back a resubmit of the payload it already
@@ -1762,8 +1765,8 @@
 				var explain = document.createElement('p');
 				explain.className = 'faz-scan-held-text';
 				explain.textContent = savesOnly
-					? __('cookies.importHeldRetrySave', 'The scan finished but the results could not be saved. Nothing is lost — they are held on the server for a few minutes. Retrying saves them; it does not scan the site again.')
-					: __('cookies.importHeldRerun', 'The scan finished but the results could not be saved. The capture session is held on the server for a few minutes, so retrying reuses it instead of failing — but this browser has to walk the pages again.');
+					? fazI18n('cookies.importHeldRetrySave', 'The scan finished but the results could not be saved. Nothing is lost — they are held on the server for a few minutes. Retrying saves them; it does not scan the site again.')
+					: fazI18n('cookies.importHeldRerun', 'The scan finished but the results could not be saved. The capture session is held on the server for a few minutes, so retrying reuses it instead of failing — but this browser has to walk the pages again.');
 				panel.appendChild(explain);
 
 				if (err && err.message) {
@@ -1779,12 +1782,12 @@
 				retryBtn.type = 'button';
 				retryBtn.className = 'faz-btn faz-btn-sm faz-btn-primary';
 				retryBtn.textContent = savesOnly
-					? __('cookies.retryImport', 'Retry import')
-					: __('cookies.retryImportRescan', 'Retry import (re-scans the site)');
+					? fazI18n('cookies.retryImport', 'Retry import')
+					: fazI18n('cookies.retryImportRescan', 'Retry import (re-scans the site)');
 				var dismissBtn = document.createElement('button');
 				dismissBtn.type = 'button';
 				dismissBtn.className = 'faz-btn faz-btn-sm';
-				dismissBtn.textContent = __('cookies.discardHeldScan', 'Discard');
+				dismissBtn.textContent = fazI18n('cookies.discardHeldScan', 'Discard');
 				actions.appendChild(retryBtn);
 				actions.appendChild(dismissBtn);
 				panel.appendChild(actions);
@@ -1799,8 +1802,8 @@
 					retryBtn.disabled = true;
 					dismissBtn.disabled = true;
 					FAZ.btnLoading(btn, true);
-					btn.textContent = __('cookies.scanStarted', 'Scanning...');
-					statusEl.textContent = __('cookies.savingResults', 'Saving results...');
+					btn.textContent = fazI18n('cookies.scanStarted', 'Scanning...');
+					statusEl.textContent = fazI18n('cookies.savingResults', 'Saving results...');
 					var attempt = savesOnly
 						? err.retryImport()
 						// Same scan id, so the held session is re-entered rather
@@ -1830,19 +1833,19 @@
 			stopBtn.addEventListener('click', function () {
 				if (typeof run.cancel !== 'function') { return; }
 				stopBtn.disabled = true;
-				stopBtn.textContent = __('cookies.stoppingScan', 'Stopping…');
+				stopBtn.textContent = fazI18n('cookies.stoppingScan', 'Stopping…');
 				run.cancel();
 			});
 			return run.then(handleScanSuccess, handleScanFailure);
 		}).catch(function (err) {
 			console.error('[FAZ Scanner] Scan failed:', err);
-			finishScan(btn, progressWrap, (err && err.message) || __('cookies.scanFailed', 'Scan failed.'), true);
+			finishScan(btn, progressWrap, (err && err.message) || fazI18n('cookies.scanFailed', 'Scan failed.'), true);
 		});
 	}
 
 	function finishScan(btn, progress, message, isError) {
 		FAZ.btnLoading(btn, false);
-		btn.textContent = __('cookies.scanSite', 'Scan Site') + ' ▾';
+		btn.textContent = fazI18n('cookies.scanSite', 'Scan Site') + ' ▾';
 		if (progress.parentNode) { progress.parentNode.removeChild(progress); }
 		FAZ.notify(message, isError ? 'error' : 'success');
 	}
@@ -1872,7 +1875,7 @@
 
 			if (!targetCookies.length) {
 				FAZ.btnLoading(btn, false);
-				FAZ.notify(scopeAll ? __('cookies.noCookiesToProcess', 'No cookies to process.') : __('cookies.noUncategorized', 'No uncategorized cookies to process.'));
+				FAZ.notify(scopeAll ? fazI18n('cookies.noCookiesToProcess', 'No cookies to process.') : fazI18n('cookies.noUncategorized', 'No uncategorized cookies to process.'));
 				return;
 			}
 
@@ -1913,7 +1916,7 @@
 
 				if (!updateQueue.length) {
 					FAZ.btnLoading(btn, false);
-					FAZ.notify(__('cookies.noneAutoCategorized', 'No cookies could be auto-categorized.'));
+					FAZ.notify(fazI18n('cookies.noneAutoCategorized', 'No cookies could be auto-categorized.'));
 					return;
 				}
 
@@ -1945,7 +1948,7 @@
 			});
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('cookies.autoCatFailed', 'Auto-categorize failed.'), 'error');
+			FAZ.notify(fazI18n('cookies.autoCatFailed', 'Auto-categorize failed.'), 'error');
 		});
 	}
 
@@ -1955,7 +1958,7 @@
 		if (!el) return;
 		FAZ.get('cookies/definitions').then(function (meta) {
 			if (!meta || !meta.has_definitions) {
-				el.textContent = __('cookies.noDefinitions', 'No definitions downloaded yet. Click "Update Definitions" to download.');
+				el.textContent = fazI18n('cookies.noDefinitions', 'No definitions downloaded yet. Click "Update Definitions" to download.');
 				return;
 			}
 			var count = meta.count || 0;
@@ -1966,7 +1969,7 @@
 			}
 			el.textContent = count + ' cookie definitions loaded' + (updated ? ' - last updated: ' + updated : '');
 		}).catch(function () {
-			el.textContent = __('cookies.definitionsLoadFailed', 'Could not load definitions status.');
+			el.textContent = fazI18n('cookies.definitionsLoadFailed', 'Could not load definitions status.');
 		});
 	}
 
@@ -1974,21 +1977,21 @@
 		var btn = document.getElementById('faz-update-defs-btn');
 		var el = document.getElementById('faz-defs-status');
 		FAZ.btnLoading(btn, true);
-		if (el) el.textContent = __('cookies.downloadingDefinitions', 'Downloading definitions from GitHub...');
+		if (el) el.textContent = fazI18n('cookies.downloadingDefinitions', 'Downloading definitions from GitHub...');
 
 		FAZ.post('cookies/definitions/update').then(function (result) {
 			FAZ.btnLoading(btn, false);
 			if (result && result.success) {
-				FAZ.notify(result.message || __('cookies.definitionsUpdated', 'Definitions updated.'));
+				FAZ.notify(result.message || fazI18n('cookies.definitionsUpdated', 'Definitions updated.'));
 				loadDefinitionsStatus();
 			} else {
-				FAZ.notify(result.message || __('cookies.definitionsFailed', 'Update failed.'), 'error');
-				if (el) el.textContent = __('cookies.definitionsFailed', 'Update failed.') + ': ' + (result.message || 'unknown error');
+				FAZ.notify(result.message || fazI18n('cookies.definitionsFailed', 'Update failed.'), 'error');
+				if (el) el.textContent = fazI18n('cookies.definitionsFailed', 'Update failed.') + ': ' + (result.message || 'unknown error');
 			}
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('cookies.definitionsFailed', 'Update failed.'), 'error');
-			if (el) el.textContent = __('cookies.definitionsNetworkFailed', 'Update failed. Check your network connection.');
+			FAZ.notify(fazI18n('cookies.definitionsFailed', 'Update failed.'), 'error');
+			if (el) el.textContent = fazI18n('cookies.definitionsNetworkFailed', 'Update failed. Check your network connection.');
 		});
 	}
 
@@ -2030,7 +2033,7 @@
 		var input = document.createElement('input');
 		input.type = 'text';
 		input.className = 'faz-input';
-		input.placeholder = __('cookies.rulePlaceholder', 'e.g. custom-tracker.com/script.js');
+		input.placeholder = fazI18n('cookies.rulePlaceholder', 'e.g. custom-tracker.com/script.js');
 		input.value = pattern;
 		input.setAttribute('data-rule', 'pattern');
 		input.style.width = '100%';
@@ -2043,7 +2046,7 @@
 		select.style.width = '100%';
 		var emptyOpt = document.createElement('option');
 		emptyOpt.value = '';
-		emptyOpt.textContent = __('cookies.select', '— Select —');
+		emptyOpt.textContent = fazI18n('cookies.select', '— Select —');
 		select.appendChild(emptyOpt);
 		ruleCategories.forEach(function (cat) {
 			var opt = document.createElement('option');
@@ -2059,7 +2062,7 @@
 		var removeBtn = document.createElement('button');
 		removeBtn.type = 'button';
 		removeBtn.className = 'faz-btn faz-btn-danger faz-btn-sm';
-		removeBtn.textContent = __('cookies.remove', 'Remove');
+		removeBtn.textContent = fazI18n('cookies.remove', 'Remove');
 		removeBtn.addEventListener('click', function () { tr.remove(); });
 		tdActions.appendChild(removeBtn);
 
@@ -2093,7 +2096,7 @@
 		var btn = document.getElementById('faz-save-rules-btn');
 		var collected = collectCustomRules();
 		if (collected.invalid > 0) {
-			FAZ.notify(collected.invalid + ' ' + __('cookies.rulesIncomplete', 'rule(s) incomplete — fill in both pattern and category.'), 'error');
+			FAZ.notify(collected.invalid + ' ' + fazI18n('cookies.rulesIncomplete', 'rule(s) incomplete — fill in both pattern and category.'), 'error');
 			return;
 		}
 		FAZ.btnLoading(btn, true);
@@ -2103,10 +2106,10 @@
 			return FAZ.post('settings', current);
 		}).then(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('cookies.rulesSaved', 'Custom rules saved.'));
+			FAZ.notify(fazI18n('cookies.rulesSaved', 'Custom rules saved.'));
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('cookies.rulesSaveFailed', 'Failed to save custom rules.'), 'error');
+			FAZ.notify(fazI18n('cookies.rulesSaveFailed', 'Failed to save custom rules.'), 'error');
 		});
 	}
 
@@ -2123,7 +2126,7 @@
 			if (!templates || !templates.length) {
 				var emptyMsg = document.createElement('p');
 				emptyMsg.style.color = 'var(--faz-text-muted)';
-				emptyMsg.textContent = __('cookies.noTemplates', 'No templates available.');
+				emptyMsg.textContent = fazI18n('cookies.noTemplates', 'No templates available.');
 				container.appendChild(emptyMsg);
 				return;
 			}
@@ -2189,7 +2192,7 @@
 							link.className = 'faz-template-card-inert-link';
 							link.href = inertUrl;
 							link.textContent = tpl.not_applicable.link_label
-								|| __('cookies.sbOpenSettings', 'Open Instagram Feed settings');
+								|| fazI18n('cookies.sbOpenSettings', 'Open Instagram Feed settings');
 							card.appendChild(link);
 						}
 					}
@@ -2198,7 +2201,7 @@
 				cardAction.addEventListener('click', function () {
 					var patterns = Array.isArray(tpl.patterns) ? tpl.patterns : [];
 					if (!patterns.length && !(Array.isArray(tpl.cookies) && tpl.cookies.length)) {
-						FAZ.notify(__('cookies.templateEmpty', 'No patterns or cookies in template.'), 'error');
+						FAZ.notify(fazI18n('cookies.templateEmpty', 'No patterns or cookies in template.'), 'error');
 						return;
 					}
 					var added = 0;
@@ -2208,7 +2211,7 @@
 					});
 					if (added) {
 						saveCustomRules();
-						FAZ.notify(__('cookies.rulesAdded', 'Added %1$d rules from %2$s (saved)').replace('%1$d', added).replace('%2$s', tpl.name), 'success');
+						FAZ.notify(fazI18n('cookies.rulesAdded', 'Added %1$d rules from %2$s (saved)').replace('%1$d', added).replace('%2$s', tpl.name), 'success');
 					}
 
 					// Also create cookies from the template if they don't already exist
@@ -2221,7 +2224,7 @@
 						if (c.slug === tpl.category) catId = c.id;
 					});
 					if (!catId) {
-						FAZ.notify('Category "' + tpl.category + '" ' + __('cookies.templateCatNotFound', 'not found — cookies not added.'), 'error');
+						FAZ.notify('Category "' + tpl.category + '" ' + fazI18n('cookies.templateCatNotFound', 'not found — cookies not added.'), 'error');
 						return;
 					}
 
@@ -2251,7 +2254,7 @@
 						});
 
 						if (!creates.length) {
-							FAZ.notify(__('cookies.allCookiesExist', 'All cookies from %s already exist').replace('%s', tpl.name), 'info');
+							FAZ.notify(fazI18n('cookies.allCookiesExist', 'All cookies from %s already exist').replace('%s', tpl.name), 'info');
 							return;
 						}
 
@@ -2261,7 +2264,7 @@
 							loadCategories();
 						});
 					}).catch(function () {
-						FAZ.notify(__('cookies.templateCookiesFailed', 'Failed to create cookies from template.'), 'error');
+						FAZ.notify(fazI18n('cookies.templateCookiesFailed', 'Failed to create cookies from template.'), 'error');
 					});
 				});
 
@@ -2273,7 +2276,7 @@
 				while (container.firstChild) container.removeChild(container.firstChild);
 				var errMsg = document.createElement('p');
 				errMsg.style.color = 'var(--faz-danger, red)';
-				errMsg.textContent = __('cookies.templateLoadFailed', 'Failed to load templates.');
+				errMsg.textContent = fazI18n('cookies.templateLoadFailed', 'Failed to load templates.');
 				container.appendChild(errMsg);
 			}
 		});

--- a/admin/assets/js/pages/dashboard.js
+++ b/admin/assets/js/pages/dashboard.js
@@ -7,7 +7,10 @@
 	'use strict';
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -51,7 +54,7 @@
 						card.hidden = true;
 					}).catch(function () {
 						dismissBtn.disabled = false;
-						FAZ.notify(__('setup.dismiss_failed', 'Could not dismiss. Please try again.'), 'error');
+						FAZ.notify(fazI18n('setup.dismiss_failed', 'Could not dismiss. Please try again.'), 'error');
 					});
 				});
 			}
@@ -95,11 +98,11 @@
 				var to = toEl ? toEl.value : '';
 
 				if (!from || !to) {
-					FAZ.notify(__('dashboard.selectBothDates', 'Please select both start and end dates.'), 'error');
+					FAZ.notify(fazI18n('dashboard.selectBothDates', 'Please select both start and end dates.'), 'error');
 					return;
 				}
 				if (from > to) {
-					FAZ.notify(__('dashboard.startBeforeEnd', 'Start date must be before end date.'), 'error');
+					FAZ.notify(fazI18n('dashboard.startBeforeEnd', 'Start date must be before end date.'), 'error');
 					return;
 				}
 
@@ -492,7 +495,7 @@
 				if (!hasCats) {
 					var emptyP = document.createElement('p');
 					emptyP.style.color = 'var(--faz-text-muted)';
-					emptyP.textContent = __('dashboard.noCategoryData', 'No category data yet.');
+					emptyP.textContent = fazI18n('dashboard.noCategoryData', 'No category data yet.');
 					catContainer.appendChild(emptyP);
 				}
 			}
@@ -537,7 +540,7 @@
 			if (totalConsents === 0) {
 				var empty = document.createElement('p');
 				empty.style.color = 'var(--faz-text-muted)';
-				empty.textContent = __(
+				empty.textContent = fazI18n(
 					'dashboard.abTestNoData',
 					'No consents recorded for these variants yet. Results appear once visitors respond to the banner.'
 				);
@@ -574,7 +577,7 @@
 				meta.style.color = 'var(--faz-text-muted)';
 				meta.style.fontSize = '12px';
 				meta.style.marginTop = '2px';
-				meta.textContent = __('dashboard.abTestAcceptedOf', '{accepted} accepted of {total} consents')
+				meta.textContent = fazI18n('dashboard.abTestAcceptedOf', '{accepted} accepted of {total} consents')
 					.replace('{accepted}', (parseInt(v.accepted, 10) || 0).toLocaleString())
 					.replace('{total}', total.toLocaleString());
 
@@ -601,7 +604,7 @@
 				while (body.firstChild) { body.removeChild(body.firstChild); }
 				var errEl = document.createElement('p');
 				errEl.style.color = 'var(--faz-text-muted)';
-				errEl.textContent = __('dashboard.abTestLoadError', 'Could not load A/B test results.');
+				errEl.textContent = fazI18n('dashboard.abTestLoadError', 'Could not load A/B test results.');
 				body.appendChild(errEl);
 			}).catch(function () {
 				// Can't even confirm the enabled state — fall back to hiding.

--- a/admin/assets/js/pages/gcm.js
+++ b/admin/assets/js/pages/gcm.js
@@ -5,7 +5,10 @@
 	'use strict';
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -28,7 +31,7 @@
 		FAZ.get('gcm').then(function (data) {
 			FAZ.populateForm(form, data);
 		}).catch(function () {
-			FAZ.notify(__('gcm.loadFailed', 'Failed to load GCM settings.'), 'error');
+			FAZ.notify(fazI18n('gcm.loadFailed', 'Failed to load GCM settings.'), 'error');
 		});
 	}
 
@@ -40,10 +43,10 @@
 
 		FAZ.post('gcm', data).then(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('gcm.saved', 'GCM settings saved successfully.'));
+			FAZ.notify(fazI18n('gcm.saved', 'GCM settings saved successfully.'));
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('gcm.saveFailed', 'Failed to save GCM settings.'), 'error');
+			FAZ.notify(fazI18n('gcm.saveFailed', 'Failed to save GCM settings.'), 'error');
 		});
 	}
 

--- a/admin/assets/js/pages/gvl.js
+++ b/admin/assets/js/pages/gvl.js
@@ -7,7 +7,10 @@
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
 	// `key` is a hard-coded string from this file (e.g. 'gvl.savedCount'),
 	// never reachable from user input — the computed-key walk is safe.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -74,7 +77,7 @@
 			// Give AT users context for the disabled button while the saved
 			// selection hydrates. Cleared once hydration completes / the button
 			// is re-enabled in loadSelectedVendors().
-			setAutoDetectStatus(__('gvl.autoDetectHydrating', 'Loading saved selection…'), 'info');
+			setAutoDetectStatus(fazI18n('gvl.autoDetectHydrating', 'Loading saved selection…'), 'info');
 			autoBtn.addEventListener('click', autoDetectFromCookies);
 		}
 
@@ -104,15 +107,15 @@
 
 			if (data.version && data.version > 0) {
 				var b1 = document.createElement('strong');
-				b1.textContent = __('gvl.version', 'GVL Version: ');
+				b1.textContent = fazI18n('gvl.version', 'GVL Version: ');
 				el.appendChild(b1);
 				el.appendChild(document.createTextNode(data.version + '  |  '));
 				var b2 = document.createElement('strong');
-				b2.textContent = __('gvl.vendors', 'Vendors: ');
+				b2.textContent = fazI18n('gvl.vendors', 'Vendors: ');
 				el.appendChild(b2);
 				el.appendChild(document.createTextNode(data.vendor_count + '  |  '));
 				var b3 = document.createElement('strong');
-				b3.textContent = __('gvl.lastUpdated', 'Last Updated: ');
+				b3.textContent = fazI18n('gvl.lastUpdated', 'Last Updated: ');
 				el.appendChild(b3);
 				el.appendChild(document.createTextNode(data.last_updated || 'N/A'));
 
@@ -129,11 +132,11 @@
 					});
 				}
 			} else {
-				el.textContent = __('gvl.noData', 'No GVL data downloaded yet. Click "Update GVL Now" to download.');
+				el.textContent = fazI18n('gvl.noData', 'No GVL data downloaded yet. Click "Update GVL Now" to download.');
 			}
 		}).catch(function () {
 			var el = document.getElementById('faz-gvl-meta');
-			if (el) el.textContent = __('gvl.loadFailed', 'Failed to load GVL status.');
+			if (el) el.textContent = fazI18n('gvl.loadFailed', 'Failed to load GVL status.');
 		});
 	}
 
@@ -160,7 +163,7 @@
 			// Auto-detect and leave `hydrated` false — saveSelection() now holds
 			// only an empty set, and committing it would wipe the server-side
 			// selection. Surface the failure and still show the vendor list.
-			setAutoDetectStatus(__('gvl.selectedLoadFailed', 'Could not load your saved selection — reload before changing it.'), 'error');
+			setAutoDetectStatus(fazI18n('gvl.selectedLoadFailed', 'Could not load your saved selection — reload before changing it.'), 'error');
 			loadVendors();
 		});
 	}
@@ -175,7 +178,7 @@
 			renderPagination(data.total || 0, data.pages || 0, data.page || 1);
 		}).catch(function () {
 			var el = document.getElementById('faz-gvl-vendor-list');
-			if (el) el.textContent = __('gvl.vendorsLoadFailed', 'Failed to load vendors. Make sure GVL is downloaded.');
+			if (el) el.textContent = fazI18n('gvl.vendorsLoadFailed', 'Failed to load vendors. Make sure GVL is downloaded.');
 		});
 	}
 
@@ -184,7 +187,7 @@
 		container.textContent = '';
 
 		if (!vendors.length) {
-			container.textContent = __('gvl.noVendors', 'No vendors found.');
+			container.textContent = fazI18n('gvl.noVendors', 'No vendors found.');
 			return;
 		}
 
@@ -304,7 +307,7 @@
 
 		var info = document.createElement('span');
 		info.style.color = 'var(--faz-text-secondary)';
-		info.textContent = __('gvl.pagination', 'Page %1$d of %2$d (%3$d vendors)').replace('%1$d', page).replace('%2$d', pages).replace('%3$d', total);
+		info.textContent = fazI18n('gvl.pagination', 'Page %1$d of %2$d (%3$d vendors)').replace('%1$d', page).replace('%2$d', pages).replace('%3$d', total);
 		container.appendChild(info);
 	}
 
@@ -327,7 +330,7 @@
 
 			alert(lines.join('\n'));
 		}).catch(function () {
-			FAZ.notify(__('gvl.vendorDetailFailed', 'Failed to load vendor details.'), 'error');
+			FAZ.notify(fazI18n('gvl.vendorDetailFailed', 'Failed to load vendor details.'), 'error');
 		});
 	}
 
@@ -349,14 +352,14 @@
 	function updateSelectedCount() {
 		var count = Object.keys(selectedVendors).length;
 		var el = document.getElementById('faz-gvl-selected-count');
-		if (el) el.textContent = (count !== 1 ? __('gvl.selectedVendors', 'Selected: %d vendors') : __('gvl.selectedVendor', 'Selected: %d vendor')).replace('%d', count);
+		if (el) el.textContent = (count !== 1 ? fazI18n('gvl.selectedVendors', 'Selected: %d vendors') : fazI18n('gvl.selectedVendor', 'Selected: %d vendor')).replace('%d', count);
 	}
 
 	function saveSelection() {
 		// Refuse to save before the saved selection has loaded — selectedVendors
 		// would be empty and committing it would wipe the server-side selection.
 		if (!hydrated) {
-			FAZ.notify(__('gvl.notHydrated', 'Your saved selection has not loaded yet — reload the page before saving.'), 'error');
+			FAZ.notify(fazI18n('gvl.notHydrated', 'Your saved selection has not loaded yet — reload the page before saving.'), 'error');
 			return;
 		}
 		var btn = document.getElementById('faz-gvl-save');
@@ -366,13 +369,13 @@
 		FAZ.post('gvl/selected', { vendor_ids: ids }).then(function (data) {
 			FAZ.btnLoading(btn, false);
 			if (data.success) {
-				FAZ.notify(__('gvl.savedCount', 'Saved %d vendor(s).').replace('%d', data.count), 'success');
+				FAZ.notify(fazI18n('gvl.savedCount', 'Saved %d vendor(s).').replace('%d', data.count), 'success');
 			} else {
-				FAZ.notify(__('gvl.selectionFailed', 'Failed to save selection.'), 'error');
+				FAZ.notify(fazI18n('gvl.selectionFailed', 'Failed to save selection.'), 'error');
 			}
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('gvl.selectionFailed', 'Failed to save selection.'), 'error');
+			FAZ.notify(fazI18n('gvl.selectionFailed', 'Failed to save selection.'), 'error');
 		});
 	}
 
@@ -393,11 +396,11 @@
 		var requestId = ++autoDetectRequestId;
 		// Read-only scan, not a save — pass a scan-specific spinner label so
 		// the button doesn't misleadingly read "Saving..." during detection.
-		FAZ.btnLoading(btn, true, __('gvl.autoDetectScanning', 'Scanning cookie inventory…'));
+		FAZ.btnLoading(btn, true, fazI18n('gvl.autoDetectScanning', 'Scanning cookie inventory…'));
 		// Scanning state: announce it in the aria-live status region (no
 		// timer — stays until the next status write replaces it) so screen
 		// readers hear the scan start, matching the cookie-policy page.
-		setAutoDetectStatus(__('gvl.autoDetectScanning', 'Scanning cookie inventory…'), 'info');
+		setAutoDetectStatus(fazI18n('gvl.autoDetectScanning', 'Scanning cookie inventory…'), 'info');
 
 		FAZ.get('gvl/suggest').then(function (data) {
 			if (requestId !== autoDetectRequestId) { return; }
@@ -408,7 +411,7 @@
 				// silently doing nothing. Write the SAME message to the
 				// persistent status span so a faded toast still leaves a
 				// trace — parity with cookie-policy.js (F007).
-				var noGvlMsg = __('gvl.autoDetectNoGvl', 'Update the Global Vendor List first, then try Auto-detect again.');
+				var noGvlMsg = fazI18n('gvl.autoDetectNoGvl', 'Update the Global Vendor List first, then try Auto-detect again.');
 				setAutoDetectStatus(noGvlMsg, 'warning');
 				FAZ.notify(noGvlMsg, 'warning');
 				return;
@@ -419,7 +422,7 @@
 			// both collapse to the no-match hint, so the admin who simply
 			// forgot to run the scanner gets the wrong nudge.
 			if (data.scan_available !== true) {
-				var noScanMsg = __('gvl.autoDetectNoScan', 'No scanner data yet. Run the cookie scanner first.');
+				var noScanMsg = fazI18n('gvl.autoDetectNoScan', 'No scanner data yet. Run the cookie scanner first.');
 				setAutoDetectStatus(noScanMsg, 'warning');
 				FAZ.notify(noScanMsg, 'warning');
 				return;
@@ -434,7 +437,7 @@
 				// but no scanned domain matched the curated map. Soft info
 				// string in the persistent span instead of going blank — keeps
 				// a trace after the toast fades (F007).
-				var noMatchMsg = __('gvl.autoDetectNoMatch', 'No matching ad-tech vendors were found in the scanned cookies.');
+				var noMatchMsg = fazI18n('gvl.autoDetectNoMatch', 'No matching ad-tech vendors were found in the scanned cookies.');
 				setAutoDetectStatus(noMatchMsg, 'info');
 				FAZ.notify(noMatchMsg, 'info');
 				return;
@@ -484,11 +487,11 @@
 				// sibling branches already avoid via alreadyInSession). Fall back to
 				// a "left unticked" note when none remain.
 				msg = (alreadyInSession.length > 0)
-					? __('gvl.autoDetectAllAlready', 'All %d auto-detected vendor(s) were already in your selection.').replace('%d', alreadyInSession.length)
-					: __('gvl.autoDetectNoneAdded', 'Auto-detected vendors left unticked, as you set them.');
+					? fazI18n('gvl.autoDetectAllAlready', 'All %d auto-detected vendor(s) were already in your selection.').replace('%d', alreadyInSession.length)
+					: fazI18n('gvl.autoDetectNoneAdded', 'Auto-detected vendors left unticked, as you set them.');
 			} else if (alreadyInSession.length === 0) {
 				// Single placeholder — no reordering possible, plain %d is fine.
-				msg = __('gvl.autoDetectAdded', 'Pre-ticked %d vendor(s) from cookie scan. Click Save Selection to apply.')
+				msg = fazI18n('gvl.autoDetectAdded', 'Pre-ticked %d vendor(s) from cookie scan. Click Save Selection to apply.')
 					.replace('%d', added.length);
 			} else {
 				// Dual-mode formatter. Both the registered string (class-admin.php)
@@ -497,7 +500,7 @@
 				// handle that case. The trailing plain-%d replaces are a defensive
 				// no-op kept only so a translation that happens to use plain %d
 				// still renders. Mirrors cookie-policy.js svcAutoDetectDone.
-				var template = __('gvl.autoDetectMixed', 'Pre-ticked %1$d new vendor(s), %2$d were already selected. Click Save Selection to apply.');
+				var template = fazI18n('gvl.autoDetectMixed', 'Pre-ticked %1$d new vendor(s), %2$d were already selected. Click Save Selection to apply.');
 				msg = template
 					.replace(/%1\$d/g, String(added.length))
 					.replace(/%2\$d/g, String(alreadyInSession.length))
@@ -514,7 +517,7 @@
 			// Persist the failure in the status span too — the toast
 			// auto-dismisses but the admin still needs a trace (F007).
 			// 'error' kind => no auto-clear timer, stays visible.
-			var failedMsg = __('gvl.autoDetectFailed', 'Auto-detect failed. Check the cookie scanner and try again.');
+			var failedMsg = fazI18n('gvl.autoDetectFailed', 'Auto-detect failed. Check the cookie scanner and try again.');
 			setAutoDetectStatus(failedMsg, 'error');
 			FAZ.notify(failedMsg, 'error');
 		});
@@ -526,18 +529,18 @@
 		FAZ.post('gvl/update').then(function (data) {
 			FAZ.btnLoading(btn, false);
 			if (data.success) {
-				var updatedMsg = __('gvl.updatedWithMeta', 'GVL updated: v{version} ({count} vendors)')
+				var updatedMsg = fazI18n('gvl.updatedWithMeta', 'GVL updated: v{version} ({count} vendors)')
 					.replace('{version}', String(data.version))
 					.replace('{count}', String(data.vendor_count));
 				FAZ.notify(updatedMsg);
 				loadMeta();
 				loadVendors();
 			} else {
-				FAZ.notify(data.message || __('gvl.updateFailed', 'Failed to update GVL.'), 'error');
+				FAZ.notify(data.message || fazI18n('gvl.updateFailed', 'Failed to update GVL.'), 'error');
 			}
 		}).catch(function (err) {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify((err && err.message) || __('gvl.updateFailed', 'Failed to update GVL.'), 'error');
+			FAZ.notify((err && err.message) || fazI18n('gvl.updateFailed', 'Failed to update GVL.'), 'error');
 		});
 	}
 

--- a/admin/assets/js/pages/import-export.js
+++ b/admin/assets/js/pages/import-export.js
@@ -2,7 +2,10 @@
     'use strict';
 
     // i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-    function __(key, fallback) {
+    // Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+    // map, not gettext. Under the gettext name, translate.wordpress.org harvests
+    // the dotted keys below as if they were translatable English text.
+    function fazI18n(key, fallback) {
         var parts = key.split('.');
         var obj = (window.fazConfig && window.fazConfig.i18n) || {};
         for (var i = 0; i < parts.length; i++) {
@@ -55,7 +58,7 @@
     // --- Export ---
     document.getElementById('faz-export-btn').addEventListener('click', function() {
         this.disabled = true;
-        this.textContent = __('importExport.exporting', 'Exporting...');
+        this.textContent = fazI18n('importExport.exporting', 'Exporting...');
         var btn = this;
 
         FAZ.get('settings/export').then(function(data) {
@@ -68,7 +71,7 @@
             a.click();
             a.remove();
             URL.revokeObjectURL(url);
-            FAZ.notify(__('importExport.exportOk', 'Settings exported successfully.'), 'success');
+            FAZ.notify(fazI18n('importExport.exportOk', 'Settings exported successfully.'), 'success');
             btn.disabled = false;
             btn.textContent = '';
             var temp = document.createElement('span');
@@ -76,7 +79,7 @@
             while (temp.firstChild) btn.appendChild(temp.firstChild);
             btn.appendChild(document.createTextNode('Export Settings'));
         }).catch(function(err) {
-            FAZ.notify(__('importExport.exportFailed', 'Export failed.') + ': ' + (err.message || err), 'error');
+            FAZ.notify(fazI18n('importExport.exportFailed', 'Export failed.') + ': ' + (err.message || err), 'error');
             btn.disabled = false;
             btn.textContent = '';
             var temp = document.createElement('span');
@@ -96,7 +99,7 @@
             try {
                 importData = JSON.parse(ev.target.result);
             } catch (err) {
-                FAZ.notify(__('importExport.invalidJson', 'Invalid JSON file.'), 'error');
+                FAZ.notify(fazI18n('importExport.invalidJson', 'Invalid JSON file.'), 'error');
                 importData = null;
                 document.getElementById('faz-import-preview').style.display = 'none';
                 document.getElementById('faz-import-btn').disabled = true;
@@ -105,7 +108,7 @@
 
             // Validate structure
             if (!importData.plugin || importData.plugin !== 'faz-cookie-manager') {
-                FAZ.notify(__('importExport.notFazExport', 'This file is not a FAZ Cookie Manager export.'), 'error');
+                FAZ.notify(fazI18n('importExport.notFazExport', 'This file is not a FAZ Cookie Manager export.'), 'error');
                 importData = null;
                 document.getElementById('faz-import-preview').style.display = 'none';
                 document.getElementById('faz-import-btn').disabled = true;
@@ -125,21 +128,21 @@
     // --- Import: Apply ---
     document.getElementById('faz-import-btn').addEventListener('click', function() {
         if (!importData) return;
-        if (!confirm(__('importExport.importConfirm', 'This will overwrite your current settings. Continue?'))) return;
+        if (!confirm(fazI18n('importExport.importConfirm', 'This will overwrite your current settings. Continue?'))) return;
 
         this.disabled = true;
         var statusEl = document.getElementById('faz-import-status');
         statusEl.style.display = 'block';
-        statusEl.textContent = __('importExport.importing', 'Importing...');
+        statusEl.textContent = fazI18n('importExport.importing', 'Importing...');
         statusEl.style.color = 'var(--faz-text-secondary)';
 
         FAZ.post('settings/import', importData).then(function(result) {
-            statusEl.textContent = __('importExport.importOk', 'Import completed successfully. Reloading...');
+            statusEl.textContent = fazI18n('importExport.importOk', 'Import completed successfully. Reloading...');
             statusEl.style.color = 'var(--faz-success)';
-            FAZ.notify(__('importExport.importedOk', 'Settings imported successfully.'), 'success');
+            FAZ.notify(fazI18n('importExport.importedOk', 'Settings imported successfully.'), 'success');
             setTimeout(function() { window.location.reload(); }, 1500);
         }).catch(function(err) {
-            statusEl.textContent = __('importExport.importFailed', 'Import failed: %s').replace('%s', err.message || err);
+            statusEl.textContent = fazI18n('importExport.importFailed', 'Import failed: %s').replace('%s', err.message || err);
             statusEl.style.color = 'var(--faz-danger)';
             document.getElementById('faz-import-btn').disabled = false;
         });

--- a/admin/assets/js/pages/languages.js
+++ b/admin/assets/js/pages/languages.js
@@ -6,7 +6,10 @@
 	'use strict';
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -40,7 +43,7 @@
 			renderTags();
 			renderDefaultSelect();
 		}).catch(function () {
-			FAZ.notify(__('languages.loadFailed', 'Failed to load languages.'), 'error');
+			FAZ.notify(fazI18n('languages.loadFailed', 'Failed to load languages.'), 'error');
 		});
 	}
 
@@ -51,7 +54,7 @@
 		if (!selected.length) {
 			var empty = document.createElement('span');
 			empty.className = 'faz-text-muted';
-			empty.textContent = __('languages.noLanguages', 'No languages selected. Add one below.');
+			empty.textContent = fazI18n('languages.noLanguages', 'No languages selected. Add one below.');
 			container.appendChild(empty);
 			return;
 		}
@@ -69,7 +72,7 @@
 			removeBtn.type = 'button';
 			removeBtn.className = 'faz-lang-tag-remove';
 			removeBtn.textContent = '\u00D7'; // multiplication sign ×
-			removeBtn.title = __('languages.removeLanguage', 'Remove %s').replace('%s', name);
+			removeBtn.title = fazI18n('languages.removeLanguage', 'Remove %s').replace('%s', name);
 			removeBtn.addEventListener('click', function () {
 				removeLanguage(code);
 			});
@@ -103,7 +106,7 @@
 
 	function removeLanguage(code) {
 		if (selected.length <= 1) {
-			FAZ.notify(__('languages.atLeastOne', 'At least one language must be selected.'), 'error');
+			FAZ.notify(fazI18n('languages.atLeastOne', 'At least one language must be selected.'), 'error');
 			return;
 		}
 		selected = selected.filter(function (c) { return c !== code; });
@@ -168,7 +171,7 @@
 				if (already) {
 					var badge = document.createElement('span');
 					badge.className = 'faz-badge faz-badge-muted';
-					badge.textContent = __('languages.added', 'Added');
+					badge.textContent = fazI18n('languages.added', 'Added');
 					item.appendChild(badge);
 				} else {
 					(function (c) {
@@ -186,7 +189,7 @@
 		if (count === 0) {
 			var noResult = document.createElement('div');
 			noResult.className = 'faz-lang-dropdown-item disabled';
-			noResult.textContent = __('languages.noResults', 'No languages found.');
+			noResult.textContent = fazI18n('languages.noResults', 'No languages found.');
 			dropdown.appendChild(noResult);
 		}
 
@@ -217,10 +220,10 @@
 			return FAZ.post('settings', current);
 		}).then(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('languages.saved', 'Languages saved successfully.'));
+			FAZ.notify(fazI18n('languages.saved', 'Languages saved successfully.'));
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('languages.saveFailed', 'Failed to save languages.'), 'error');
+			FAZ.notify(fazI18n('languages.saveFailed', 'Failed to save languages.'), 'error');
 		});
 	}
 

--- a/admin/assets/js/pages/settings.js
+++ b/admin/assets/js/pages/settings.js
@@ -5,7 +5,10 @@
 	'use strict';
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back to provided string.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -64,7 +67,7 @@
 				// Invalidate any readiness request still in flight: it answers
 				// the question the admin has just stopped asking.
 				geoBootstrapStatusId++;
-				status.textContent = __('settings.bootstrapSaveToCheck', 'Save settings to check whether the bootstrap can activate.');
+				status.textContent = fazI18n('settings.bootstrapSaveToCheck', 'Save settings to check whether the bootstrap can activate.');
 				status.setAttribute('data-level', 'info');
 			});
 		}
@@ -80,7 +83,7 @@
 	 */
 	function invalidateConsents() {
 		var btn = document.getElementById('faz-invalidate-consents');
-		var message = __(
+		var message = fazI18n(
 			'settings.invalidateConfirm',
 			'Show the cookie banner to ALL returning visitors on their next visit? This cannot be undone from the UI.'
 		);
@@ -95,10 +98,10 @@
 			// Invalidate any in-flight loadSettings() so its stale payload
 			// cannot overwrite the revision we just bumped.
 			settingsRequestId++;
-			FAZ.notify(__('settings.invalidateOk', 'All consents invalidated. Banner will reappear for returning visitors.'));
+			FAZ.notify(fazI18n('settings.invalidateOk', 'All consents invalidated. Banner will reappear for returning visitors.'));
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('settings.invalidateFail', 'Failed to invalidate consents.'), 'error');
+			FAZ.notify(fazI18n('settings.invalidateFail', 'Failed to invalidate consents.'), 'error');
 		});
 	}
 
@@ -132,7 +135,7 @@
 			renderAbVariants(data);
 			applyShowIf();
 		}).catch(function () {
-			FAZ.notify(__('settings.loadFailed', 'Failed to load settings.'), 'error');
+			FAZ.notify(fazI18n('settings.loadFailed', 'Failed to load settings.'), 'error');
 		});
 	}
 
@@ -166,7 +169,7 @@
 			if (list.length < 2) {
 				var hint = document.createElement('p');
 				hint.style.color = 'var(--faz-text-muted)';
-				hint.textContent = __(
+				hint.textContent = fazI18n(
 					'settings.abTestNeedBanners',
 					'Create at least two active banners on the Banner page to run an A/B test.'
 				);
@@ -204,7 +207,7 @@
 			while (container.firstChild) { container.removeChild(container.firstChild); }
 			var err = document.createElement('p');
 			err.style.color = 'var(--faz-text-muted)';
-			err.textContent = __('settings.abTestLoadFailed', 'Could not load banners for the A/B test.');
+			err.textContent = fazI18n('settings.abTestLoadFailed', 'Could not load banners for the A/B test.');
 			container.appendChild(err);
 			// Load failed — the checkbox list is empty/stale. Keep saveSettings()
 			// from treating serializeAbVariants() as authoritative.
@@ -463,14 +466,14 @@
 			});
 		}).then(function (saveWarnings) {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('settings.saved', 'Settings saved successfully.'));
+			FAZ.notify(fazI18n('settings.saved', 'Settings saved successfully.'));
 			loadGeoBootstrapStatus();
 			(saveWarnings || []).forEach(function (message) {
 				FAZ.notify(message, 'warning');
 			});
 		}).catch(function () {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify(__('settings.saveFailed', 'Failed to save settings.'), 'error');
+			FAZ.notify(fazI18n('settings.saveFailed', 'Failed to save settings.'), 'error');
 		});
 	}
 
@@ -482,11 +485,11 @@
 			if (requestId !== geoBootstrapStatusId) return;
 			el.textContent = data && data.message
 				? data.message
-				: __('settings.bootstrapStatusFailed', 'Bootstrap readiness could not be determined. Pages keep the safe no-cache fallback.');
+				: fazI18n('settings.bootstrapStatusFailed', 'Bootstrap readiness could not be determined. Pages keep the safe no-cache fallback.');
 			el.setAttribute('data-level', data && data.level ? data.level : 'warning');
 		}).catch(function () {
 			if (requestId !== geoBootstrapStatusId) return;
-			el.textContent = __('settings.bootstrapStatusFailed', 'Bootstrap readiness could not be determined. Pages keep the safe no-cache fallback.');
+			el.textContent = fazI18n('settings.bootstrapStatusFailed', 'Bootstrap readiness could not be determined. Pages keep the safe no-cache fallback.');
 			el.setAttribute('data-level', 'warning');
 		});
 	}
@@ -527,13 +530,13 @@
 			// no longer active and Ab_Test::pick_variant() has nothing to choose
 			// between. Ask the catalogue, not the leftovers.
 			if (effectiveVariants.length < 2 || (abActiveBannerCount !== null && abActiveBannerCount < 2)) {
-				abTestWarnings.push(__(
+				abTestWarnings.push(fazI18n(
 					'settings.abTestWarnVariants',
 					'A/B testing needs at least 2 selected banner variants to run.'
 				));
 			}
 			if (current.banner_control.cache_compatibility) {
-				abTestWarnings.push(__(
+				abTestWarnings.push(fazI18n(
 					'settings.abTestWarnCache',
 					'A/B testing is disabled while Cache Compatibility Mode is on.'
 				));
@@ -548,14 +551,14 @@
 		if (current.banner_control && current.banner_control.cache_compatibility) {
 			var geoOn = !!(current.geolocation && current.geolocation.geo_targeting);
 			if (geoOn) {
-					saveWarnings.push(__(
+					saveWarnings.push(fazI18n(
 						'settings.cacheCompatWarnGeo',
 						'Jurisdiction enforcement keeps Cache Compatibility Mode itself inactive. Enable the cache-safe jurisdiction bootstrap to cache compatible pages without weakening enforcement.'
 					));
 			}
 			var cmpId = current.iab ? parseInt(current.iab.cmp_id, 10) : 0;
 			if (!geoOn && current.iab && current.iab.enabled && !isNaN(cmpId) && cmpId >= 2) {
-				saveWarnings.push(__(
+				saveWarnings.push(fazI18n(
 					'settings.cacheCompatWarnIab',
 					'Cache Compatibility Mode applies the conservative IAB TCF default (GDPR applies) to every visitor instead of deciding by country.'
 				));
@@ -574,16 +577,16 @@
 				var rawSize = parseInt(data.database.size, 10);
 			var sizeKB = isFinite(rawSize) ? Math.round(rawSize / 1024) : 0;
 				var b = document.createElement('strong');
-				b.textContent = __('settings.dbLabel', 'Database: ');
+				b.textContent = fazI18n('settings.dbLabel', 'Database: ');
 				el.appendChild(b);
 				el.appendChild(document.createTextNode(
-					__('settings.dbFileInfo', '{file} ({size} KB) - Last updated: {date}')
+					fazI18n('settings.dbFileInfo', '{file} ({size} KB) - Last updated: {date}')
 						.replace('{file}', data.database.file)
 						.replace('{size}', sizeKB)
 						.replace('{date}', data.database.modified)
 				));
 			} else {
-				el.textContent = __('settings.noGeoipDb', 'No GeoIP database installed. Enter your license key and click "Update Database".');
+				el.textContent = fazI18n('settings.noGeoipDb', 'No GeoIP database installed. Enter your license key and click "Update Database".');
 			}
 			el.style.display = 'block';
 		}).catch(function (err) {
@@ -598,23 +601,23 @@
 			el.textContent = '';
 			if (data.version && data.version > 0) {
 				var b1 = document.createElement('strong');
-				b1.textContent = __('settings.gvlVersion', 'GVL Version: ');
+				b1.textContent = fazI18n('settings.gvlVersion', 'GVL Version: ');
 				el.appendChild(b1);
 				el.appendChild(document.createTextNode(data.version + ' | '));
 				var b2 = document.createElement('strong');
-				b2.textContent = __('settings.gvlVendors', 'Vendors: ');
+				b2.textContent = fazI18n('settings.gvlVendors', 'Vendors: ');
 				el.appendChild(b2);
 				el.appendChild(document.createTextNode((data.vendor_count || 0) + ' | '));
 				var b3 = document.createElement('strong');
-				b3.textContent = __('settings.gvlLastUpdated', 'Last Updated: ');
+				b3.textContent = fazI18n('settings.gvlLastUpdated', 'Last Updated: ');
 				el.appendChild(b3);
 				el.appendChild(document.createTextNode(data.last_updated || 'N/A'));
 			} else {
-				el.textContent = __('settings.noGvlData', 'No GVL data downloaded yet. Click "Update GVL Now" to download.');
+				el.textContent = fazI18n('settings.noGvlData', 'No GVL data downloaded yet. Click "Update GVL Now" to download.');
 			}
 		}).catch(function () {
 			var el = document.getElementById('faz-gvl-status');
-			if (el) el.textContent = __('settings.noGvlAvailable', 'No GVL data available.');
+			if (el) el.textContent = fazI18n('settings.noGvlAvailable', 'No GVL data available.');
 		});
 	}
 
@@ -625,17 +628,17 @@
 		FAZ.post('gvl/update').then(function (data) {
 			FAZ.btnLoading(btn, false);
 			if (data.success) {
-				var gvlMsg = __('settings.gvlUpdatedWithMeta', 'GVL updated: v{version} ({count} vendors)')
+				var gvlMsg = fazI18n('settings.gvlUpdatedWithMeta', 'GVL updated: v{version} ({count} vendors)')
 					.replace('{version}', String(data.version))
 					.replace('{count}', String(data.vendor_count));
 				FAZ.notify(gvlMsg);
 				loadGvlStatus();
 			} else {
-				FAZ.notify(data.message || __('settings.gvlFailed', 'Failed to update GVL.'), 'error');
+				FAZ.notify(data.message || fazI18n('settings.gvlFailed', 'Failed to update GVL.'), 'error');
 			}
 		}).catch(function (err) {
 			FAZ.btnLoading(btn, false);
-			FAZ.notify((err && err.message) || __('settings.gvlFailed', 'Failed to update GVL.'), 'error');
+			FAZ.notify((err && err.message) || fazI18n('settings.gvlFailed', 'Failed to update GVL.'), 'error');
 		});
 	}
 
@@ -648,7 +651,7 @@
 		var edition = edInput && (edInput.value === 'city' || edInput.value === 'country') ? edInput.value : '';
 
 		if (!licenseKey) {
-			FAZ.notify(__('settings.geoipNoKey', 'Please enter a MaxMind license key first.'), 'error');
+			FAZ.notify(fazI18n('settings.geoipNoKey', 'Please enter a MaxMind license key first.'), 'error');
 			return;
 		}
 
@@ -656,15 +659,15 @@
 		FAZ.post('settings/geolite2/update', { license_key: licenseKey, edition: edition }).then(function (data) {
 			FAZ.btnLoading(btn, false);
 			if (data.success) {
-				FAZ.notify(__('settings.geoipUpdated', 'GeoIP database updated successfully.'));
+				FAZ.notify(fazI18n('settings.geoipUpdated', 'GeoIP database updated successfully.'));
 				loadGeoDbStatus();
 			}
 			else {
-				FAZ.notify(data.message || __('settings.geoipFailed', 'Failed to update database.'), 'error');
+				FAZ.notify(data.message || fazI18n('settings.geoipFailed', 'Failed to update database.'), 'error');
 			}
 		}).catch(function (err) {
 			FAZ.btnLoading(btn, false);
-			var msg = (err && err.message) ? err.message : __('settings.geoipFailed', 'Failed to update database.');
+			var msg = (err && err.message) ? err.message : fazI18n('settings.geoipFailed', 'Failed to update database.');
 			FAZ.notify(msg, 'error');
 		});
 	}

--- a/admin/assets/js/pages/setup.js
+++ b/admin/assets/js/pages/setup.js
@@ -14,7 +14,10 @@
 
 	// i18n helper — looks up fazConfig.i18n.<key> with dot-notation, falls back
 	// to the provided English string. Mirrors dashboard.js.
-	function __(key, fallback) {
+	// Not named `__`: this is a key lookup into the PHP-provided fazConfig.i18n
+	// map, not gettext. Under the gettext name, translate.wordpress.org harvests
+	// the dotted keys below as if they were translatable English text.
+	function fazI18n(key, fallback) {
 		var parts = key.split('.');
 		var obj = (window.fazConfig && window.fazConfig.i18n) || {};
 		for (var i = 0; i < parts.length; i++) {
@@ -298,7 +301,7 @@
 		if (recommendations.cache_plugin && bootstrap) {
 			if (cacheBadge) {
 				cacheBadge.textContent = interpolateStr(
-				__('setup.detected_named', 'Detected: %s'),
+				fazI18n('setup.detected_named', 'Detected: %s'),
 				recommendations.cache_plugin
 				);
 				cacheBadge.hidden = false;
@@ -312,7 +315,7 @@
 		// Google tags badge (step 4).
 		var googleBadge = document.getElementById('faz-setup-google-badge');
 		if (googleBadge && recommendations.google_tags) {
-			googleBadge.textContent = __('setup.detected_google', 'Google tags detected on this site');
+			googleBadge.textContent = fazI18n('setup.detected_google', 'Google tags detected on this site');
 			googleBadge.hidden = false;
 		}
 
@@ -364,10 +367,10 @@
 			var badge = document.createElement('span');
 			badge.className = 'faz-setup-badge';
 			badge.textContent = gateway.source === 'scan'
-				? __('setup.detected_scan', 'Found by the cookie scan')
+				? fazI18n('setup.detected_scan', 'Found by the cookie scan')
 				: (gateway.source === 'enabled'
-					? __('setup.detected_enabled', 'Currently always allowed')
-					: __('setup.detected_plugin', 'Active plugin detected'));
+					? fazI18n('setup.detected_enabled', 'Currently always allowed')
+					: fazI18n('setup.detected_plugin', 'Active plugin detected'));
 			label.appendChild(document.createTextNode(' '));
 			label.appendChild(badge);
 
@@ -451,7 +454,7 @@
 		if (!window.FAZ || !FAZ.scanEngine || typeof FAZ.scanEngine.run !== 'function') {
 			// The engine script was blocked (ad blockers match "cookie"/"scan"
 			// filenames). Say so rather than failing mutely.
-			setScanStatus(__('setup.scan_engine_missing', 'The scanner could not load. You can skip this step and run a full scan on the Cookies page.'));
+			setScanStatus(fazI18n('setup.scan_engine_missing', 'The scanner could not load. You can skip this step and run a full scan on the Cookies page.'));
 			return;
 		}
 
@@ -459,7 +462,7 @@
 		// A fresh scan reclaims any held capture session on the server, so a
 		// leftover retry offer would 409 the moment it was used. Remove it.
 		removeHeldPanel();
-		setScanStatus(__('setup.scan_starting', 'Starting scan…'));
+		setScanStatus(fazI18n('setup.scan_starting', 'Starting scan…'));
 		startScanActivity();
 
 		var hooks = {
@@ -500,8 +503,8 @@
 	}
 
 	function showTerminalScanFailure(err) {
-		setScanStatus((err && err.message) || __('setup.scan_failed', 'The scan could not be started. You can skip this step or run a full scan on the Cookies page.'));
-		FAZ.notify(__('setup.scan_failed_notify', 'Cookie scan could not be started.'), 'error');
+		setScanStatus((err && err.message) || fazI18n('setup.scan_failed', 'The scan could not be started. You can skip this step or run a full scan on the Cookies page.'));
+		FAZ.notify(fazI18n('setup.scan_failed_notify', 'Cookie scan could not be started.'), 'error');
 	}
 
 	function handleScanSuccess(res) {
@@ -512,16 +515,16 @@
 		// twice, so the counts are described as what is already on record
 		// rather than as a fresh import.
 		if (res && res.importResult && res.importResult.duplicate) {
-			doneMessage = __('cookies.scanAlreadySaved', 'Already saved — %1$d cookies on %2$d pages were imported by an earlier attempt. Nothing was saved twice.')
+			doneMessage = fazI18n('cookies.scanAlreadySaved', 'Already saved — %1$d cookies on %2$d pages were imported by an earlier attempt. Nothing was saved twice.')
 				.replace('%1$d', function () { return String(found); })
 				.replace('%2$d', function () { return String((res && typeof res.pagesScanned === 'number') ? res.pagesScanned : 0); });
 		} else {
 			doneMessage = found > 0
-				? interpolate(__('setup.scan_done_found', 'Scan complete — %d cookies found.'), found)
-				: __('setup.scan_done_empty', 'Scan complete. No new cookies were found.');
+				? interpolate(fazI18n('setup.scan_done_found', 'Scan complete — %d cookies found.'), found)
+				: fazI18n('setup.scan_done_empty', 'Scan complete. No new cookies were found.');
 		}
 		if (res && res.importResult && res.importResult.enrichment_pending) {
-			doneMessage += ' ' + __('setup.scan_enrichment_pending', 'Server-header enrichment continues in the background.');
+			doneMessage += ' ' + fazI18n('setup.scan_enrichment_pending', 'Server-header enrichment continues in the background.');
 		}
 		setScanStatus(doneMessage);
 		// The scan may have discovered payment-gateway cookies — refresh the
@@ -556,7 +559,7 @@
 			return;
 		}
 		removeHeldPanel();
-		setScanStatus(__('cookies.importNotSaved', 'Not saved'));
+		setScanStatus(fazI18n('cookies.importNotSaved', 'Not saved'));
 
 		var savesOnly = !!(err && typeof err.retryImport === 'function');
 
@@ -569,8 +572,8 @@
 		var explain = document.createElement('p');
 		explain.className = 'faz-scan-held-text';
 		explain.textContent = savesOnly
-			? __('cookies.importHeldRetrySave', 'The scan finished but the results could not be saved. Nothing is lost — they are held on the server for a few minutes. Retrying saves them; it does not scan the site again.')
-			: __('cookies.importHeldRerun', 'The scan finished but the results could not be saved. The capture session is held on the server for a few minutes, so retrying reuses it instead of failing — but this browser has to walk the pages again.');
+			? fazI18n('cookies.importHeldRetrySave', 'The scan finished but the results could not be saved. Nothing is lost — they are held on the server for a few minutes. Retrying saves them; it does not scan the site again.')
+			: fazI18n('cookies.importHeldRerun', 'The scan finished but the results could not be saved. The capture session is held on the server for a few minutes, so retrying reuses it instead of failing — but this browser has to walk the pages again.');
 		panel.appendChild(explain);
 
 		if (err && err.message) {
@@ -586,12 +589,12 @@
 		retryBtn.type = 'button';
 		retryBtn.className = 'faz-btn faz-btn-sm faz-btn-primary';
 		retryBtn.textContent = savesOnly
-			? __('cookies.retryImport', 'Retry import')
-			: __('cookies.retryImportRescan', 'Retry import (re-scans the site)');
+			? fazI18n('cookies.retryImport', 'Retry import')
+			: fazI18n('cookies.retryImportRescan', 'Retry import (re-scans the site)');
 		var dismissBtn = document.createElement('button');
 		dismissBtn.type = 'button';
 		dismissBtn.className = 'faz-btn faz-btn-sm';
-		dismissBtn.textContent = __('cookies.discardHeldScan', 'Discard');
+		dismissBtn.textContent = fazI18n('cookies.discardHeldScan', 'Discard');
 		actions.appendChild(retryBtn);
 		actions.appendChild(dismissBtn);
 		panel.appendChild(actions);
@@ -600,7 +603,7 @@
 		retryBtn.addEventListener('click', function () {
 			removeHeldPanel();
 			btn.disabled = true;
-			setScanStatus(__('cookies.savingResults', 'Saving results...'));
+			setScanStatus(fazI18n('cookies.savingResults', 'Saving results...'));
 			var attempt;
 			if (savesOnly) {
 				attempt = err.retryImport();
@@ -840,7 +843,7 @@
 				// Keep the response contract forward-compatible with advisory notices.
 				FAZ.notify(result.warning, 'warning');
 			} else {
-				FAZ.notify(__('setup.finished', 'Setup complete. Your cookie banner is ready.'), 'success');
+				FAZ.notify(fazI18n('setup.finished', 'Setup complete. Your cookie banner is ready.'), 'success');
 			}
 			// Brief pause so the toast is visible before navigating.
 			setTimeout(function () {
@@ -852,7 +855,7 @@
 			finishing = false;
 			finishBtn.disabled = false;
 			backBtn.disabled = false;
-			FAZ.notify((err && err.message) || __('setup.finish_failed', 'Setup could not be saved. Please try again.'), 'error');
+			FAZ.notify((err && err.message) || fazI18n('setup.finish_failed', 'Setup could not be saved. Please try again.'), 'error');
 		});
 	}
 


### PR DESCRIPTION
Removes the ceiling found while preparing the translate.wordpress.org import in #272.

## The problem, measured

Each admin JS file declares its own helper:

```js
function __( key, fallback ) {
    var parts = key.split('.');
    var obj = (window.fazConfig && window.fazConfig.i18n) || {};
    …
    return typeof obj === 'string' ? obj : fallback;
}
```

It is **not gettext** — it reads a dotted key out of a map PHP already translated. But because it is named `__`, the extractor behind translate.wordpress.org matches it against WordPress' own `__()` signature, where argument one *is* the translatable text, and harvests the keys as if they were English.

Extracting **without domain filtering**, which is evidently what wp.org does:

| tree | entries | dotted keys |
|---|---|---|
| before (HEAD) | **1882** | 267 |
| after (renamed) | **1597** | **0** |

1882 matches the wp.org project's 1881 plus a header exactly; 1597 matches our own catalogue. The 285 difference is the phantom set.

Those entries cannot legitimately be translated, so every locale was capped at **1596/1881 = 84.8%** however complete our catalogues became, and no language pack could be generated. Removing them lets a full import read 100%.

## A local check that says "no change" is measuring the wrong extractor

`wp i18n make-pot` with default settings shows **no difference at all** before and after this change. It filters by text domain, and our second argument is an English fallback rather than a domain, so it discards these calls entirely. That is why the table above uses `--ignore-domain`. Worth stating, because the obvious verification here returns a confident, useless answer.

## No behaviour changes

Keys, English fallbacks and the lookup are untouched; only the function's name differs. `fazConfig.i18n` is unchanged, so PHP needs no edit.

## Verification

- **The diff is the rename and nothing else** — reversing `fazI18n(` → `__(` and dropping the three inserted comment lines reproduces each of the 11 files byte-for-byte against HEAD.
- No `__(` remains anywhere under `admin/assets/js`, in any spacing; `function __` is gone.
- `node --check` passes on all 11 files.
- **All 11 admin screens load with zero console errors and zero ReferenceErrors** — Dashboard, Banner, Cookies, Consent Logs, GCM, Languages, Settings, Setup, GVL, Import/Export, Cookie Policy.
- That probe is **mutation-proven**: renaming a single definition turns the Cookies screen red with `ReferenceError: fazI18n is not defined`, and restoring it turns it green. A page-load check that has never been seen to fail proves nothing about 289 call sites.
- Unit gate 147/147; admin E2E slice (admin-and-api, admin-rest-routes, release-verify-admin-misc, setup-wizard) 39/39.

## What happens next

The effect appears on wp.org only after the next release, when GlotPress re-syncs from the stable ZIP and the 285 entries disappear. The import files already prepared from #272 stay valid — they fill the 1,596 real strings today and will read 100% once the project shrinks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti**
  * Rinominato l’helper interno per le traduzioni da `__()` a `fazI18n()`.
  * Mantenuti invariati messaggi visualizzati, fallback e comportamento delle funzioni.
  * Migliorata l’identificazione delle stringhe traducibili senza modificare l’esperienza nell’interfaccia amministrativa.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->