### PR TITLE
Fix the six 1.30.0 findings the green suite did not cover

### DIFF
--- a/admin/assets/js/pages/dashboard.js
+++ b/admin/assets/js/pages/dashboard.js
@@ -187,12 +187,28 @@
 	// Whether the site records pageviews at all. Printed on the wrapper by
 	// dashboard.php so the panel can tell "nobody visited" from "we are not
 	// counting", which the old zeroes conflated.
+	// Every filter click fires loadStats() and loadChart() again without
+	// cancelling what is already in flight, and the two ranges are served by
+	// different queries with different costs. Clicking 30D while 1D is still
+	// loading therefore lets the slower answer land last and paint the range
+	// nobody asked for, under a filter bar that says something else. Each call
+	// takes a ticket and refuses to touch the DOM unless it is still the
+	// newest, which is cheaper and more reliable than trying to abort a fetch.
+	//
+	// One counter PER endpoint, not one for the panel: reloadDashboard() calls
+	// both loaders in a row, so a shared counter would have the chart's ticket
+	// invalidate the stats request issued a line earlier and the cards would
+	// stay empty. A request may only cancel an older request of its own kind.
+	var statsRequestSeq = 0;
+	var chartRequestSeq = 0;
+
 	function pageviewTrackingEnabled() {
 		var dashboard = document.getElementById('faz-dashboard');
 		return !!dashboard && dashboard.getAttribute('data-pageview-tracking') === '1';
 	}
 
 	function loadStats(params) {
+		var seq = ++statsRequestSeq;
 		if (!pageviewTrackingEnabled()) {
 			// Not zero — unavailable. Reporting 0 accepted / 0 rejected reads as
 			// "every visitor ignored the banner", which is a very different and
@@ -206,6 +222,7 @@
 			return;
 		}
 		FAZ.get('pageviews/banner-stats', params).then(function (data) {
+			if (seq !== statsRequestSeq) return; // a newer range was requested
 			var banner   = data.banner_view || 0;
 			var accepted = data.banner_accept || 0;
 			var rejected = data.banner_reject || 0;
@@ -222,6 +239,7 @@
 			hideEmpty('faz-consent-empty');
 			drawConsentDonut(accepted, rejected);
 		}).catch(function () {
+			if (seq !== statsRequestSeq) return;
 			showEmpty('faz-consent-empty');
 		});
 	}
@@ -229,6 +247,7 @@
 	/* ── Pageviews Line Chart ── */
 
 	function loadChart(params) {
+		var seq = ++chartRequestSeq;
 		var totalEl = document.getElementById('faz-stat-pageviews');
 		// Cleared first so a failed or pending request never leaves the previous
 		// range's total on screen next to the new range's chart.
@@ -239,6 +258,7 @@
 			return;
 		}
 		FAZ.get('pageviews/chart', params).then(function (data) {
+			if (seq !== chartRequestSeq) return; // a newer range was requested
 			var items = Array.isArray(data) ? data : (data.data || data.items || []);
 			// A genuine zero is reported as 0; only a missing figure stays '--'.
 			if (totalEl && typeof data.total_views === 'number') {
@@ -268,6 +288,7 @@
 
 			drawLineChart('faz-chart-pageviews', labels, values);
 		}).catch(function () {
+			if (seq !== chartRequestSeq) return;
 			showEmpty('faz-chart-empty');
 		});
 	}

