### PR TITLE
ci: retain GitHub-hosted checks and cancel superseded PR runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 8 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,8 +11,12 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    # Trusted jobs run in disposable VMs; fork PRs stay on GitHub-hosted runners.
+    runs-on: ${{ fromJSON((github.actor == github.repository_owner || github.actor == 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","fabio-ci"]' || '["ubuntu-latest"]') }}
+    timeout-minutes: 60
     permissions:
+      contents: read
+      actions: read
       security-events: write
     strategy:
       matrix:
@@ -21,6 +25,12 @@ jobs:
         # PHPCS in their own jobs; CodeQL only scans the JS/TS here.
         language: [ javascript-typescript ]
     steps:
+      - name: Prepare disposable Linux runner
+        if: runner.environment == 'self-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    # Trusted jobs run in disposable VMs; fork PRs stay on GitHub-hosted runners.
-    runs-on: ${{ fromJSON((github.actor == github.repository_owner || github.actor == 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","fabio-ci"]' || '["ubuntu-latest"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
@@ -29,12 +28,6 @@ jobs:
         # PHPCS in their own jobs; CodeQL only scans the JS/TS here.
         language: [ javascript-typescript ]
     steps:
-      - name: Prepare disposable Linux runner
-        if: runner.environment == 'self-hosted'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
         with:

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -10,11 +10,19 @@ on:
 jobs:
   plugin-check:
     name: Plugin Check (wp.org shape)
-    runs-on: ubuntu-latest
+    # Trusted jobs run in disposable VMs; fork PRs stay on GitHub-hosted runners.
+    runs-on: ${{ fromJSON((github.actor == github.repository_owner || github.actor == 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","fabio-ci"]' || '["ubuntu-latest"]') }}
+    timeout-minutes: 60
     permissions:
       contents: read
 
     steps:
+      - name: Prepare disposable Linux runner
+        if: runner.environment == 'self-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Build a wp.org-shape copy (mirrors scripts/build-release.sh).

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -21,7 +21,8 @@ jobs:
         if: runner.environment == 'self-hosted'
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv
+          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv docker-compose-v2
+          docker compose version
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   plugin-check:
     name: Plugin Check (wp.org shape)

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -14,20 +14,12 @@ concurrency:
 jobs:
   plugin-check:
     name: Plugin Check (wp.org shape)
-    # Trusted jobs run in disposable VMs; fork PRs stay on GitHub-hosted runners.
-    runs-on: ${{ fromJSON((github.actor == github.repository_owner || github.actor == 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","fabio-ci"]' || '["ubuntu-latest"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
 
     steps:
-      - name: Prepare disposable Linux runner
-        if: runner.environment == 'self-hosted'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv docker-compose-v2
-          docker compose version
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Build a wp.org-shape copy (mirrors scripts/build-release.sh).

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   quality:
     name: Quality

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,11 +10,19 @@ on:
 jobs:
   quality:
     name: Quality
-    runs-on: ubuntu-latest
+    # Trusted jobs run in disposable VMs; fork PRs stay on GitHub-hosted runners.
+    runs-on: ${{ fromJSON((github.actor == github.repository_owner || github.actor == 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","fabio-ci"]' || '["ubuntu-latest"]') }}
+    timeout-minutes: 60
     permissions:
       contents: read
 
     steps:
+      - name: Prepare disposable Linux runner
+        if: runner.environment == 'self-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,19 +14,12 @@ concurrency:
 jobs:
   quality:
     name: Quality
-    # Trusted jobs run in disposable VMs; fork PRs stay on GitHub-hosted runners.
-    runs-on: ${{ fromJSON((github.actor == github.repository_owner || github.actor == 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '["self-hosted","Linux","X64","fabio-ci"]' || '["ubuntu-latest"]') }}
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: read
 
     steps:
-      - name: Prepare disposable Linux runner
-        if: runner.environment == 'self-hosted'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends default-mysql-client gh jq rsync gettext zip unzip shellcheck python3-venv
-
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2

--- a/docs/CI-SERVER.md
+++ b/docs/CI-SERVER.md
@@ -1,25 +1,23 @@
-# CI server, with GitHub as the primary platform
+# GitHub-hosted CI and private Git backups
 
 GitHub remains authoritative for code, PRs, issues, discussions, Actions checks,
-logs, artifacts and releases. The private GitLab mirror only backs up Git refs;
-it does not replace GitHub.
+logs, artifacts and releases. Quality, Plugin Check and CodeQL always use
+standard GitHub-hosted Ubuntu runners, including same-repository and fork PRs.
+There is no actor-dependent route to the personal server.
 
-Quality, Plugin Check and CodeQL run on Fabio's disposable Linux VM runners
-for the repository owner and same-repository Dependabot jobs. Fork PRs and
-other actors use GitHub-hosted Ubuntu runners. Preserve this routing.
+The owner withdrew the self-hosted migration on 7 September 2026. The CI
+controller on SSH host `fabiodalez` is stopped and disabled at boot. Do not
+re-enable it or restore self-hosted labels. Superseded queued runs must be
+cancelled and replaced by runs on the updated workflow revision.
 
-The `fabiodalez` SSH host executes one job at a time across repositories, in
-a fresh KVM Ubuntu 24.04 VM (4 vCPU, 8 GiB RAM), labelled
-`self-hosted`, `Linux`, `X64`, `fabio-ci`. Docker/wp-env runs inside the VM;
-the disk is discarded after the job. Host credentials and private networking
-are not available to the VM. Never use a persistent runner for public PR code.
-Workflow expressions/labels alone are not a security boundary; host-side VM
-and network isolation must stay enabled.
+Existing WordPress, Plugin Check, dependency pins and quality gates remain.
+Concurrency cancels superseded PR runs; workflow timeouts prevent unbounded
+execution. No plugin version, tag or release is created by this change.
 
-Existing WordPress, Plugin Check, dependency pins and quality gates are retained.
-The runner installs its required Linux tools explicitly. No plugin release is
-created by this migration. Check all three workflows on the migration commit
-before treating the new runner as verified.
+The private GitLab mirror is retained with CI disabled. The server polls for
+new GitHub pushes every minute when the mirror queue is free, backs up changed
+repositories and performs an hourly full check. Replaced Git history is kept;
+PRs/issues remain on GitHub, not in this Git-only backup.
 
-Shared orchestration code and tests live in `eventi/infra/ci/`; root-only server
-configuration controls reviewed public repositories. GitLab CI remains disabled.
+Shared backup code lives in `eventi/infra/ci/`. Keep `fabio-git-mirror.timer`
+and `fabio-git-mirror-poll.timer` active. Credentials remain outside Git.

--- a/docs/CI-SERVER.md
+++ b/docs/CI-SERVER.md
@@ -1,0 +1,25 @@
+# CI server, with GitHub as the primary platform
+
+GitHub remains authoritative for code, PRs, issues, discussions, Actions checks,
+logs, artifacts and releases. The private GitLab mirror only backs up Git refs;
+it does not replace GitHub.
+
+Quality, Plugin Check and CodeQL run on Fabio's disposable Linux VM runners
+for the repository owner and same-repository Dependabot jobs. Fork PRs and
+other actors use GitHub-hosted Ubuntu runners. Preserve this routing.
+
+The `fabiodalez` SSH host executes one job at a time across repositories, in
+a fresh KVM Ubuntu 24.04 VM (4 vCPU, 8 GiB RAM), labelled
+`self-hosted`, `Linux`, `X64`, `fabio-ci`. Docker/wp-env runs inside the VM;
+the disk is discarded after the job. Host credentials and private networking
+are not available to the VM. Never use a persistent runner for public PR code.
+Workflow expressions/labels alone are not a security boundary; host-side VM
+and network isolation must stay enabled.
+
+Existing WordPress, Plugin Check, dependency pins and quality gates are retained.
+The runner installs its required Linux tools explicitly. No plugin release is
+created by this migration. Check all three workflows on the migration commit
+before treating the new runner as verified.
+
+Shared orchestration code and tests live in `eventi/infra/ci/`; root-only server
+configuration controls reviewed public repositories. GitLab CI remains disabled.


### PR DESCRIPTION
The self-hosted migration has been withdrawn at the owner’s request. Quality, Plugin Check and CodeQL now always use standard GitHub-hosted Ubuntu runners. Removed actor-dependent routing and VM-only preparation. This also removes the public self-hosted runner-selection issue. Retain concurrency, timeouts, explicit permissions and all existing WordPress/Plugin Check pins and quality gates. The personal-server CI controller is stopped and disabled; private GitLab backups remain active. Local actionlint and diff checks passed. Fresh checks run on commit a98af03; inspect their results before merging. No plugin release or version change.