--- a/admin/views/banner.php
+++ b/admin/views/banner.php
@@ -545,7 +545,7 @@ $faz_gpc_req      = $faz_requirement( array( 'signals.gpc_honored', 'signals.gpc
 				</div>
 				<div class="faz-form-group" style="border-top:1px solid var(--faz-border);padding-top:16px;margin-top:4px;max-width:280px;">
 					<label for="faz-b-border-radius"><?php esc_html_e( 'Button corner radius', 'faz-cookie-manager' ); ?></label>
-					<input type="text" class="faz-input faz-input-sm" id="faz-b-border-radius" style="width:110px;" placeholder="2px" inputmode="numeric" aria-describedby="faz-b-border-radius-help">
+					<input type="text" class="faz-input faz-input-sm" id="faz-b-border-radius" style="width:110px;" placeholder="2px" aria-describedby="faz-b-border-radius-help">
 					<div id="faz-b-border-radius-help" class="faz-help"><?php esc_html_e( 'Applies to every banner button — Accept, Reject, Customise and Do Not Sell — in the notice bar and the preference center. A length such as 0, 8px, 50px for pill-shaped, or 0.5rem. Leave empty to keep the shipped 2px.', 'faz-cookie-manager' ); ?></div>
 				</div>
 			</div>

--- a/readme.txt
+++ b/readme.txt
@@ -345,7 +345,7 @@ Categories are the right granularity on most sites, and while **Per-service cons
 6. **IAB TCF v2.3 Global Vendor List** -- Browse the bundled GVL, filter by purpose, and select which vendors your site works with. Full Transparency and Consent Framework v2.3 API and UI, no cloud required. Note: broadcasting valid TC strings to vendors requires your own registered IAB Europe CMP ID; until one is configured the TCF layer stays inactive by design.
 7. **Consent logs** -- Local, tamper-resistant audit trail of every visitor consent: status, categories, hashed IP, URL and timestamp. Filter, search and export to CSV for DPIA / audits.
 8. **Google Consent Mode v2** -- Default vs. granted state for `ad_storage`, `analytics_storage`, `ad_user_data`, `ad_personalization`, `functionality_storage`, `personalization_storage` and `security_storage`. Works with GTM and gtag.
-9. **Languages** -- Manage active languages and the default banner language. Works alongside WPML / Polylang; Italian, Dutch, German, French and Czech translations ship out of the box.
+9. **Languages** -- Manage active languages and the default banner language. Works alongside WPML / Polylang. The admin interface ships translated into Italian, Dutch, German, French, Czech and Croatian; banner and cookie-category text ships in those plus Spanish, Finnish, Hungarian, Polish, Portuguese, Brazilian Portuguese, Russian and Ukrainian.
 10. **Settings** -- Global controls: enable/disable the banner, exclude specific pages, cross-domain consent forwarding, hide from bots, GTM dataLayer events, consent log retention and scanner limits.
 
 == Cache Plugin Compatibility ==

--- a/tests/e2e/specs/footer-link-radius-and-tracking.spec.ts
+++ b/tests/e2e/specs/footer-link-radius-and-tracking.spec.ts
@@ -26,7 +26,7 @@ test('footer shortcode opens preferences using keyboard navigation', async ({ pa
   upsertPage(slug, 'Footer consent link', '[faz_cookie_settings type="link" text="Cookie preferences"]');
   const url = wpEval(`$p = get_page_by_path('${slug}'); echo get_permalink($p->ID);`).trim();
   try {
-    await page.goto(url);
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
     const accept = page.locator('[data-faz-tag="accept-button"]:visible').first();
     await expect(accept).toBeVisible();
     await accept.click();
@@ -47,7 +47,7 @@ test('disabled pageview tracking displays unavailable metrics', async ({ page, l
   try {
     wpEval('$s = get_option("faz_settings", array()); $s["pageview_tracking"] = false; update_option("faz_settings", $s);');
     await loginAsAdmin(page);
-    await page.goto('/wp-admin/admin.php?page=faz-cookie-manager');
+    await page.goto('/wp-admin/admin.php?page=faz-cookie-manager', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#faz-dashboard')).toHaveAttribute('data-pageview-tracking', '0');
     for (const stat of ['pageviews', 'banner', 'accept', 'reject']) {
       await expect(page.locator('#faz-stat-' + stat)).toHaveText('--');

--- a/tests/unit/js/dashboard-tracking-disabled.test.mjs
+++ b/tests/unit/js/dashboard-tracking-disabled.test.mjs
@@ -28,5 +28,42 @@ w.FAZ.get = () => Promise.reject(new Error('offline'));
 w.chart({});
 await new Promise(resolve => setTimeout(resolve, 0));
 assert.equal(w.document.getElementById('faz-stat-pageviews').textContent, '--');
-console.log('10 passed: disabled tracking, genuine zero, actual pageview total, request error');
+
+// Out-of-order responses. Clicking 30D while 1D is still loading leaves two
+// requests in flight over different queries with different costs; before the
+// sequence token the slower one landed last and painted the range nobody
+// asked for, under a filter bar that said something else.
+const deferred = [];
+w.FAZ.get = () => new Promise(resolve => deferred.push(resolve));
+w.chart({ days: 1 });    // richiesta lenta, chiesta per prima
+w.chart({ days: 30 });   // richiesta veloce, chiesta per seconda
+assert.equal(deferred.length, 2, 'both requests are in flight');
+deferred[1]({ total_views: 30, data: [] });   // la seconda risponde per prima
+await new Promise(resolve => setTimeout(resolve, 0));
+assert.equal(w.document.getElementById('faz-stat-pageviews').textContent, '30');
+deferred[0]({ total_views: 1, data: [] });    // la prima arriva in ritardo
+await new Promise(resolve => setTimeout(resolve, 0));
+assert.equal(
+  w.document.getElementById('faz-stat-pageviews').textContent,
+  '30',
+  'a stale response must not overwrite the range actually selected'
+);
+
+// The same applies to a stale FAILURE: an old request rejecting must not blank
+// the panel that a newer, successful one has already filled.
+const late = [];
+w.FAZ.get = () => new Promise((resolve, reject) => late.push({ resolve, reject }));
+w.chart({ days: 1 });
+w.chart({ days: 30 });
+late[1].resolve({ total_views: 42, data: [] });
+await new Promise(resolve => setTimeout(resolve, 0));
+late[0].reject(new Error('slow request gave up'));
+await new Promise(resolve => setTimeout(resolve, 0));
+assert.equal(
+  w.document.getElementById('faz-stat-pageviews').textContent,
+  '42',
+  'a stale rejection must not blank a newer answer'
+);
+
+console.log('15 passed: disabled tracking, genuine zero, actual pageview total, request error, out-of-order responses');
 dom.window.close();

--- a/tests/unit/test-button-corner-radius-php.php
+++ b/tests/unit/test-button-corner-radius-php.php
@@ -10,6 +10,16 @@
 define( 'ABSPATH', __DIR__ . '/' );
 function sanitize_text_field( $v ) { return (string) $v; }
 function sanitize_hex_color( $v ) { return preg_match( '/^#[0-9a-f]{3,8}$/i', (string) $v ) ? $v : ''; }
+// The settings round-trip below walks EVERY default key, so the switch's other
+// branches run too and need their WordPress helpers present.
+function wp_strip_all_tags( $v ) { return strip_tags( (string) $v ); }
+function wp_kses_post( $v ) { return (string) $v; }
+function sanitize_textarea_field( $v ) { return (string) $v; }
+function sanitize_key( $v ) { return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $v ) ); }
+function esc_url_raw( $v ) { return (string) $v; }
+function absint( $v ) { return abs( (int) $v ); }
+function wp_json_encode( $v ) { return json_encode( $v ); }
+function __( $v, $d = '' ) { return $v; }
 require_once dirname( __DIR__, 2 ) . '/includes/class-formatting.php';
 
 $passed = 0;
@@ -54,29 +64,64 @@ foreach ( array(
 t( '' === faz_sanitize_css_length( array( '8px' ) ), 'rejects a non-scalar' );
 t( '' === faz_sanitize_css_length( null ), 'rejects null' );
 
-// Wiring: the banner sanitiser must route this key to the strict check, not to
-// the switch's faz_sanitize_text() default, which would let `;` through.
-$banner = file_get_contents( dirname( __DIR__, 2 ) . '/admin/modules/banners/includes/class-banner.php' );
-t( false !== strpos( $banner, "case 'borderRadius':" ), 'sanitize_option has a borderRadius case' );
-$case_at = strpos( $banner, "case 'borderRadius':" );
-$next_break = strpos( $banner, 'break;', $case_at );
-t(
-	false !== strpos( substr( $banner, $case_at, $next_break - $case_at ), 'faz_sanitize_css_length' ),
-	'the borderRadius case calls faz_sanitize_css_length'
-);
+// Behaviour, not source text. The previous version asserted with strpos() that
+// class-banner.php contained "case 'borderRadius':" and that class-template.php
+// contained the variable name — which passes when the code is renamed into
+// uselessness and fails when it is merely reformatted. These call the real
+// code instead.
+$root = dirname( __DIR__, 2 );
+require_once $root . '/includes/class-store.php';
+require_once $root . '/admin/modules/banners/includes/class-banner.php';
+$banner = 'FazCookie\\Admin\\Modules\\Banners\\Includes\\Banner';
 
-// Wiring: the key must exist in the shipped defaults, or sanitize_settings()
-// drops it before it is ever stored (it iterates the defaults, not the input).
-foreach ( array( 'gdpr', 'ccpa' ) as $law ) {
-	$cfg = json_decode( file_get_contents( dirname( __DIR__, 2 ) . "/admin/modules/banners/includes/configs/$law.json" ), true );
-	t( is_array( $cfg ) , "$law.json parses" );
-	t( array_key_exists( 'borderRadius', $cfg['settings'] ), "$law.json declares settings.borderRadius" );
-	t( '' === $cfg['settings']['borderRadius'], "$law.json defaults it to empty (existing banners unchanged)" );
+// The key must reach the strict sanitiser rather than the switch's
+// faz_sanitize_text() default, which would let `;` through into the CSS.
+foreach ( array(
+	'8px'                     => '8px',
+	'0'                       => '0',
+	'0.5rem'                  => '0.5rem',
+	'50%'                     => '50%',
+	'4px;}body{display:none}' => '',
+	'2px;color:red'           => '',
+	'red'                     => '',
+	'-4px'                    => '',
+	'12'                      => '',
+	'calc(4px + 1em)'         => '',
+) as $in => $expected ) {
+	t(
+		$banner::sanitize_option( 'borderRadius', $in ) === $expected,
+		'sanitize_option(borderRadius, ' . var_export( $in, true ) . ') === ' . var_export( $expected, true )
+	);
 }
 
-// Wiring: the template emits the variable only when the setting is non-empty.
-$template = file_get_contents( dirname( __DIR__, 2 ) . '/admin/modules/banners/includes/class-template.php' );
-t( false !== strpos( $template, "--faz-btn-border-radius" ), 'the template emits --faz-btn-border-radius' );
-t( false !== strpos( $template, "if ( '' !== \$radius ) {" ), 'and only when the setting is non-empty' );
+// A whole settings round-trip against the SHIPPED defaults. sanitize_settings()
+// walks the defaults, so this also proves the key is declared in them — without
+// it the value is dropped silently on the way to the database, and no amount of
+// admin UI would help.
+foreach ( array( 'gdpr', 'ccpa' ) as $law ) {
+	$defaults = json_decode( file_get_contents( $root . "/admin/modules/banners/includes/configs/$law.json" ), true );
+	t( is_array( $defaults ), "$law.json parses" );
+	t( '' === $defaults['settings']['borderRadius'], "$law defaults to empty, so existing banners are unchanged" );
 
-echo "$passed passed: corner-radius shape enforcement, CSS-injection rejection, and wiring\n";
+	$kept = $banner::sanitize_settings(
+		array( $banner, 'sanitize_option' ),
+		array( 'settings' => array( 'borderRadius' => '14px' ) ) + $defaults,
+		$defaults
+	);
+	t( '14px' === $kept['settings']['borderRadius'], "$law: a valid radius survives the round-trip" );
+
+	$rejected = $banner::sanitize_settings(
+		array( $banner, 'sanitize_option' ),
+		array( 'settings' => array( 'borderRadius' => '9px;}html{display:none}' ) ) + $defaults,
+		$defaults
+	);
+	t( '' === $rejected['settings']['borderRadius'], "$law: an injection attempt round-trips to empty" );
+}
+
+// Empty is the contract the template relies on to emit nothing at all, so the
+// rendered CSS keeps its shipped 2px. That the emitted declaration then reaches
+// the button is covered end to end by the browser test in
+// tests/e2e/specs/footer-link-radius-and-tracking.spec.ts, which reads the
+// computed style rather than the source.
+
+echo "$passed passed: corner-radius shape enforcement, CSS-injection rejection, and settings round-trip\n";

--- a/tests/unit/test-scan-session-teardown-race-php.php
+++ b/tests/unit/test-scan-session-teardown-race-php.php
@@ -41,11 +41,22 @@ function wp_cache_delete( $key, $group = '' ) {
 		unset( $GLOBALS['local'][ preg_replace( '/^_transient_/', '', $key ) ] );
 	}
 }
+$GLOBALS['simulated_connections'] = array();
 function concurrent_request( $cb ) {
-	$owner = $GLOBALS['wpdb']->owner++;
+	// Every simulated request has to look like a DIFFERENT database connection.
+	// The previous version took the id with a post-increment and then restored
+	// the counter in the finally, so each call handed out the same one. That
+	// matters because GET_LOCK is re-entrant for a single connection: a second
+	// request re-using the first one's id is granted a lock the first still
+	// holds, and the contention these tests exist to prove never happens.
+	// A static counter is never rewound, so no id is issued twice in a run.
+	static $next_connection = 1000;
+	$outer = $GLOBALS['wpdb']->owner;
+	$GLOBALS['wpdb']->owner = ++$next_connection;
+	$GLOBALS['simulated_connections'][] = $GLOBALS['wpdb']->owner;
 	$local = $GLOBALS['local'];
 	$GLOBALS['local'] = array();
-	try { $cb(); } finally { $GLOBALS['local'] = $local; $GLOBALS['wpdb']->owner = $owner; }
+	try { $cb(); } finally { $GLOBALS['local'] = $local; $GLOBALS['wpdb']->owner = $outer; }
 }
 function read_store( $key, $fresh ) {
 	if ( ! $fresh && array_key_exists( $key, $GLOBALS['local'] ) ) { return $GLOBALS['local'][ $key ]; }
@@ -200,6 +211,14 @@ foreach ( array( false, true ) as $external ) {
 	t( $ctl->abort_browser_scan_session( $scan ), "$backend: explicit cleanup can revoke an expired token" );
 	t( is_string( $ctl->start_browser_scan_session( $next_scan ) ), "$backend: absolute expiry releases the scan index" );
 }
+// The concurrency proof rests on each simulated request being a separate
+// database connection. If ids were ever reused, GET_LOCK would grant the second
+// request a lock the first still holds and every contention assertion above
+// would pass without contending — green, and meaningless.
+$sim = $GLOBALS['simulated_connections'];
+t( count( $sim ) > 1, 'more than one concurrent request was simulated' );
+t( count( $sim ) === count( array_unique( $sim ) ), 'no simulated connection id is reused' );
+
 echo "\nscan session lifecycle: $ok passed, $ko failed\n";
 exit( $ko > 0 ? 1 : 0 );
 }


### PR DESCRIPTION
The six findings from the second review of 1.30.0. All six are real; none of them could fail the suite, which is the part worth recording — four were untested paths and two were tests asserting the wrong thing. The release is still a draft; nothing is published.

## Stale dashboard responses can overwrite recent ones

Every filter click re-issued `loadStats()` and `loadChart()` without cancelling what was in flight, and the two ranges are served by different queries with different costs. Clicking **30D** while **1D** was still loading let the slower answer land last and paint the range nobody asked for, under a filter bar that said something else.

Each call now takes a ticket and refuses to touch the DOM unless it is still the newest — including from the `catch`, so a stale rejection cannot blank a newer answer either.

**One counter per endpoint, not one for the panel.** The first attempt shared a single counter and the existing test caught it immediately: `reloadDashboard()` calls both loaders in a row, so the chart's ticket invalidated the stats request issued a line earlier and the cards stayed empty. Worth stating because the obvious implementation is the wrong one.

## Numeric keyboard on the radius field

`inputmode="numeric"` opens a keypad with no letters, and the field requires a unit — a bare `12` is rejected by design, only `0` is accepted unitless. On a phone the setting was therefore impossible to enter correctly. The attribute is gone.

## Two E2E navigations without `domcontentloaded`

Two of the five navigations in that spec waited for `load`, which on this stack can hang on a third-party resource long after the page is usable. They now match the other three.

## Reused connection ids in the lock tests

`concurrent_request()` took its id with a post-increment and then restored the counter in the `finally`, so every simulated request received the same one.

That matters more than it looks: `GET_LOCK` is re-entrant for a single connection, so a "second" request re-using the first one's id is granted a lock the first still holds — **every contention assertion passed without contending**. A static counter now issues an id that is never rewound, and a new assertion fails if any id repeats.

## Radius tests asserted source text

They used `strpos()` to check that `class-banner.php` contained `case 'borderRadius':` and that `class-template.php` contained the variable name. That passes when the code is renamed into uselessness and fails when it is merely reformatted.

They now call `Banner::sanitize_option()` directly and run a whole settings round-trip against the shipped defaults — which also proves the key is declared in them, without which the value is dropped silently on its way to the database. The emitted CSS reaching the button stays covered by the browser test, which reads the computed style rather than the source.

## README language list

It named five interface translations and omitted Croatian, and said nothing about banner and cookie-category text, which ships in eight more languages including the Russian and Ukrainian added in this release.

## Verification

- 160 unit suites, 0 failed.
- The affected browser specs with `--retries=0`: 3 passed, 1 skipped (the online Playground check, which runs after publication).
- PHP lint and `node --check` on every touched file.

Mutation-checked, each against the assertion it is supposed to defend:

| Mutation | Fails on |
|---|---|
| restore the post-increment | `no simulated connection id is reused` |
| remove the chart's sequence guard | `a stale response must not overwrite the range actually selected` |
| route the radius through `faz_sanitize_text()` | `sanitize_option(borderRadius, '4px;}body{display:none}') === ''` |

## Before publishing

This branch changes `dashboard.js` and `banner.php`, so the full suite recorded for `f260fb02` no longer covers the head. `release.md` wants it re-run on the final commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correzioni**
  - I dati del dashboard ora restano coerenti quando le richieste per intervalli diversi terminano in ordine non previsto.
  - Gli errori delle richieste precedenti non sovrascrivono più i risultati validi più recenti.
  - Il campo del raggio degli angoli accetta correttamente valori come `px` e `rem`.

- **Documentazione**
  - Aggiornata la descrizione delle lingue disponibili nell’interfaccia amministrativa.

- **Test**
  - Ampliata la copertura dei casi di richieste simultanee, sanificazione delle impostazioni e navigazione nel gestore dei cookie.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->